### PR TITLE
Fix model-selector pre-submit settlement

### DIFF
--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -109,6 +109,11 @@ ORACLE_CDP_DISCONNECT_PRE_SUBMIT_ERROR = (
     "Chrome DevTools client disconnected before oracle finished; "
     "the browser target appears still alive."
 )
+ORACLE_MODEL_SELECTOR_BUTTON_PRE_SUBMIT_ERROR = (
+    "Unable to locate the ChatGPT model selector button. If the desired model is already "
+    "selected in the browser, retry with --browser-model-strategy current; otherwise retry "
+    "with --browser-model-strategy ignore to skip model selection."
+)
 ORACLE_STANDALONE_PRO_NO_SUBMISSION_VERSIONS = {"0.17.1"}
 USER_CONFIRMED_NO_SUBMISSION = "user-confirmed-no-submission"
 USER_CONFIRMED_EXECUTION_ENDED = "user-confirmed-task-ended"
@@ -1568,7 +1573,13 @@ def _standalone_pro_attachment_no_submission_evidence(
 
 
 def _standalone_pro_no_submission_evidence(state_path: Path) -> dict[str, Any] | None:
-    """Return bounded evidence for user adjudication of one qualified Pro run."""
+    """Return bounded evidence for user adjudication of one qualified Pro run.
+
+    Prompt-observation timeouts remain eligible through their exact transcript.
+    A model-selector-button failure additionally requires Oracle 0.17.1's exact
+    session ledger to prove the browser never left the ChatGPT home composer and
+    ``promptSubmitted`` stayed false.
+    """
     state = load_state(state_path)
     run_dir = state_path.parent
     run_id = str(state.get("run_id") or "")
@@ -1622,23 +1633,144 @@ def _standalone_pro_no_submission_evidence(state_path: Path) -> dict[str, Any] |
         stdout_text = stdout_bytes.decode("utf-8", errors="strict")
     except UnicodeDecodeError:
         return None
-    marker_lines = {
+    prompt_marker_lines = {
         line.strip()
         for line in stdout_text.splitlines()
         if ORACLE_PROMPT_NOT_OBSERVED_MARKER in line
     }
-    allowed_marker_lines = {
+    allowed_prompt_marker_lines = {
         f"ERROR: {ORACLE_PROMPT_NOT_OBSERVED_MARKER}",
         f"User error (browser-automation): {ORACLE_PROMPT_NOT_OBSERVED_MARKER}",
     }
+    selector_marker_lines = {
+        line.strip()
+        for line in stdout_text.splitlines()
+        if ORACLE_MODEL_SELECTOR_BUTTON_PRE_SUBMIT_ERROR in line
+    }
+    allowed_selector_marker_lines = {
+        f"ERROR: {ORACLE_MODEL_SELECTOR_BUTTON_PRE_SUBMIT_ERROR}",
+        f"User error (browser-automation): {ORACLE_MODEL_SELECTOR_BUTTON_PRE_SUBMIT_ERROR}",
+    }
+    prompt_marker_valid = (
+        bool(prompt_marker_lines)
+        and prompt_marker_lines.issubset(allowed_prompt_marker_lines)
+        and stdout_text.count(ORACLE_PROMPT_NOT_OBSERVED_MARKER) == len(prompt_marker_lines)
+    )
+    selector_marker_valid = (
+        selector_marker_lines == allowed_selector_marker_lines
+        and stdout_text.count(ORACLE_MODEL_SELECTOR_BUTTON_PRE_SUBMIT_ERROR) == 2
+    )
     if (
-        not marker_lines
-        or not marker_lines.issubset(allowed_marker_lines)
-        or stdout_text.count(ORACLE_PROMPT_NOT_OBSERVED_MARKER) != len(marker_lines)
+        prompt_marker_valid == selector_marker_valid
         or f"Session: {locator}" not in stdout_text
         or CHATGPT_CONVERSATION_URL_RE.search(stdout_text)
     ):
         return None
+    selector_meta_evidence: dict[str, Any] = {}
+    if selector_marker_valid:
+        lines = stdout_text.splitlines()
+        expected_tail = [
+            f"ERROR: {ORACLE_MODEL_SELECTOR_BUTTON_PRE_SUBMIT_ERROR}",
+            f"User error (browser-automation): {ORACLE_MODEL_SELECTOR_BUTTON_PRE_SUBMIT_ERROR}",
+        ]
+        if (
+            len(lines) != 13
+            or re.fullmatch(r".{1,4} oracle 0\.17\.1 .{2,120}", lines[0]) is None
+            or lines[1] != f"Session: {locator}"
+            or lines[2:6] != [
+                "Mode: browser foreground",
+                "Models: 1",
+                "Detach: no",
+                f"Reattach: oracle session {locator}",
+            ]
+            or not re.fullmatch(
+                r"Launching browser mode \(target=GPT-5\.6 Sol; requested=gpt-5\.6-sol\) "
+                r"with ~[1-9][0-9]* tokens\.",
+                lines[6],
+            )
+            or lines[7:11] != [
+                "This run can take up to an hour (usually ~10 minutes).",
+                "[browser] Browser control: launch Chrome in hidden-window mode; may focus/control the browser UI.",
+                "[browser] Browser guidance: On macOS, Oracle launches Chrome off-screen while keeping the page rendered.",
+                "[browser] Browser guidance: For the calmest shared-desktop flow, prefer --browser-attach-running or --remote-chrome.",
+            ]
+            or lines[-2:] != expected_tail
+        ):
+            return None
+        session_root = Path(
+            os.environ.get("ORACLE_SESSION_ROOT") or (Path.home() / ".oracle" / "sessions")
+        ).resolve()
+        meta_path = session_root / locator / "meta.json"
+        if meta_path.is_symlink():
+            return None
+        try:
+            meta_bytes = meta_path.read_bytes()
+            meta = json.loads(meta_bytes.decode("utf-8", errors="strict"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        browser = meta.get("browser") if isinstance(meta.get("browser"), dict) else {}
+        config = browser.get("config") if isinstance(browser.get("config"), dict) else {}
+        runtime = browser.get("runtime") if isinstance(browser.get("runtime"), dict) else {}
+        error = meta.get("error") if isinstance(meta.get("error"), dict) else {}
+        details = error.get("details") if isinstance(error.get("details"), dict) else {}
+        details_runtime = (
+            details.get("runtime") if isinstance(details.get("runtime"), dict) else {}
+        )
+        options = meta.get("options") if isinstance(meta.get("options"), dict) else {}
+        option_browser = (
+            options.get("browserConfig")
+            if isinstance(options.get("browserConfig"), dict)
+            else {}
+        )
+        try:
+            meta_cwd = Path(str(meta.get("cwd") or "")).resolve()
+            meta_output = Path(str(options.get("writeOutputPath") or "")).resolve()
+            state_profile = Path(str(profile.get("copy_profile") or "")).resolve()
+            config_profile = Path(str(config.get("copyProfileSource") or "")).resolve()
+            option_profile = Path(str(option_browser.get("copyProfileSource") or "")).resolve()
+        except OSError:
+            return None
+        if not str(profile.get("copy_profile") or "").strip() or not state_profile.is_absolute():
+            return None
+        if (
+            meta.get("id") != locator
+            or meta.get("status") != "error"
+            or meta.get("model") != "gpt-5.6-sol"
+            or meta.get("mode") != "browser"
+            or not str(meta.get("completedAt") or "").strip()
+            or meta_cwd != Path(str(state.get("project_root") or "")).resolve()
+            or meta_output != output.resolve()
+            or config_profile != state_profile
+            or option_profile != state_profile
+            or config.get("desiredModel") != "GPT-5.6 Sol"
+            or config.get("modelStrategy") != "select"
+            or config.get("thinkingTime") != "heavy"
+            or options.get("model") != "gpt-5.6-sol"
+            or options.get("slug") != locator
+            or option_browser.get("modelStrategy") != "select"
+            or option_browser.get("desiredModel") != "GPT-5.6 Sol"
+            or option_browser.get("thinkingTime") != "heavy"
+            or runtime.get("promptSubmitted") is not False
+            or runtime.get("tabUrl") != "https://chatgpt.com/"
+            or details_runtime.get("promptSubmitted") not in {None, False}
+            or error.get("category") != "browser-automation"
+            or error.get("message") != ORACLE_MODEL_SELECTOR_BUTTON_PRE_SUBMIT_ERROR
+            or details.get("stage") != "execute-browser"
+            or str(meta.get("errorMessage") or "")
+            != ORACLE_MODEL_SELECTOR_BUTTON_PRE_SUBMIT_ERROR
+            or CHATGPT_CONVERSATION_URL_RE.search(
+                meta_bytes.decode("utf-8", errors="strict")
+            )
+        ):
+            return None
+        selector_meta_evidence = {
+            "pre_submit_marker": "oracle-model-selector-button-missing/v1",
+            "oracle_meta_path": str(meta_path),
+            "oracle_meta_sha256": hashlib.sha256(meta_bytes).hexdigest(),
+            "oracle_meta_stage": "execute-browser",
+            "prompt_submitted": False,
+            "tab_url": "https://chatgpt.com/",
+        }
     mission = state.get("mission") if isinstance(state.get("mission"), dict) else {}
     source_path = Path(str(mission.get("path") or ""))
     transport_path = Path(str(mission.get("transport_path") or ""))
@@ -1713,6 +1845,7 @@ def _standalone_pro_no_submission_evidence(state_path: Path) -> dict[str, Any] |
         "recovery_evidence": recovery_records,
         "output_absent": True,
         "conversation_url_absent": True,
+        **selector_meta_evidence,
         "_source_mission_path": str(source_path),
         "_transport_mission_path": str(transport_path),
     }
@@ -2029,6 +2162,11 @@ def proven_user_confirmed_no_submission(state_path: Path) -> dict[str, Any] | No
             "source_mission_sha256", "transport_mission_path", "transport_mission_sha256",
             "oracle_version",
         )
+        if current.get("pre_submit_marker") == "oracle-model-selector-button-missing/v1":
+            required += (
+                "pre_submit_marker", "oracle_meta_path", "oracle_meta_sha256",
+                "oracle_meta_stage", "prompt_submitted", "tab_url",
+            )
     elif current.get("settlement_eligibility") == "oracle-direct-devspace/v1":
         required = (
             "settlement_eligibility", "transport", "profile", "source_mission_path",
@@ -2093,7 +2231,7 @@ def settle_user_confirmed_no_submission(
     if evidence is None:
         raise OracleStateError(
             "NO_SUBMISSION_EVIDENCE_INCOMPLETE",
-            "run lacks the exact prompt-timeout and recovery-binding evidence required for user adjudication",
+            "run lacks the exact pre-submit UI and recovery-binding evidence required for user adjudication",
         )
     recorded = {
         "schema": "codex.chatgpt.oracle-user-confirmed-no-submission/v1",
@@ -2113,7 +2251,12 @@ def settle_user_confirmed_no_submission(
         "artifact_sha256": None,
         "transport_status": "not_submitted_user_confirmed",
         "task_outcome": "pending",
-        "task_outcome_reason": "user-confirmed-no-submission-after-prompt-timeout",
+        "task_outcome_reason": (
+            "user-confirmed-no-submission-after-model-selector-failure"
+            if evidence.get("pre_submit_marker")
+            == "oracle-model-selector-button-missing/v1"
+            else "user-confirmed-no-submission-after-prompt-timeout"
+        ),
         "user_confirmed_no_submission": {
             "schema": "codex.chatgpt.oracle-settlement-reference/v1",
             "path": str(settlement_path),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # 기술 변경 기록
 
+## 1.15.1 - 모델 선택 전 미제출 정산 결속
+
+- Oracle 0.17.1이 ChatGPT 홈에서 모델 선택 버튼을 찾지 못해 prompt 전송 전에
+  종료된 qualified Pro run을 사용자 확인 정산 후보로 추가했습니다. 정확한
+  selector 오류만으로는 해제하지 않으며 exact slug, 버전, copied profile,
+  `execute-browser` stage, `promptSubmitted=false`, 홈 URL, output·대화 URL 부재,
+  recovery-binding 불가 증거와 모든 관련 SHA-256이 함께 일치해야 합니다.
+- prompt 제출, 대화 URL, output, 다른 오류·stage, 누락되거나 변경된 Oracle
+  session ledger 중 하나라도 있으면 기존 잠금이 유지됩니다. 정산 receipt가
+  만들어진 뒤 meta가 바뀌어도 재검증이 실패해 해당 run이 다시 unresolved로
+  취급됩니다.
+
 ## 1.15.0 - 울트라 GPT 모드
 
 - setup 문서와 실제 기본 runner app name의 불일치를 제거해 기본값을 수동

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.19 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -306,6 +306,104 @@ def cdp_disconnect_pre_submit_popen(session_root: Path, *, variation: str | None
     return popen
 
 
+def model_selector_button_pre_submit_popen(
+    session_root: Path,
+    *,
+    variation: str | None = None,
+):
+    def popen(command, **kwargs):
+        slug = command[command.index("--slug") + 1]
+        output_path = Path(command[command.index("--write-output") + 1]).resolve()
+        expected_profile = (Path.home() / ".oracle" / "browser-profile").resolve()
+        error_message = (
+            "Unable to locate the ChatGPT model selector button. If the desired model is "
+            "already selected in the browser, retry with --browser-model-strategy current; "
+            "otherwise retry with --browser-model-strategy ignore to skip model selection."
+        )
+        emitted_error = (
+            "Unable to locate a different browser control."
+            if variation == "different-error"
+            else error_message
+        )
+        lines = [
+            "? oracle 0.17.1 deterministic fixture",
+            f"Session: {slug}",
+            "Mode: browser foreground",
+            "Models: 1",
+            "Detach: no",
+            f"Reattach: oracle session {slug}",
+            "Launching browser mode (target=GPT-5.6 Sol; requested=gpt-5.6-sol) with ~200 tokens.",
+            "This run can take up to an hour (usually ~10 minutes).",
+            "[browser] Browser control: launch Chrome in hidden-window mode; may focus/control the browser UI.",
+            "[browser] Browser guidance: On macOS, Oracle launches Chrome off-screen while keeping the page rendered.",
+            "[browser] Browser guidance: For the calmest shared-desktop flow, prefer --browser-attach-running or --remote-chrome.",
+            f"ERROR: {emitted_error}",
+            f"User error (browser-automation): {emitted_error}",
+        ]
+        kwargs["stdout"].write(("\n".join(lines) + "\n").encode("utf-8"))
+        kwargs["stdout"].flush()
+        tab_url = (
+            "https://chatgpt.com/c/existing-conversation"
+            if variation == "conversation-url"
+            else "https://chatgpt.com/"
+        )
+        prompt_submitted = variation == "prompt-submitted"
+        meta = {
+            "id": slug,
+            "createdAt": "2026-08-20T00:09:39.348Z",
+            "startedAt": "2026-08-20T00:09:39.393Z",
+            "completedAt": "2026-08-20T00:10:07.368Z",
+            "status": "error",
+            "model": "gpt-5.6-sol",
+            "cwd": str(Path(kwargs["cwd"]).resolve()),
+            "mode": "browser",
+            "browser": {
+                "config": {
+                    "copyProfileSource": str(expected_profile),
+                    "desiredModel": "GPT-5.6 Sol",
+                    "modelStrategy": "select",
+                    "thinkingTime": "heavy",
+                },
+                "runtime": {
+                    "chromePid": 16424,
+                    "chromePort": 9222,
+                    "chromeHost": "127.0.0.1",
+                    "tabUrl": tab_url,
+                    "promptSubmitted": prompt_submitted,
+                    "controllerPid": 27784,
+                },
+            },
+            "options": {
+                "model": "gpt-5.6-sol",
+                "slug": slug,
+                "writeOutputPath": str(output_path),
+                "browserConfig": {
+                    "copyProfileSource": str(expected_profile),
+                    "desiredModel": "GPT-5.6 Sol",
+                    "modelStrategy": "select",
+                    "thinkingTime": "heavy",
+                },
+            },
+            "errorMessage": error_message,
+            "error": {
+                "category": "browser-automation",
+                "message": error_message,
+                "details": {
+                    "stage": "different-stage" if variation == "different-stage" else "execute-browser",
+                },
+            },
+        }
+        if variation != "missing-meta":
+            meta_path = session_root / slug / "meta.json"
+            meta_path.parent.mkdir(parents=True, exist_ok=True)
+            meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        if variation == "output-present":
+            output_path.write_text("contradictory output", encoding="utf-8")
+        return Process(1, [])
+
+    return popen
+
+
 def isolated_default_oracle_profile(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1541,6 +1639,124 @@ def test_model_switcher_failure_with_a_conversation_url_does_not_release_lock(tm
     legacy.pop("pre_submit_failure", None)
     runner.STATE.write_json_atomic(state_path, legacy)
     assert runner.STATE.settle_proven_pre_submit_failure(state_path) is None
+    assert runner.STATE.load_state(state_path)["session_authority"] == "submitted_unknown"
+
+
+def test_user_confirmed_model_selector_button_failure_is_hash_bound_and_releases_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    isolated_default_oracle_profile(tmp_path, monkeypatch)
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    initial = execute_run(
+        runner,
+        pro_readonly_manifest(tmp_path, run_id="7" * 32),
+        run_factory=version_0171_runner,
+        popen_factory=model_selector_button_pre_submit_popen(session_root),
+    )
+    run_dir = Path(initial["run_dir"])
+    state_path = run_dir / "state.json"
+    state = runner.STATE.load_state(state_path)
+    slug = state["oracle"]["slug"]
+    (run_dir / "recovery-live-stdout.log").write_text(
+        f'No live ChatGPT tab matched session "{slug}". Attempting recovery by reopening the saved conversation URL.\n',
+        encoding="utf-8",
+    )
+    (run_dir / "recovery-live-stderr.log").write_text(
+        "Cannot recover conversation: session metadata has no recoverable ChatGPT conversation URL.\n",
+        encoding="utf-8",
+    )
+
+    assert initial["result"]["status"] == "attention_required"
+    settled = runner.settle_user_confirmed_no_submission(
+        run_dir,
+        confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
+        reason="user confirmed the exact selector failure created no prompt or conversation",
+    )
+    proof = runner.STATE.proven_user_confirmed_no_submission(state_path)
+    receipt = json.loads(
+        (run_dir / "user-confirmed-no-submission.json").read_text(encoding="utf-8")
+    )
+
+    assert settled["ok"] is True
+    assert settled["safe_for_fresh_run"] is True
+    assert settled["result"]["session_authority"] == "pre_submit"
+    assert settled["result"]["task_outcome_reason"] == (
+        "user-confirmed-no-submission-after-model-selector-failure"
+    )
+    assert proof is not None
+    assert proof["pre_submit_marker"] == "oracle-model-selector-button-missing/v1"
+    assert proof["prompt_submitted"] is False
+    assert proof["tab_url"] == "https://chatgpt.com/"
+    assert receipt["oracle_meta_sha256"] == hashlib.sha256(
+        (session_root / slug / "meta.json").read_bytes()
+    ).hexdigest()
+    assert runner.STATE.unresolved_project_sessions(run_dir.parent, tmp_path) == []
+
+    meta_path = session_root / slug / "meta.json"
+    tampered = json.loads(meta_path.read_text(encoding="utf-8"))
+    tampered["browser"]["runtime"]["promptSubmitted"] = True
+    meta_path.write_text(json.dumps(tampered), encoding="utf-8")
+    assert runner.STATE.proven_user_confirmed_no_submission(state_path) is None
+    assert [
+        owner["run_id"]
+        for owner in runner.STATE.unresolved_project_sessions(run_dir.parent, tmp_path)
+    ] == ["7" * 32]
+
+
+@pytest.mark.parametrize(
+    "variation",
+    (
+        "prompt-submitted",
+        "conversation-url",
+        "different-stage",
+        "different-error",
+        "output-present",
+        "missing-meta",
+    ),
+)
+def test_model_selector_button_user_settlement_keeps_lock_on_incomplete_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    variation: str,
+) -> None:
+    runner = load_runner()
+    isolated_default_oracle_profile(tmp_path, monkeypatch)
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    initial = execute_run(
+        runner,
+        pro_readonly_manifest(tmp_path, run_id="8" * 32),
+        run_factory=version_0171_runner,
+        popen_factory=model_selector_button_pre_submit_popen(
+            session_root,
+            variation=variation,
+        ),
+    )
+    run_dir = Path(initial["run_dir"])
+    state_path = run_dir / "state.json"
+    state = runner.STATE.load_state(state_path)
+    slug = state["oracle"]["slug"]
+    (run_dir / "recovery-live-stdout.log").write_text(
+        f'No live ChatGPT tab matched session "{slug}". Attempting recovery by reopening the saved conversation URL.\n',
+        encoding="utf-8",
+    )
+    (run_dir / "recovery-live-stderr.log").write_text(
+        "Cannot recover conversation: session metadata has no recoverable ChatGPT conversation URL.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        runner.STATE.OracleStateError,
+        match="run lacks the exact pre-submit UI",
+    ):
+        runner.settle_user_confirmed_no_submission(
+            run_dir,
+            confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
+            reason="insufficient exact evidence must remain fail closed",
+        )
     assert runner.STATE.load_state(state_path)["session_authority"] == "submitted_unknown"
 
 


### PR DESCRIPTION
## Summary
- recognize Oracle 0.17.1 model-selector-button failures as user-confirmable no-submission evidence only when the exact session ledger proves `promptSubmitted=false` at the ChatGPT home URL
- keep fail-closed locks for prompt submission, conversation URLs, outputs, mismatched stages/errors, missing metadata, or post-settlement metadata tampering
- publish the repair as v1.15.1

## Verification
- `python -m pytest tests/test_chatgpt_oracle_run.py tests/test_chatgpt_oracle_diagnose.py tests/test_chatgpt_oracle_incident.py -q` -> 162 passed, 1 skipped
- `python -m pytest tests -q --basetemp=.codex-tmp\pytest-v1151-full` -> 870 passed, 8 skipped
- docs contract PASS
- portability PASS
- fast gate PASS in 46.7s
- golden-path smoke PASS with submitted_question=false