### PR TITLE
feat: add isolated Cloudflare DevSpace tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,11 @@ python3 skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py setup
   --root "$PWD" --dry-run
 ```
 
+Tailscale Funnel의 공개 엣지가 OpenAI 연결 제한을 반복해서 넘기는 환경은
+별도 Cloudflare Named Tunnel을 사용할 수 있습니다. 기존 터널과 서비스를
+재사용하지 않는 절차는 [macOS Ultrawork 가이드](docs/MACOS_ULTRAWORK.md#cloudflare-named-tunnel-대체-경로)를
+따릅니다.
+
 자세한 과정은
 [DevSpace + Tailscale 설정](docs/DEVSPACE_TAILSCALE_SETUP.md)을
 참고하세요.

--- a/bin/codexpro_cloudflared_launchd.py
+++ b/bin/codexpro_cloudflared_launchd.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import re
+import subprocess
+import sys
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NewType, Sequence, TypedDict
+
+
+LABEL = "com.ventianima.codexpro-automation.cloudflared-devspace"
+ORIGIN = "http://127.0.0.1:7676"
+TunnelId = NewType("TunnelId", str)
+
+
+@dataclass(frozen=True, slots=True)
+class TunnelConfigError(ValueError):
+    field: str
+    reason: str
+
+    def __str__(self) -> str:
+        return f"{self.field}: {self.reason}"
+
+
+@dataclass(frozen=True, slots=True)
+class TunnelSpec:
+    hostname: str
+    tunnel_id: TunnelId
+    credentials_file: Path
+
+    @classmethod
+    def parse(cls, *, hostname: str, tunnel_id: str, credentials_file: Path) -> TunnelSpec:
+        normalized_hostname = hostname.strip().lower().rstrip(".")
+        labels = normalized_hostname.split(".")
+        hostname_is_valid = (
+            len(normalized_hostname) <= 253
+            and len(labels) >= 2
+            and all(re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", label) for label in labels)
+        )
+        if not hostname_is_valid:
+            raise TunnelConfigError(field="hostname", reason="expected a valid DNS hostname")
+        try:
+            normalized_tunnel_id = TunnelId(str(uuid.UUID(tunnel_id)))
+        except ValueError as exc:
+            raise TunnelConfigError(field="tunnel_id", reason="expected a UUID") from exc
+        resolved_credentials = credentials_file.expanduser().resolve()
+        if not resolved_credentials.is_file():
+            raise TunnelConfigError(field="credentials_file", reason="file does not exist")
+        return cls(
+            hostname=normalized_hostname,
+            tunnel_id=normalized_tunnel_id,
+            credentials_file=resolved_credentials,
+        )
+
+
+class ServicePlist(TypedDict):
+    Label: str
+    ProgramArguments: list[str]
+    RunAtLoad: bool
+    KeepAlive: bool
+    ProcessType: str
+    ThrottleInterval: int
+    WorkingDirectory: str
+    StandardOutPath: str
+    StandardErrorPath: str
+    CodexProManaged: bool
+
+
+@dataclass(frozen=True, slots=True)
+class InstallPaths:
+    codex_home: Path
+    launch_agents: Path
+    project_root: Path
+    cloudflared: Path
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceRuntime:
+    project_root: Path
+    cloudflared: str
+    config: Path
+    logs: Path
+
+
+class InstallResult(TypedDict):
+    ok: bool
+    config: str
+    plist: str
+    label: str
+    loaded: bool
+
+
+class DoctorResult(TypedDict):
+    ok: bool
+    installed: bool
+    managed: bool
+    loaded: bool
+    config: str
+    plist: str
+
+
+def render_config(spec: TunnelSpec) -> str:
+    credentials = json.dumps(str(spec.credentials_file), ensure_ascii=False)
+    return (
+        f"tunnel: {spec.tunnel_id}\n"
+        f"credentials-file: {credentials}\n"
+        "ingress:\n"
+        f"  - hostname: {spec.hostname}\n"
+        f"    service: {ORIGIN}\n"
+        "  - service: http_status:404\n"
+    )
+
+
+def service_plist(*, runtime: ServiceRuntime, tunnel_id: TunnelId) -> ServicePlist:
+    return {
+        "Label": LABEL,
+        "ProgramArguments": [
+            runtime.cloudflared,
+            "tunnel",
+            "--no-autoupdate",
+            "--config",
+            str(runtime.config),
+            "run",
+            str(tunnel_id),
+        ],
+        "RunAtLoad": True,
+        "KeepAlive": True,
+        "ProcessType": "Background",
+        "ThrottleInterval": 15,
+        "WorkingDirectory": str(runtime.project_root),
+        "StandardOutPath": str(runtime.logs / "cloudflared.out.log"),
+        "StandardErrorPath": str(runtime.logs / "cloudflared.err.log"),
+        "CodexProManaged": True,
+    }
+
+
+def _write_atomic(path: Path, content: bytes, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def install_service(*, paths: InstallPaths, spec: TunnelSpec, load: bool) -> InstallResult:
+    codex_home = paths.codex_home.expanduser().resolve()
+    launch_agents = paths.launch_agents.expanduser().resolve()
+    project_root = paths.project_root.expanduser().resolve()
+    cloudflared = paths.cloudflared.expanduser().resolve()
+    if not project_root.is_dir():
+        raise TunnelConfigError(field="project_root", reason="directory does not exist")
+    if not cloudflared.is_file():
+        raise TunnelConfigError(field="cloudflared", reason="executable does not exist")
+
+    state = codex_home / "state" / "codexpro-cloudflare"
+    logs = codex_home / "logs" / "codexpro-automation"
+    config = state / "config.yml"
+    plist_path = launch_agents / f"{LABEL}.plist"
+    if plist_path.exists():
+        try:
+            prior = plistlib.loads(plist_path.read_bytes())
+        except (OSError, plistlib.InvalidFileException) as exc:
+            raise TunnelConfigError(field="launch_agent", reason="existing plist is unreadable") from exc
+        if prior.get("CodexProManaged") is not True or prior.get("Label") != LABEL:
+            raise TunnelConfigError(field="launch_agent", reason="label is owned by another service")
+
+    logs.mkdir(parents=True, exist_ok=True)
+    runtime = ServiceRuntime(
+        project_root=project_root,
+        cloudflared=str(cloudflared),
+        config=config,
+        logs=logs,
+    )
+    plist = service_plist(runtime=runtime, tunnel_id=spec.tunnel_id)
+    _write_atomic(config, render_config(spec).encode("utf-8"), 0o600)
+    _write_atomic(plist_path, plistlib.dumps(plist, fmt=plistlib.FMT_XML, sort_keys=True), 0o644)
+
+    if load:
+        if sys.platform != "darwin":
+            raise TunnelConfigError(field="platform", reason="launchd requires macOS")
+        domain = f"gui/{os.getuid()}"
+        subprocess.run(["launchctl", "bootout", domain, str(plist_path)], capture_output=True, text=True, check=False)
+        result = subprocess.run(["launchctl", "bootstrap", domain, str(plist_path)], capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            raise TunnelConfigError(field="launchctl", reason=result.stderr.strip() or "bootstrap failed")
+
+    return {
+        "ok": True,
+        "config": str(config),
+        "plist": str(plist_path),
+        "label": LABEL,
+        "loaded": load,
+    }
+
+
+def doctor_service(*, codex_home: Path, launch_agents: Path) -> DoctorResult:
+    config = codex_home.expanduser().resolve() / "state" / "codexpro-cloudflare" / "config.yml"
+    plist_path = launch_agents.expanduser().resolve() / f"{LABEL}.plist"
+    installed = config.is_file() and plist_path.is_file()
+    managed = False
+    if plist_path.is_file():
+        try:
+            value = plistlib.loads(plist_path.read_bytes())
+            managed = value.get("CodexProManaged") is True and value.get("Label") == LABEL
+        except (OSError, plistlib.InvalidFileException):
+            managed = False
+    loaded = False
+    if sys.platform == "darwin":
+        current = subprocess.run(
+            ["launchctl", "print", f"gui/{os.getuid()}/{LABEL}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        loaded = current.returncode == 0
+    return {
+        "ok": installed and managed,
+        "installed": installed,
+        "managed": managed,
+        "loaded": loaded,
+        "config": str(config),
+        "plist": str(plist_path),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--codex-home", type=Path, default=Path.home() / ".codex")
+    parser.add_argument("--launch-agents", type=Path, default=Path.home() / "Library" / "LaunchAgents")
+    commands = parser.add_subparsers(dest="command", required=True)
+    install = commands.add_parser("install")
+    install.add_argument("--project-root", type=Path, required=True)
+    install.add_argument("--cloudflared", type=Path, required=True)
+    install.add_argument("--hostname", required=True)
+    install.add_argument("--tunnel-id", required=True)
+    install.add_argument("--credentials-file", type=Path, required=True)
+    install.add_argument("--load", action="store_true")
+    commands.add_parser("doctor")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "install":
+            spec = TunnelSpec.parse(
+                hostname=args.hostname,
+                tunnel_id=args.tunnel_id,
+                credentials_file=args.credentials_file,
+            )
+            paths = InstallPaths(
+                codex_home=args.codex_home,
+                launch_agents=args.launch_agents,
+                project_root=args.project_root,
+                cloudflared=args.cloudflared,
+            )
+            result = install_service(paths=paths, spec=spec, load=args.load)
+        else:
+            result = doctor_service(codex_home=args.codex_home, launch_agents=args.launch_agents)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0 if result["ok"] else 2
+    except TunnelConfigError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,9 @@ README는 현재 제품의 목적과 사용법만 설명합니다. 구현 변경
 - `RUNNING → CHECKPOINT_DUE(75분) → HANDOFF_PENDING(80분)` 상태 머신과
   exact Oracle 회수, 동일 Codex session resume, launchd 감독기를 추가했습니다.
 - DevSpace 1.0.4를 macOS에서 직접 실행하고 MagicDNS 자동 탐지 및 Tailscale
-  Funnel `8443 → 127.0.0.1:7676` 복구 경로를 추가했습니다.
+  Funnel `443 → 127.0.0.1:7676` 복구 경로를 추가했습니다. Funnel 엣지가
+  OpenAI 연결 제한을 넘길 때 사용할 격리된 Cloudflare Named Tunnel
+  LaunchAgent도 제공합니다.
 - GitHub Actions는 `windows-latest`와 `macos-14`를 모두 검증합니다.
 
 ### Oracle + DevSpace 단일 실행 경로

--- a/docs/MACOS_ULTRAWORK.md
+++ b/docs/MACOS_ULTRAWORK.md
@@ -44,6 +44,32 @@ Mode 등록과 Owner 승인은 수동으로 완료한다. URL은 doctor가 출�
 `https://<magic-dns>/mcp`다. 표준 HTTPS 443을 사용하므로 ChatGPT OAuth
 메타데이터 수집 경로에도 별도 포트가 붙지 않는다.
 
