### PR TITLE
Prefer headless Tailscale for macOS Funnel

### DIFF
--- a/bin/codexpro_macos_launchd.py
+++ b/bin/codexpro_macos_launchd.py
@@ -84,6 +84,9 @@ def service_plists(
                 str(codex_home / "skills" / "chatgpt-workspace-setup" / "scripts" / "devspace_tailscale_setup.py"),
                 "ensure", "--root", str(project_root), "--public-port", "443",
             ],
+            "EnvironmentVariables": {
+                "PATH": "/opt/homebrew/bin:/usr/local/bin:" + str(Path.home() / ".local" / "bin") + ":/usr/bin:/bin",
+            },
             "RunAtLoad": True,
             "StartInterval": 300,
             "WorkingDirectory": str(project_root),

--- a/tests/test_codexpro_macos_launchd.py
+++ b/tests/test_codexpro_macos_launchd.py
@@ -44,3 +44,6 @@ def test_launchd_funnel_uses_standard_https_port_for_chatgpt_oauth(tmp_path: Pat
     values = module.service_plists(codex_home=codex_home, project_root=project.resolve(), python="/usr/bin/python3", npx="/opt/homebrew/bin/npx")
 
     assert values["funnel"]["ProgramArguments"][-3:] == [str(project.resolve()), "--public-port", "443"]
+    funnel_path = values["funnel"]["EnvironmentVariables"]["PATH"]
+    assert funnel_path.startswith("/opt/homebrew/bin:/usr/local/bin:")
+    assert "/Applications/Tailscale.app/" not in funnel_path


### PR DESCRIPTION
## Summary
- prioritize Homebrew `tailscale`/`tailscaled` in the managed macOS Funnel LaunchAgent
- remove the unsupported App Store GUI binary directory from the Funnel service PATH
- retain `~/.local/bin` as a lower-priority compatibility fallback

## Why
Tailscale documents Funnel as unsupported by the macOS App Store and Standalone GUI variants. Resolving the app bundle binary can also launch GUI mode instead of the CLI under launchd. The open-source `tailscaled` variant is the supported macOS Funnel runtime.

## Verification
- `tests/test_codexpro_macos_launchd.py`: 3 targeted test functions passed
- live macOS smoke: Homebrew Tailscale 1.102.2, public Funnel TLS on both anycast A records, OAuth discovery, and authenticated OpenAI MCP sessions succeeded