### PR TITLE
Fix Oracle runtime skill metadata

### DIFF
--- a/skills/chatgpt-oracle-runtime/SKILL.md
+++ b/skills/chatgpt-oracle-runtime/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chatgpt-oracle-runtime
-description: Current Oracle runtime path for new ChatGPT work: regular modes use the manually registered DevSpace app, Pro is attachment-only, and it includes recovery, comprehensive relay, and genuine multi-session Web Multi-GPT.
+description: "Current Oracle runtime path for new ChatGPT work: regular modes use the manually registered DevSpace app, Pro is attachment-only, and it includes recovery, comprehensive relay, and genuine multi-session Web Multi-GPT."
 ---
 
 # ChatGPT Oracle Runtime


### PR DESCRIPTION
## What changed

- Quote the `chatgpt-oracle-runtime` skill description in YAML frontmatter.

## Why

The description contains a colon followed by a space (`work: regular`), which is not valid as an unquoted YAML plain scalar in this frontmatter. DevSpace reports `Nested mappings are not allowed in compact mappings` and omits the skill from normal discovery.

This keeps the description text unchanged while making the metadata parseable.

## Validation

- `yaml.safe_load` parses the corrected frontmatter and returns the expected name and description.
- `python3 -m pytest -q tests/test_release_packaging.py`: 8 passed.
- `python3 scripts/check_portability.py --root .`: passed.
- `git diff --check`: passed.
- Native Windows local-checkout gates passed portability, fast-gate, and golden-path. The v4 focused gate reported 39 passed and two legacy dependency opt-in failures because this PC has Windows PowerShell 5.1 but not `pwsh`; PowerShell 5.1 could not activate the temporary mocked `npm.cmd`. The changed metadata is not involved in those paths. The upstream Windows CI run is pending maintainer approval for the first-time fork workflow and should provide the authoritative PowerShell 7 result.

## Impact

DevSpace and other YAML-based skill loaders can discover `chatgpt-oracle-runtime` without changing Oracle routing, models, transports, credentials, or runtime state.