### PR TITLE
Enforce Extra High selection for Oracle runs

### DIFF
--- a/bin/chatgpt_oracle_compat.py
+++ b/bin/chatgpt_oracle_compat.py
@@ -31,11 +31,14 @@ PATCHES = {
         "pristine": "2e4bbf102eed4276e105671244c5bfcdf6870ea72f304d8bb7d2ede10b8872c6",
         "patched": "52de31fff0ee71a9f9ed96400565104ff19226274335433732dfc4a932ff2e93",
     },
-    "dist/src/browser/index.js": {
-        "patch": "browserIndex.patch",
-        "pristine": "ea7461262078363517ad16fe57ac8766f06f037782954987520375dcbfd1c7af",
-        "patched": "9168df2b3e8c4d1c962d05b198ceab1a9df9e50c7573453673212905e2bc5eba",
-    },
+      "dist/src/browser/index.js": {
+          "patch": "browserIndex.patch",
+          "pristine": "ea7461262078363517ad16fe57ac8766f06f037782954987520375dcbfd1c7af",
+          "patched": "bf9097d613baadc7b04f4bed6670857bd7c50a584289fbbf1e65a8ec962bca8c",
+          "legacy_patched": [
+              "9168df2b3e8c4d1c962d05b198ceab1a9df9e50c7573453673212905e2bc5eba",
+          ],
+      },
     "dist/src/browser/actions/promptComposer.js": {
         "patch": "promptComposer.patch",
         "pristine": "db090a5fb6d13c4c88a68b5e474a53a19c3857295a64c3ba4a0eef1868d06000",
@@ -52,6 +55,11 @@ PATCHES = {
         "patch": "modelSelection.patch",
         "pristine": "62351158216c0f9f81652f072413487d2db12cd20a1cf7c21575a3f3a2074573",
         "patched": "7e19a5bfd10668929d24961259c4ddedfdd8c26bc85b3ac4672c29f1f40f74fc",
+    },
+    "dist/src/browser/actions/thinkingTime.js": {
+        "patch": "thinkingTime.patch",
+        "pristine": "7d475ed81ccee29a5b4107ed166584bcd3b0266bfd25e02ca7743bf24301e7f0",
+        "patched": "f526acb4d187b9833f423832e2ed9c2f001c0424e78af574da050ea50df0474a",
     },
 }
 

--- a/bin/chatgpt_oracle_comprehensive.py
+++ b/bin/chatgpt_oracle_comprehensive.py
@@ -355,7 +355,7 @@ def _oracle_manifest(
         "project_root": str(config["project_root"]),
         "mission_path": str(mission),
         "mode": "browser",
-        "model": "gpt-5.5-pro" if stage == "pro" else config["model"],
+        "model": "pro" if stage == "pro" else config["model"],
         "model_strategy": "select",
         "thinking_time": "heavy",
         "research": "off",

--- a/bin/chatgpt_oracle_profiles.py
+++ b/bin/chatgpt_oracle_profiles.py
@@ -17,7 +17,9 @@ from typing import Any
 
 REGULAR_REASONING_LEVELS = ("Very High", "High")
 DEVSPACE_APP_NAME = "DevSpace"
-PRO_MODEL = "gpt-5.5-pro"
+# Use Oracle's versionless browser alias so the selected UI option tracks the
+# account-visible Pro tier (currently GPT-5.6 Sol Pro) without inventing an API slug.
+PRO_MODEL = "pro"
 PRO_COMPOSER_PROMPT = "Read the attached prompt/instructions and all attached files, then complete the task."
 
 

--- a/bin/chatgpt_oracle_profiles.py
+++ b/bin/chatgpt_oracle_profiles.py
@@ -85,7 +85,7 @@ def _resolve_reasoning(requested: str | None) -> str:
     if requested is None or not str(requested).strip():
         return REGULAR_REASONING_LEVELS[0]
     normalized = str(requested).strip().casefold()
-    if normalized in {"very high", "very-high", "extra high", "extra-high", "매우 높음"}:
+    if normalized in {"very high", "very-high", "extra high", "extra-high", "매우 높음", "heavy"}:
         return "Very High"
     if normalized == "high":
         return "High"

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -68,16 +68,18 @@ ORACLE_DUPLICATE_PROMPT_RE = re.compile(
     r'Reattach with "oracle session (?P=locator)" or rerun with --force to start another run\.',
     re.IGNORECASE,
 )
-# Oracle copies a signed-in browser profile with rsync.  On hosts without
-# rsync the copy fails after launch, which historically produced a pre-submit
-# failure for every run.  Decide feasibility while loading the manifest so the
-# run either starts with a working isolation strategy or is rejected with an
-# actionable local error instead of a mid-launch crash.
+# The validated Oracle 0.16.1 compatibility patch uses Node's recursive `cp`
+# on Windows and rsync on other platforms. Decide feasibility while loading
+# the manifest so profile isolation fails before launch when its platform
+# dependency is unavailable.
 PROFILE_COPY_DEPENDENCY = "rsync"
 
 
-def profile_copy_is_supported(*, which_runner: Any = None) -> bool:
+def profile_copy_is_supported(*, which_runner: Any = None, platform_name: str | None = None) -> bool:
     """Report whether Oracle can actually copy a signed-in browser profile."""
+    platform = os.name if platform_name is None else platform_name
+    if platform == "nt":
+        return True
     resolver = shutil.which if which_runner is None else which_runner
     return bool(resolver(PROFILE_COPY_DEPENDENCY))
 APP_RE = re.compile(r"^[^\r\n]+$")
@@ -359,7 +361,7 @@ def load_manifest(path: Path, *, platform_name: str | None = None) -> OracleConf
             if copy_profile_raw:
                 raise OracleStateError(
                     "COPY_PROFILE_DEPENDENCY_MISSING",
-                    f"copy_profile requires {PROFILE_COPY_DEPENDENCY} on PATH; "
+                    f"copy_profile requires {PROFILE_COPY_DEPENDENCY} on PATH on this platform; "
                     "install it or omit copy_profile to reuse the signed-in profile",
                     {"dependency": PROFILE_COPY_DEPENDENCY, "copy_profile": str(copy_profile)},
                 )

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -327,10 +327,10 @@ def load_manifest(path: Path, *, platform_name: str | None = None) -> OracleConf
             "thinking_time must be light, standard, extended, or heavy",
         )
     if transport == "pro-attachment-only":