+### Cloudflare Named Tunnel 대체 경로
+
+OpenAI 쪽에서 Tailscale Funnel 엣지 연결이 반복적으로 시간 초과하면, 기존
+터널이나 `com.openclaw.*` 서비스를 재사용하지 말고 DevSpace 전용 터널을
+만든다.
+
+```bash
+cloudflared tunnel create codexpro-devspace-macos
+cloudflared tunnel route dns <tunnel-uuid> devspace.example.com
+
+python3 "$HOME/.codex/bin/codexpro_cloudflared_launchd.py" install \
+  --project-root "/absolute/path/to/codexpro-automation" \
+  --cloudflared "/opt/homebrew/bin/cloudflared" \
+  --hostname "devspace.example.com" \
+  --tunnel-id "<tunnel-uuid>" \
+  --credentials-file "$HOME/.cloudflared/<tunnel-uuid>.json" \
+  --load
+python3 "$HOME/.codex/bin/codexpro_cloudflared_launchd.py" doctor
+```
+
+DevSpace의 `publicBaseUrl`은 `https://devspace.example.com`과 정확히 같아야
+한다. 전환 뒤 `/healthz`, OAuth authorization-server metadata, protected
+resource metadata, 인증 없는 `/mcp`의 401 challenge를 확인한다. ChatGPT
+Developer Mode 앱 등록과 Owner 승인은 사용자가 새 URL로 다시 수행한다.
+Cloudflare Access나 대화형 WAF challenge를 이 hostname 앞에 추가하지 않는다.
+
 ## launchd
 
 ```bash
@@ -55,6 +81,10 @@ python3 "$HOME/.codex/bin/codexpro_macos_launchd.py" doctor
 DevSpace는 실패 시 재시작되고, Funnel 상태는 5분마다 확인되며, 하네스
 감독기는 60초마다 실행된다. 제거는 동일 CLI의 `uninstall`로 이 프로젝트가
 소유한 세 plist만 대상으로 한다.
+
+Cloudflare 대체 경로의 plist는 별도 label
+`com.ventianima.codexpro-automation.cloudflared-devspace`로 관리되며 기존 세
+plist와 기존 Cloudflare 터널을 수정하지 않는다.
 
 압축 clock canary는 `python3 scripts/run_harness_canary.py`로 실행한다. 배포 전
 실제 85분 증거가 필요하면 같은 명령에 `--real-time`을 추가하며, 이 경로도

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -51,6 +51,7 @@
     "bin/codexpro_exact_unit_cloudflare_bootstrap.ps1",
     "bin/codexpro_fixed_runtime_watchdog.py",
     "bin/codexpro_harness.py",
+    "bin/codexpro_cloudflared_launchd.py",
     "bin/codexpro_macos_launchd.py",
     "bin/codexpro_mcp_identity.py",
     "bin/codexpro_lifecycle.py",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "bin/codexpro_exact_unit_cloudflare_bootstrap.ps1",
     "bin/codexpro_fixed_runtime_watchdog.py",
     "bin/codexpro_harness.py",
+    "bin/codexpro_cloudflared_launchd.py",
     "bin/codexpro_lifecycle.py",
     "bin/codexpro_macos_launchd.py",
     "bin/codexpro_mcp_identity.py",

--- a/tests/test_codexpro_cloudflared_launchd.py
+++ b/tests/test_codexpro_cloudflared_launchd.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import plistlib
 import subprocess
 import sys
@@ -88,7 +89,8 @@ def test_install_writes_private_config_and_managed_launchagent(tmp_path: Path) -
     config = Path(result["config"])
     plist_path = Path(result["plist"])
     assert config.parent == codex_home / "state" / "codexpro-cloudflare"
-    assert config.stat().st_mode & 0o777 == 0o600
+    if os.name == "posix":
+        assert config.stat().st_mode & 0o777 == 0o600
     assert plistlib.loads(plist_path.read_bytes())["CodexProManaged"] is True
     assert result["loaded"] is False
 

--- a/tests/test_codexpro_cloudflared_launchd.py
+++ b/tests/test_codexpro_cloudflared_launchd.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import plistlib
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "bin" / "codexpro_cloudflared_launchd.py"
+
+
+def load_module():
+    assert MODULE_PATH.is_file()
+    spec = importlib.util.spec_from_file_location("codexpro_cloudflared_launchd_test", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cloudflared_artifacts_are_isolated_and_route_only_devspace(tmp_path: Path) -> None:
+    module = load_module()
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    credentials = tmp_path / "credentials.json"
+    credentials.touch()
+    config = tmp_path / "config.yml"
+
+    spec = module.TunnelSpec.parse(
+        hostname="devspace.example.com",
+        tunnel_id="44ba10ff-1b67-47eb-a10c-9ec085647d98",
+        credentials_file=credentials,
+    )
+    config_text = module.render_config(spec)
+    runtime = module.ServiceRuntime(
+        project_root=project_root.resolve(),
+        cloudflared="/opt/homebrew/bin/cloudflared",
+        config=config,
+        logs=tmp_path / "logs",
+    )
+    plist = module.service_plist(runtime=runtime, tunnel_id=spec.tunnel_id)
+
+    assert module.LABEL == "com.ventianima.codexpro-automation.cloudflared-devspace"
+    assert "hostname: devspace.example.com" in config_text
+    assert "service: http://127.0.0.1:7676" in config_text
+    assert config_text.rstrip().endswith("- service: http_status:404")
+    assert plist["CodexProManaged"] is True
+    assert plist["ProgramArguments"] == [
+        "/opt/homebrew/bin/cloudflared",
+        "tunnel",
+        "--no-autoupdate",
+        "--config",
+        str(config),
+        "run",
+        str(spec.tunnel_id),
+    ]
+    assert plistlib.loads(plistlib.dumps(plist))["Label"] == module.LABEL
+
+
+def test_install_writes_private_config_and_managed_launchagent(tmp_path: Path) -> None:
+    module = load_module()
+    codex_home = tmp_path / "codex"
+    launch_agents = tmp_path / "LaunchAgents"
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    credentials = tmp_path / "credentials.json"
+    credentials.touch()
+    cloudflared = tmp_path / "cloudflared"
+    cloudflared.touch(mode=0o755)
+    spec = module.TunnelSpec.parse(
+        hostname="devspace.example.com",
+        tunnel_id="44ba10ff-1b67-47eb-a10c-9ec085647d98",
+        credentials_file=credentials,
+    )
+
+    paths = module.InstallPaths(
+        codex_home=codex_home,
+        launch_agents=launch_agents,
+        project_root=project_root,
+        cloudflared=cloudflared,
+    )
+    result = module.install_service(paths=paths, spec=spec, load=False)
+
+    config = Path(result["config"])
+    plist_path = Path(result["plist"])
+    assert config.parent == codex_home / "state" / "codexpro-cloudflare"
+    assert config.stat().st_mode & 0o777 == 0o600
+    assert plistlib.loads(plist_path.read_bytes())["CodexProManaged"] is True
+    assert result["loaded"] is False
+
+
+def test_doctor_accepts_installed_managed_artifacts(tmp_path: Path) -> None:
+    module = load_module()
+    codex_home = tmp_path / "codex"
+    launch_agents = tmp_path / "LaunchAgents"
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    credentials = tmp_path / "credentials.json"
+    credentials.touch()
+    cloudflared = tmp_path / "cloudflared"
+    cloudflared.touch(mode=0o755)
+    spec = module.TunnelSpec.parse(
+        hostname="devspace.example.com",
+        tunnel_id="44ba10ff-1b67-47eb-a10c-9ec085647d98",
+        credentials_file=credentials,
+    )
+    paths = module.InstallPaths(codex_home, launch_agents, project_root, cloudflared)
+    module.install_service(paths=paths, spec=spec, load=False)
+
+    result = module.doctor_service(codex_home=codex_home, launch_agents=launch_agents)
+
+    assert result["ok"] is True
+    assert result["managed"] is True
+    assert result["installed"] is True
+
+
+def test_cli_installs_artifacts_without_loading_launchd(tmp_path: Path) -> None:
+    codex_home = tmp_path / "codex"
+    launch_agents = tmp_path / "LaunchAgents"
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    credentials = tmp_path / "credentials.json"
+    credentials.touch()
+    cloudflared = tmp_path / "cloudflared"
+    cloudflared.touch(mode=0o755)
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(MODULE_PATH),
+            "--codex-home",
+            str(codex_home),
+            "--launch-agents",
+            str(launch_agents),
+            "install",
+            "--project-root",
+            str(project_root),
+            "--cloudflared",
+            str(cloudflared),
+            "--hostname",
+            "devspace.example.com",
+            "--tunnel-id",
+            "44ba10ff-1b67-47eb-a10c-9ec085647d98",
+            "--credentials-file",
+            str(credentials),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout)["label"] == "com.ventianima.codexpro-automation.cloudflared-devspace"

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -53,6 +53,7 @@ def test_manifest_covers_runtime_and_schemas() -> None:
         'bin/codexpro_agbrowse_app.py',
         'bin/codexpro_fixed_runtime_watchdog.py',
         'bin/codexpro_harness.py',
+        'bin/codexpro_cloudflared_launchd.py',
         'bin/codexpro_lifecycle.py',
         'bin/codexpro_macos_launchd.py',
         'bin/codexpro_posix_process.py',


### PR DESCRIPTION
## Summary
- add a macOS LaunchAgent CLI for a locally managed, isolated Cloudflare Named Tunnel
- keep existing com.openclaw services and Cloudflare tunnels untouched
- package and document the stable HTTPS fallback for DevSpace OAuth/MCP

## Verification
- fast gate: 186 passed, 1 skipped
- focused lifecycle and packaging tests: 17 passed
- no-excuse Python audit: clean
- macOS launchd doctor: installed, managed, loaded
- live restart QA: cloudflared restarted under KeepAlive and public health remained HTTP 200
- OAuth discovery metadata and unauthenticated MCP challenge validated on a host-only endpoint

## Manual gate
- ChatGPT Developer Mode registration and Owner approval remain user-operated.