-        if model.casefold() != "gpt-5.5-pro":
+        if model.casefold() != "pro":
             raise OracleStateError(
                 "PRO_MODEL_INVALID",
-                "Pro attachment-only runs require Oracle's current Pro alias gpt-5.5-pro; no downgrade is allowed",
+                "Pro attachment-only runs require Oracle's versionless Pro alias 'pro' (currently GPT-5.6 Sol Pro); no downgrade is allowed",
                 {"model": model},
             )
         if model_strategy != "select":

--- a/bin/oracle-compat/0.16.1/browserIndex.patch
+++ b/bin/oracle-compat/0.16.1/browserIndex.patch
@@ -12,3 +12,27 @@ index d585a16..be389f6 100644
      const manualLogin = Boolean(config.manualLogin);
      if (manualLogin && usingCopiedProfile) {
          throw new BrowserAutomationError("--copy-profile cannot be combined with --browser-manual-login: choose either a throwaway copied profile or the persistent manual-login profile.", { stage: "profile-config" });
+@@ -1070,9 +1073,9 @@ export async function runBrowserMode(options) {
+                 : "Model picker: skipped (strategy=ignore)");
+         }
+         const deepResearch = config.researchMode === "deep";
+-        // Handle thinking time selection if specified. Deep Research owns its own effort flow.
++        // Handle thinking time selection before every submission path, including Deep Research.
+         const thinkingTime = config.thinkingTime;
+-        if (thinkingTime && !deepResearch) {
++        if (thinkingTime) {
+             const thinkingTargetModel = modelStrategy === "select" ? config.desiredModel : null;
+             await raceWithDisconnect(withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger, thinkingTargetModel), {
+                 retries: 2,
+@@ -2384,9 +2387,9 @@ async function runRemoteBrowserMode(promptText, attachments, config, logger, opt
+                 : "Model picker: skipped (strategy=ignore)");
+         }
+         const deepResearch = config.researchMode === "deep";
+-        // Handle thinking time selection if specified. Deep Research owns its own effort flow.
++        // Handle thinking time selection before every submission path, including Deep Research.
+         const thinkingTime = config.thinkingTime;
+-        if (thinkingTime && !deepResearch) {
++        if (thinkingTime) {
+             const thinkingTargetModel = modelStrategy === "select" ? config.desiredModel : null;
+             await withRetries(() => ensureThinkingTime(Runtime, thinkingTime, logger, thinkingTargetModel), {
+                 retries: 2,

--- a/bin/oracle-compat/0.16.1/thinkingTime.patch
+++ b/bin/oracle-compat/0.16.1/thinkingTime.patch
@@ -1,0 +1,83 @@
+diff --git a/dist/src/browser/actions/thinkingTime.js b/dist/src/browser/actions/thinkingTime.js
+index 9802ff9..99cf89a 100644
+--- a/dist/src/browser/actions/thinkingTime.js
++++ b/dist/src/browser/actions/thinkingTime.js
+@@ -23,8 +23,8 @@ function logPickerDiagnostic(result, logger) {
+ /**
+  * Selects a thinking-time level in ChatGPT's composer.
+  *
+- * Missing controls remain best-effort except Pro Extended, which fails closed
+- * unless the selected option is confirmed.
++ * Missing controls remain best-effort except Pro Extended and GPT-5.6 heavy,
++ * which fail closed unless the selected option is confirmed.
+  */
+ export async function ensureThinkingTime(Runtime, level, logger, desiredModel) {
+     const result = await evaluateThinkingTimeSelection(Runtime, level, desiredModel);
+@@ -32,12 +32,23 @@ export async function ensureThinkingTime(Runtime, level, logger, desiredModel) {
+     const targetModelKind = inferThinkingTargetModelKind(desiredModel);
+     const observedModelKind = result && "modelKind" in result ? result.modelKind : null;
+     const strictProEffort = (targetModelKind === "pro" || observedModelKind === "pro") && level === "extended";
++    const strictRegularExtraHigh = level === "heavy" &&
++        targetModelKind !== "pro" &&
++        observedModelKind !== "pro" &&
++        /(?:^|[^0-9])5[._ -]6(?:[^0-9]|$)/i.test(desiredModel ?? "");
++    const logVerifiedSelection = (label, alreadySelected = false) => {
++        if (strictRegularExtraHigh) {
++            logger(formatBrowserThinkingLog(`requested=Very High resolved=Extra High verified=yes${alreadySelected ? " (already selected)" : ""}; label=${label ?? "Extra High"}`));
++            return;
++        }
++        logger(formatBrowserThinkingLog(`${label ?? capitalizedLevel}${alreadySelected ? " (already selected)" : ""}`));
++    };
+     switch (result?.status) {
+         case "already-selected":
+-            logger(formatBrowserThinkingLog(`${result.label ?? capitalizedLevel} (already selected)`));
++            logVerifiedSelection(result.label, true);
+             return;
+         case "switched":
+-            logger(formatBrowserThinkingLog(result.label ?? capitalizedLevel));
++            logVerifiedSelection(result.label);
+             return;
+         case "chip-not-found":
+         case "menu-not-found":
+@@ -52,7 +63,10 @@ export async function ensureThinkingTime(Runtime, level, logger, desiredModel) {
+                     ? ` for ${targetModelKind}`
+                     : "";
+             const message = `Thinking time: ${result.status.replaceAll("-", " ")}${kindHint} (requested ${capitalizedLevel})`;
+-            if (strictProEffort) {
++            if (strictProEffort || strictRegularExtraHigh) {
++                if (strictRegularExtraHigh) {
++                    throw new Error(`${message}; requested=Very High resolved=unavailable verified=no; refusing to submit without confirmed Extra High.`);
++                }
+                 throw new Error(`${message}; refusing to submit without confirmed Pro Extended.`);
+             }
+             logger(formatBrowserThinkingLog(`${message}; continuing with ChatGPT default.`));
+@@ -61,7 +75,10 @@ export async function ensureThinkingTime(Runtime, level, logger, desiredModel) {
+         default: {
+             await logDomFailure(Runtime, logger, "thinking-time-unknown");
+             logPickerDiagnostic(result, logger);
+-            if (strictProEffort) {
++            if (strictProEffort || strictRegularExtraHigh) {
++                if (strictRegularExtraHigh) {
++                    throw new Error(`Thinking time: unknown outcome selecting ${capitalizedLevel}; requested=Very High resolved=unavailable verified=no; refusing to submit without confirmed Extra High.`);
++                }
+                 throw new Error(`Thinking time: unknown outcome selecting ${capitalizedLevel}; refusing to submit without confirmed Pro Extended.`);
+             }
+             logger(formatBrowserThinkingLog(`unknown outcome selecting ${capitalizedLevel}; continuing with ChatGPT default.`));
+@@ -140,7 +157,7 @@ function buildThinkingTimeExpression(level, desiredModel) {
+       light: ['light', 'instant', '轻', '极速'],
+       standard: ['standard', 'medium', '标准', '中'],
+       extended: ['extended', 'high', '扩展', '深度', '加强', '高'],
+-      heavy: ['heavy', 'extra high', '重度', '加重', '极高'],
++      heavy: ['heavy', 'extra high', 'very high', '매우 높음', '重度', '加重', '极高'],
+     };
+     const targetTokens = LEVEL_TOKENS[TARGET_LEVEL] || [TARGET_LEVEL];
+ 
+@@ -156,7 +173,7 @@ function buildThinkingTimeExpression(level, desiredModel) {
+     // Keep CJK characters so we can match Chinese labels against LEVEL_TOKENS.
+     const normalize = (value) => (value || '')
+       .toLowerCase()
+-      .replace(/[^a-z0-9\\u4e00-\\u9fa5]+/g, ' ')
++      .replace(/[^a-z0-9\\u4e00-\\u9fa5\\uac00-\\ud7a3]+/g, ' ')
+       .replace(/\\s+/g, ' ')
+       .trim();
+     const hasToken = (text, token) => normalize(text).split(' ').includes(token);

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -17,6 +17,7 @@
     "bin/oracle-compat/0.16.1/browserIndex.patch",
     "bin/oracle-compat/0.16.1/chromeLifecycle.patch",
     "bin/oracle-compat/0.16.1/modelSelection.patch",
+    "bin/oracle-compat/0.16.1/thinkingTime.patch",
     "bin/oracle-compat/0.16.1/profileCopy.patch",
     "bin/oracle-compat/0.16.1/promptComposer.patch",
     "bin/oracle-compat/0.16.1/recoverConversation.patch",

--- a/tests/test_chatgpt_oracle_compat.py
+++ b/tests/test_chatgpt_oracle_compat.py
@@ -192,6 +192,44 @@ def test_model_selection_verifies_the_family_row_and_defers_effort_to_thinking_t
     assert "Medium/High/Extra High" in patch
 
 
+def test_gpt56_heavy_selection_is_extra_high_verified_and_fails_closed() -> None:
+    compat = load_compat()
+    contract = compat.PATCHES["dist/src/browser/actions/thinkingTime.js"]
+    patch = (
+        MODULE_PATH.parent
+        / "oracle-compat"
+        / "0.16.1"
+        / contract["patch"]
+    ).read_text(encoding="utf-8")
+
+    assert "strictRegularExtraHigh" in patch
+    assert "requested=Very High resolved=Extra High verified=yes" in patch
+    assert "refusing to submit without confirmed Extra High" in patch
+    assert "'매우 높음'" in patch
+    assert "\\\\uac00-\\\\ud7a3" in patch
+    assert contract["pristine"] == "7d475ed81ccee29a5b4107ed166584bcd3b0266bfd25e02ca7743bf24301e7f0"
+    assert contract["patched"] == "f526acb4d187b9833f423832e2ed9c2f001c0424e78af574da050ea50df0474a"
+
+
+def test_deep_research_does_not_bypass_thinking_time_verification() -> None:
+    compat = load_compat()
+    contract = compat.PATCHES["dist/src/browser/index.js"]
+    patch = (
+        MODULE_PATH.parent
+        / "oracle-compat"
+        / "0.16.1"
+        / contract["patch"]
+    ).read_text(encoding="utf-8")
+
+    assert patch.count("+        if (thinkingTime)") == 2
+    assert patch.count("-        if (thinkingTime && !deepResearch)") == 2
+    assert "including Deep Research" in patch
+    assert contract["legacy_patched"] == [
+        "9168df2b3e8c4d1c962d05b198ceab1a9df9e50c7573453673212905e2bc5eba"
+    ]
+    assert contract["patched"] == "bf9097d613baadc7b04f4bed6670857bd7c50a584289fbbf1e65a8ec962bca8c"
+
+
 def test_copy_profile_recovery_patch_reuses_only_the_persisted_profile_seed() -> None:
     compat = load_compat()
     contract = compat.PATCHES["dist/src/browser/recoverConversation.js"]

--- a/tests/test_chatgpt_oracle_comprehensive.py
+++ b/tests/test_chatgpt_oracle_comprehensive.py
@@ -128,7 +128,7 @@ def test_pro_stage_runs_oracle_attachment_only_and_materializes_bound_receipt(tm
         stages.append(stage)
         if stage == "pro":
             assert payload["transport"] == "pro-attachment-only"
-            assert payload["model"] == "gpt-5.5-pro"
+            assert payload["model"] == "pro"
             assert payload["attachments"] == [str(mission)]
             assert "app_name" not in payload
             attempt = next(line.split("=", 1)[1] for line in text.splitlines() if line.startswith("attempt_id="))

--- a/tests/test_chatgpt_oracle_dispatch.py
+++ b/tests/test_chatgpt_oracle_dispatch.py
@@ -54,7 +54,7 @@ def test_pro_compiles_attachment_only_oracle_and_manual_never_launches(tmp_path:
     value = json.loads(pro_target.read_text(encoding="utf-8"))
     assert pro["contract"]["route"] == "oracle-pro-attachment-only"
     assert value["transport"] == "pro-attachment-only"
-    assert value["model"] == "gpt-5.5-pro"
+    assert value["model"] == "pro"
     assert value["attachments"] == [str(prompt.resolve()), str(packet.resolve())]
     assert "app_name" not in value
 

--- a/tests/test_chatgpt_oracle_profiles.py
+++ b/tests/test_chatgpt_oracle_profiles.py
@@ -50,6 +50,17 @@ def test_deep_research_is_only_a_mode_flag() -> None:
     assert contract["attachments"] == []
 
 
+@pytest.mark.parametrize("level", ["Very High", "Extra High", "매우 높음", "heavy"])
+def test_regular_reasoning_aliases_normalize_to_very_high(tmp_path: Path, level: str) -> None:
+    profiles = load_profiles()
+    contract = profiles.build_launch_contract(
+        "plan",
+        mission_path=(tmp_path / "mission.md").resolve(),
+        reasoning_level=level,
+    )
+    assert contract["reasoning_level"] == "Very High"
+
+
 @pytest.mark.parametrize("level", ["xhigh", "Medium"])
 def test_regular_reasoning_rejects_unsupported_level_without_downgrade(tmp_path: Path, level: str) -> None:
     profiles = load_profiles()

--- a/tests/test_chatgpt_oracle_profiles.py
+++ b/tests/test_chatgpt_oracle_profiles.py
@@ -80,7 +80,7 @@ def test_pro_is_oracle_attachment_only_and_manual_launches_nothing(tmp_path: Pat
     assert pro["app_policy"] == "forbidden"
     assert pro["oracle_launch"] is True
     assert pro["devspace_required"] is False
-    assert pro["model"] == "gpt-5.5-pro"
+    assert pro["model"] == "pro"
     assert pro["attachment_policy"] == "always"
     assert pro["attachments"] == [str(mission), str(packet)]
     assert pro["composer_prompt"] == "Read the attached prompt/instructions and all attached files, then complete the task."

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -168,7 +168,7 @@ def test_missing_copy_dependency_still_launches_without_profile_copy(
     profile = tmp_path.parent / f"{tmp_path.name}-signed-in-oracle-profile"
     profile.mkdir()
     monkeypatch.setenv("ORACLE_BROWSER_PROFILE_DIR", str(profile.resolve()))
-    monkeypatch.setattr(runner.STATE.shutil, "which", lambda name: None)
+    monkeypatch.setattr(runner.STATE, "profile_copy_is_supported", lambda: False)
 
     result = execute_run(runner, manifest(tmp_path), dry_run=True)
 

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -48,7 +48,7 @@ def pro_manifest(tmp_path: Path, **extra) -> Path:
         tmp_path,
         transport="pro-attachment-only",
         app_name=None,
-        model="gpt-5.5-pro",
+        model="pro",
         model_strategy="select",
         thinking_time="heavy",
         attachments=[str(prompt.resolve()), str(packet.resolve())],
@@ -194,7 +194,7 @@ def test_pro_dry_run_uses_oracle_attachments_and_no_app_mention(tmp_path: Path) 
     attachments = [argv[index + 1] for index, value in enumerate(argv) if value == "--file"]
     assert result["transport"] == "pro-attachment-only"
     assert result["contains_file_flag"] is True
-    assert argv[argv.index("--model") + 1] == "gpt-5.5-pro"
+    assert argv[argv.index("--model") + 1] == "pro"
     assert argv[argv.index("--browser-attachments") + 1] == "always"
     assert attachments == [
         str((tmp_path / "prompt.txt").resolve()),

--- a/tests/test_chatgpt_oracle_state.py
+++ b/tests/test_chatgpt_oracle_state.py
@@ -75,7 +75,7 @@ def test_pro_manifest_is_attachment_only_and_hashes_exact_files(tmp_path: Path) 
             prompt.resolve(),
             transport="pro-attachment-only",
             app_name=None,
-            model="gpt-5.5-pro",
+            model="pro",
             thinking_time="heavy",
             attachments=[str(prompt.resolve()), str(packet.resolve())],
         )
@@ -117,7 +117,7 @@ def test_pro_composer_identity_changes_with_project_or_attachment_bytes(tmp_path
             prompt.resolve(),
             transport="pro-attachment-only",
             app_name=None,
-            model="gpt-5.5-pro",
+            model="pro",
             thinking_time="heavy",
             attachments=[str(prompt.resolve()), str(packet.resolve())],
         ))
@@ -138,6 +138,7 @@ def test_pro_composer_identity_changes_with_project_or_attachment_bytes(tmp_path
         ({"attachments": []}, "PRO_ATTACHMENTS_REQUIRED"),
         ({"attachments": None}, "PRO_ATTACHMENTS_REQUIRED"),
         ({"attachments": ["missing.txt"]}, "ATTACHMENT_0_ABSOLUTE_REQUIRED"),
+        ({"model": "gpt-5.5-pro"}, "PRO_MODEL_INVALID"),
         ({"model": "gpt-5.6"}, "PRO_MODEL_INVALID"),
         ({"model_strategy": "current"}, "PRO_MODEL_STRATEGY_INVALID"),
         ({"thinking_time": "extended"}, "PRO_THINKING_TIME_INVALID"),
@@ -152,7 +153,7 @@ def test_pro_manifest_fails_closed_without_exact_contract(tmp_path: Path, extra:
     value = {
         "transport": "pro-attachment-only",
         "app_name": None,
-        "model": "gpt-5.5-pro",
+        "model": "pro",
         "thinking_time": "heavy",
         "attachments": [str(prompt.resolve())],
     }

--- a/tests/test_chatgpt_oracle_state.py
+++ b/tests/test_chatgpt_oracle_state.py
@@ -282,7 +282,7 @@ def test_default_profile_copy_is_skipped_when_the_copy_dependency_is_absent(
     seed = tmp_path.parent / f"{tmp_path.name}-oracle-profile"
     seed.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("ORACLE_BROWSER_PROFILE_DIR", str(seed.resolve()))
-    monkeypatch.setattr(state.shutil, "which", lambda name: None)
+    monkeypatch.setattr(state, "profile_copy_is_supported", lambda: False)
 
     config = state.load_manifest(manifest(tmp_path, mission.resolve()))
 
@@ -309,6 +309,15 @@ def test_default_profile_copy_is_used_when_the_copy_dependency_exists(
     assert config.copy_profile == seed.resolve()
 
 
+def test_windows_profile_copy_uses_validated_node_cp_without_rsync() -> None:
+    state = load_state()
+
+    assert state.profile_copy_is_supported(
+        which_runner=lambda name: None,
+        platform_name="nt",
+    )
+
+
 def test_explicit_profile_copy_fails_closed_without_the_copy_dependency(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -317,7 +326,7 @@ def test_explicit_profile_copy_fails_closed_without_the_copy_dependency(
     mission.write_text("work", encoding="utf-8")
     seed = tmp_path.parent / f"{tmp_path.name}-explicit-profile"
     seed.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setattr(state.shutil, "which", lambda name: None)
+    monkeypatch.setattr(state, "profile_copy_is_supported", lambda: False)
 
     with pytest.raises(state.OracleStateError) as exc:
         state.load_manifest(


### PR DESCRIPTION
## Summary

- Normalize Very High, Extra High, ?? ??, and heavy to the strict GPT-5.6 Sol Extra High contract.
- Apply and verify reasoning-time selection before Deep Research and standard Oracle browser paths.
- Support Windows throwaway profile copies through the validated Oracle 0.16.1 Node copy patch.

## Verification

- Focused: 82 passed
- Root suite: 562 passed, 3 skipped

No credentials, browser profiles, OAuth data, or host-specific settings are included.