### PR TITLE
Add scoped Oracle 0.18 compatibility for WebJjonku Linux

### DIFF
--- a/.github/workflows/release-portability.yml
+++ b/.github/workflows/release-portability.yml
@@ -8,13 +8,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-14]
+        os: [windows-latest, macos-14, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with: { python-version: '3.11' }
+      - uses: actions/setup-node@v4
+        with: { node-version: '24.19.0' }
       - run: python -m pip install "pytest>=8,<10"
+      - run: python scripts/prepare_oracle_018_ci.py
       - run: python scripts/check_portability.py --root .
       - run: python scripts/check_docs.py --root .
       - run: python scripts/run_fast_gate.py --enforce-budget

--- a/README.en.md
+++ b/README.en.md
@@ -180,6 +180,24 @@ same version. Read the [changelog](docs/CHANGELOG.md) before upgrading.
 The current tested baseline is Oracle `0.17.1`, DevSpace `1.0.4`, Node.js
 `>=22.19 <27`, Windows 11, and macOS 12 or newer.
 
+Oracle `0.18.0` is a scoped compatibility version for the WebJjonku Linux
+host running Node.js `>=24 <27`. It keeps the upstream response-observer improvements and patches only
+the browser follow-up timeout inheritance defect. The caller must provide the
+published npm archive with `--package-archive` and explicitly select
+`chatgpt_oracle_compat.py --profile webjjonku-linux`; the tool verifies the
+archive integrity and the complete published Oracle package payload before
+patching. Any separately installed `node_modules` dependency tree remains the
+invoking runtime lock's responsibility.
+The default Windows/macOS comprehensive path continues to reject every Oracle
+version other than `0.17.1`.
+
+```sh
+python bin/chatgpt_oracle_compat.py --profile webjjonku-linux --resolved-version "oracle 0.18.0" --package-root /exact/node_modules/@steipete/oracle --package-archive /exact/steipete-oracle-0.18.0.tgz
+```
+
+The scoped profile requires all three explicit version, installed-root, and
+archive arguments; it never relies on platform-specific package discovery.
+
 ## License
 
 [MIT License](LICENSE). Third-party copyrights and licenses for Oracle,

--- a/README.md
+++ b/README.md
@@ -178,8 +178,16 @@ python "$env:USERPROFILE\.codex\bin\chatgpt_oracle_dispatch.py" `
 GitHub Release가 같은 버전을 가리켜야 합니다. 업그레이드 전에는
 [변경 기록](docs/CHANGELOG.md)을 확인하세요.
 
-현재 검증 기준은 Oracle `0.17.1`, DevSpace `1.0.4`, Node.js `>=22.19 <27`,
+현재 기본 검증 기준은 Oracle `0.17.1`, DevSpace `1.0.4`, Node.js `>=22.19 <27`,
 Windows 11 및 macOS 12 이상입니다.
+
+Oracle `0.18.0`은 Node.js `>=24 <27`인 WebJjonku Linux 호스트용 범위 제한 검증 버전입니다. Upstream 응답 관찰 개선은 그대로 사용하고, browser follow-up에서 명시한 `--browser-timeout`이 부모 세션 timeout에 묻히는 결함만 해시 검증형 호환 패치로 보정합니다. 이 버전은 npm archive를 `--package-archive`로 함께 제공하고 `chatgpt_oracle_compat.py --profile webjjonku-linux`를 명시한 경우에만 허용됩니다. 도구는 archive integrity와 설치된 Oracle의 published package payload 전체를 대조한 뒤 패치합니다. 설치 시 별도로 생기는 `node_modules` dependency tree는 호출 측 lock의 검증 대상이며, 기본 Windows/macOS comprehensive 경로는 계속 `0.17.1` 이외의 버전을 거부합니다.
+
+```sh
+python bin/chatgpt_oracle_compat.py --profile webjjonku-linux --resolved-version "oracle 0.18.0" --package-root /exact/node_modules/@steipete/oracle --package-archive /exact/steipete-oracle-0.18.0.tgz
+```
+
+범위 제한 프로필은 버전·설치 루트·archive 세 인수를 모두 명시해야 하며 자동 탐색하지 않습니다.
 
 ## 라이선스
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,8 +2,9 @@
 
 This repository ships no copy of agbrowse, the Oracle package, DevSpace,
 Codex, CodexPro, browser binaries, or account data. It does ship narrow
-textual compatibility patches for hash-verified Oracle 0.16.1/0.17.1 and DevSpace
-1.0.4 installations.
+textual compatibility patches for hash-verified Oracle 0.16.1/0.17.1, the
+explicitly scoped WebJjonku Linux Oracle 0.18.0 profile, and DevSpace 1.0.4
+installations.
 
 - `hehee9/multi-gpt@4f5e130` is MIT-licensed. Its attribution and the recorded `server.mjs` hash must be preserved when its upstream-compatible integration is changed.
 - `agbrowse@0.1.18` is an external npm package retained only for recovery of
@@ -14,10 +15,14 @@ textual compatibility patches for hash-verified Oracle 0.16.1/0.17.1 and DevSpac
   metadata and re-check before any redistribution. This project installs the
   package externally and does not copy its source.
 - `@steipete/oracle` is an external MIT-licensed browser automation package.
-  The tested version is 0.17.1; agents may resolve a newer compatible version
+  The default tested version is 0.17.1. Oracle 0.18.0 is accepted only by the
+  named `webjjonku-linux` profile after its published npm archive integrity and
+  complete published package payload are verified. Separately installed
+  dependencies remain governed by the invoking runtime lock. Agents may resolve any other version
   only after capability validation. Its package source is not vendored. Files
   under `bin/oracle-compat/0.17.1` are current derivative patch instructions;
-  `bin/oracle-compat/0.16.1` remains frozen for exact legacy recovery. Both retain
+  `bin/oracle-compat/0.18.0` contains the scoped follow-up timeout patch, and
+  `bin/oracle-compat/0.16.1` remains frozen for exact legacy recovery. All retain
   the following upstream MIT notice.
 - `@waishnav/devspace` is an external MIT-licensed MCP workspace server. The
   tested version is 1.0.4. Setup resolves it externally; this repository does

--- a/bin/chatgpt_oracle_compat.py
+++ b/bin/chatgpt_oracle_compat.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import base64
 import hashlib
+import io
 import json
 import os
 import shutil
+import stat
 import subprocess
+import tarfile
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Sequence
 
 SUPPORTED_VERSION = "0.17.1"
@@ -147,6 +151,32 @@ PATCHES = {
     },
 }
 
+# Keep 0.17.1 as the only version accepted by the default Windows/macOS
+# comprehensive workflow. WebJjonku's Linux Oracle host uses upstream 0.18.0
+# for its response-observer fixes and must opt into this narrower contract by
+# name; it does not inherit the broader 0.17.1 local compatibility patches.
+SCOPED_PATCHES = {
+    "webjjonku-linux": {
+        "0.18.0": {
+            "dist/bin/oracle-cli.js": {
+                "patch": "oracle-cli.followup-timeout.patch",
+                "pristine": "6909a8fd25ff7e5459123637e90a79d72dc5733cc2af0c14220018cb663b1825",
+                "patched": "6635dab468730e1a1031edd07480517edc79ce55bcef29f165347f7d2680e11a",
+            },
+        },
+    },
+}
+
+SCOPED_PACKAGE_INTEGRITIES = {
+    "webjjonku-linux": {
+        "0.18.0": "sha512-o8KFd66zNt36jw5zdtQAV74bgrOlJibbyvnLsVikIWDamesYtez/dIUhQ4zqtD9jkx+7A6vcP9+JgcJt0H5pOw==",
+    },
+}
+SCOPED_NODE_MAJOR_RANGES = {"webjjonku-linux": (24, 27)}
+SCOPED_ARCHIVE_MAX_FILES = 10_000
+SCOPED_ARCHIVE_MAX_BYTES = 100 * 1024 * 1024
+WINDOWS_RESERVED_NAMES = {"CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))}
+
 
 class OracleCompatError(RuntimeError):
     def __init__(self, code: str, message: str, evidence: dict[str, Any] | None = None):
@@ -157,6 +187,221 @@ class OracleCompatError(RuntimeError):
 
 def sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def sha512_integrity(path: Path) -> str:
+    digest = hashlib.sha512()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha512-" + base64.b64encode(digest.digest()).decode("ascii")
+
+
+def _is_link_or_reparse(info: os.stat_result) -> bool:
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    attributes = getattr(info, "st_file_attributes", 0)
+    return stat.S_ISLNK(info.st_mode) or bool(reparse_flag and attributes & reparse_flag)
+
+
+def _safe_archive_relative(name: str) -> str | None:
+    if not name or "\\" in name or "\x00" in name or any(ord(character) < 32 for character in name):
+        raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive contains an unsafe path")
+    raw_parts = name.split("/")
+    if any(part in {"", ".", ".."} for part in raw_parts):
+        raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive contains an unsafe path")
+    path = PurePosixPath(name)
+    if path.is_absolute() or not path.parts or path.parts[0] != "package":
+        raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive contains an unsafe path")
+    if len(path.parts) == 1:
+        return None
+    for part in path.parts[1:]:
+        if ":" in part or part.endswith((" ", ".")):
+            raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive contains an unsafe path")
+        device_name = part.rstrip(" .").split(".", 1)[0].upper()
+        if device_name in WINDOWS_RESERVED_NAMES:
+            raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive contains an unsafe path")
+    return PurePosixPath(*path.parts[1:]).as_posix()
+
+
+def _verify_scoped_node_runtime(profile: str) -> None:
+    minimum, maximum = SCOPED_NODE_MAJOR_RANGES[profile]
+    node = shutil.which("node")
+    if not node:
+        raise OracleCompatError(
+            "ORACLE_NODE_VERSION_UNSUPPORTED",
+            "Scoped Oracle compatibility requires its validated Node.js runtime",
+            {"profile": profile, "required": f">={minimum} <{maximum}"},
+        )
+    resolved = subprocess.run([node, "--version"], capture_output=True, text=True, check=False)
+    value = resolved.stdout.strip().removeprefix("v")
+    try:
+        major = int(value.split(".", 1)[0])
+    except (TypeError, ValueError):
+        major = -1
+    if resolved.returncode != 0 or not minimum <= major < maximum:
+        raise OracleCompatError(
+            "ORACLE_NODE_VERSION_UNSUPPORTED",
+            "Scoped Oracle compatibility requires its validated Node.js runtime",
+            {"profile": profile, "resolved": value or None, "required": f">={minimum} <{maximum}"},
+        )
+
+
+def _scan_installed_package_tree(root: Path) -> dict[str, Path]:
+    files: dict[str, Path] = {}
+    pending: list[tuple[Path, tuple[str, ...]]] = [(root, ())]
+    total_bytes = 0
+    while pending:
+        directory, relative_parts = pending.pop()
+        try:
+            entries = list(os.scandir(directory))
+        except OSError as exc:
+            raise OracleCompatError(
+                "ORACLE_PACKAGE_TREE_MISMATCH",
+                "Installed Oracle package tree could not be inspected",
+            ) from exc
+        for entry in entries:
+            item_parts = (*relative_parts, entry.name)
+            relative = PurePosixPath(*item_parts).as_posix()
+            try:
+                item_info = entry.stat(follow_symlinks=False)
+                item_path = Path(entry.path)
+                canonical_item = item_path.resolve(strict=True)
+            except OSError as exc:
+                raise OracleCompatError(
+                    "ORACLE_PACKAGE_TREE_MISMATCH",
+                    "Installed Oracle package entry could not be inspected",
+                    {"path": relative},
+                ) from exc
+            if _is_link_or_reparse(item_info) or not canonical_item.is_relative_to(root):
+                raise OracleCompatError(
+                    "ORACLE_PACKAGE_TREE_MISMATCH",
+                    "Installed Oracle package contains a link, junction, or escaping path",
+                    {"path": relative},
+                )
+            if stat.S_ISDIR(item_info.st_mode):
+                # npm may place dependency packages below the Oracle package
+                # root. Their integrity belongs to the invoking runtime lock,
+                # not to the published Oracle tarball payload verified here.
+                if item_parts == ("node_modules",):
+                    continue
+                pending.append((item_path, item_parts))
+                continue
+            if not stat.S_ISREG(item_info.st_mode):
+                raise OracleCompatError(
+                    "ORACLE_PACKAGE_TREE_MISMATCH",
+                    "Installed Oracle package contains a non-file entry",
+                    {"path": relative},
+                )
+            files[relative] = item_path
+            total_bytes += int(item_info.st_size)
+            if len(files) > SCOPED_ARCHIVE_MAX_FILES or total_bytes > SCOPED_ARCHIVE_MAX_BYTES:
+                raise OracleCompatError(
+                    "ORACLE_PACKAGE_TREE_MISMATCH",
+                    "Installed Oracle package exceeds safety limits",
+                )
+    return files
+
+
+def _verify_scoped_package_archive(
+    package_root: Path,
+    package_archive: Path,
+    *,
+    expected_integrity: str,
+    contracts: dict[str, dict[str, Any]],
+) -> Path:
+    archive_input = package_archive.expanduser()
+    try:
+        archive_info = os.lstat(archive_input)
+    except OSError as exc:
+        raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive must be a regular file") from exc
+    if _is_link_or_reparse(archive_info) or not stat.S_ISREG(archive_info.st_mode):
+        raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive must be a regular file")
+    if archive_info.st_size > SCOPED_ARCHIVE_MAX_BYTES:
+        raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive exceeds safety limits")
+    try:
+        archive_bytes = archive_input.read_bytes()
+    except OSError as exc:
+        raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive could not be read") from exc
+    actual_integrity = "sha512-" + base64.b64encode(hashlib.sha512(archive_bytes).digest()).decode("ascii")
+    if actual_integrity != expected_integrity:
+        raise OracleCompatError(
+            "ORACLE_PACKAGE_INTEGRITY_MISMATCH",
+            "Oracle package archive integrity does not match the scoped contract",
+            {"actual": actual_integrity, "expected": expected_integrity},
+        )
+    root_input = package_root.expanduser()
+    try:
+        root_info = os.lstat(root_input)
+    except OSError as exc:
+        raise OracleCompatError("ORACLE_PACKAGE_TREE_MISMATCH", "Installed Oracle package must be a regular directory") from exc
+    if _is_link_or_reparse(root_info) or not stat.S_ISDIR(root_info.st_mode):
+        raise OracleCompatError("ORACLE_PACKAGE_TREE_MISMATCH", "Installed Oracle package must be a regular directory")
+    root = root_input.resolve(strict=True)
+    installed_files = _scan_installed_package_tree(root)
+    file_count = 0
+    total_bytes = 0
+    seen: set[str] = set()
+    try:
+        with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as package:
+            for member in package:
+                relative = _safe_archive_relative(member.name)
+                if member.isdir():
+                    continue
+                if not member.isfile() or relative is None:
+                    raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive contains a non-file entry")
+                if relative in seen:
+                    raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive contains duplicate files")
+                seen.add(relative)
+                file_count += 1
+                total_bytes += int(member.size)
+                if file_count > SCOPED_ARCHIVE_MAX_FILES or total_bytes > SCOPED_ARCHIVE_MAX_BYTES:
+                    raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive exceeds safety limits")
+                source = package.extractfile(member)
+                if source is None:
+                    raise OracleCompatError("ORACLE_PACKAGE_ARCHIVE_INVALID", "Oracle package archive file is unreadable")
+                archive_bytes = source.read()
+                target = installed_files.get(relative)
+                if target is None:
+                    raise OracleCompatError(
+                        "ORACLE_PACKAGE_TREE_MISMATCH",
+                        "Installed Oracle package is missing a regular published file",
+                        {"path": relative},
+                    )
+                if relative in contracts:
+                    archive_hash = hashlib.sha256(archive_bytes).hexdigest()
+                    contract = contracts[relative]
+                    if archive_hash != contract["pristine"]:
+                        raise OracleCompatError(
+                            "ORACLE_PACKAGE_CONTRACT_MISMATCH",
+                            "Published Oracle archive does not match the scoped patch contract",
+                            {"path": relative, "actual": archive_hash, "expected": contract["pristine"]},
+                        )
+                    current_hash = sha256_file(target)
+                    if current_hash not in {contract["pristine"], contract["patched"]}:
+                        raise OracleCompatError(
+                            "ORACLE_PACKAGE_TREE_MISMATCH",
+                            "Installed Oracle patch target differs from the verified archive",
+                            {"path": relative, "actual": current_hash},
+                        )
+                elif target.read_bytes() != archive_bytes:
+                    raise OracleCompatError(
+                        "ORACLE_PACKAGE_TREE_MISMATCH",
+                        "Installed Oracle package differs from the verified published archive",
+                        {"path": relative},
+                    )
+        extra_files = sorted(set(installed_files) - seen)
+        if extra_files:
+            raise OracleCompatError(
+                "ORACLE_PACKAGE_TREE_MISMATCH",
+                "Installed Oracle package contains files absent from the verified archive",
+                {"path": extra_files[0], "extra_count": len(extra_files)},
+            )
+        return root
+    except (OSError, tarfile.TarError) as exc:
+        raise OracleCompatError(
+            "ORACLE_PACKAGE_ARCHIVE_INVALID",
+            "Oracle package archive could not be verified",
+        ) from exc
 
 
 def package_version(package_root: Path) -> str:
@@ -200,8 +445,8 @@ def resolve_package_roots(version: str = SUPPORTED_VERSION) -> list[Path]:
     return matching
 
 
-def patch_root() -> Path:
-    return Path(__file__).resolve().parent / "oracle-compat" / SUPPORTED_VERSION
+def patch_root(version: str = SUPPORTED_VERSION) -> Path:
+    return Path(__file__).resolve().parent / "oracle-compat" / version
 
 
 def _git_kwargs() -> dict[str, Any]:
@@ -274,29 +519,64 @@ def _migrate_known_legacy_patch(
         shutil.copy2(staged_target, target)
 
 
-def ensure_oracle_compatibility(
-    resolved_version: str,
+def _validated_patch_target(root: Path, relative: str) -> Path:
+    canonical_root = root.resolve(strict=True)
+    target = canonical_root
+    parts = Path(relative).parts
+    for index, part in enumerate(parts):
+        target = target / part
+        try:
+            info = os.lstat(target)
+            canonical_target = target.resolve(strict=True)
+        except OSError as exc:
+            raise OracleCompatError(
+                "ORACLE_PACKAGE_TREE_MISMATCH",
+                "Oracle patch target could not be inspected",
+                {"path": relative},
+            ) from exc
+        if _is_link_or_reparse(info) or not canonical_target.is_relative_to(canonical_root):
+            raise OracleCompatError(
+                "ORACLE_PACKAGE_TREE_MISMATCH",
+                "Oracle patch target crosses a link, junction, or package boundary",
+                {"path": relative},
+            )
+        expected_kind = stat.S_ISREG if index == len(parts) - 1 else stat.S_ISDIR
+        if not expected_kind(info.st_mode):
+            raise OracleCompatError(
+                "ORACLE_PACKAGE_TREE_MISMATCH",
+                "Oracle patch target has an unexpected file type",
+                {"path": relative},
+            )
+        if index == len(parts) - 1 and info.st_nlink != 1:
+            raise OracleCompatError(
+                "ORACLE_PACKAGE_TREE_MISMATCH",
+                "Oracle patch target must not be hard-linked",
+                {"path": relative},
+            )
+    return target
+
+
+def _apply_oracle_compatibility(
+    version: str,
     *,
-    package_root: Path | None = None,
-    backup_root: Path | None = None,
+    package_root: Path | None,
+    backup_root: Path | None,
+    contracts: dict[str, dict[str, Any]],
+    patches: Path,
+    package_roots: Sequence[Path] | None = None,
 ) -> dict[str, Any]:
-    version = resolved_version.strip().removeprefix("oracle ").strip()
-    if version != SUPPORTED_VERSION:
-        raise OracleCompatError(
-            "ORACLE_VERSION_UNVALIDATED",
-            "Oracle compatibility is validated only for the tested version",
-            {"resolved": resolved_version, "supported": SUPPORTED_VERSION},
-        )
-    roots = resolve_package_roots(version) if package_root is None else [package_root.expanduser().resolve(strict=True)]
-    patches = patch_root()
+    if package_roots is not None:
+        roots = [root.expanduser().resolve(strict=True) for root in package_roots]
+    else:
+        roots = resolve_package_roots(version) if package_root is None else [package_root.expanduser().resolve(strict=True)]
     backup = backup_root or (Path.home() / ".codex" / "state" / "oracle-compat-backups" / version)
     changed: list[str] = []
     already: list[str] = []
     for root in roots:
         if package_version(root) != version:
             raise OracleCompatError("ORACLE_VERSION_MISMATCH", "Oracle package version does not match the resolved CLI version")
-        for relative, contract in PATCHES.items():
-            target = root / Path(relative)
+        for relative, contract in contracts.items():
+            target = _validated_patch_target(root, relative)
             current = sha256_file(target)
             item = relative if len(roots) == 1 else f"{root}:{relative}"
             if current == contract["patched"]:
@@ -353,15 +633,125 @@ def ensure_oracle_compatibility(
     }
 
 
+def ensure_oracle_compatibility(
+    resolved_version: str,
+    *,
+    package_root: Path | None = None,
+    backup_root: Path | None = None,
+) -> dict[str, Any]:
+    """Apply only the default comprehensive-workflow Oracle contract."""
+    version = resolved_version.strip().removeprefix("oracle ").strip()
+    if version != SUPPORTED_VERSION:
+        raise OracleCompatError(
+            "ORACLE_VERSION_UNVALIDATED",
+            "Oracle compatibility is validated only for the default tested version",
+            {"resolved": resolved_version, "supported": SUPPORTED_VERSION},
+        )
+    return _apply_oracle_compatibility(
+        version,
+        package_root=package_root,
+        backup_root=backup_root,
+        contracts=PATCHES,
+        patches=patch_root(),
+    )
+
+
+def ensure_scoped_oracle_compatibility(
+    resolved_version: str,
+    *,
+    profile: str,
+    package_root: Path | None = None,
+    package_archive: Path | None = None,
+    backup_root: Path | None = None,
+) -> dict[str, Any]:
+    """Apply an explicitly named, deployment-scoped Oracle contract."""
+    normalized_profile = profile.strip()
+    profile_versions = SCOPED_PATCHES.get(normalized_profile)
+    if profile_versions is None:
+        raise OracleCompatError(
+            "ORACLE_COMPAT_PROFILE_UNVALIDATED",
+            "Oracle compatibility profile is not validated",
+            {"profile": profile, "supported_profiles": sorted(SCOPED_PATCHES)},
+        )
+    version = resolved_version.strip().removeprefix("oracle ").strip()
+    contracts = profile_versions.get(version)
+    if contracts is None:
+        raise OracleCompatError(
+            "ORACLE_VERSION_UNVALIDATED",
+            "Oracle compatibility is not validated for this scoped profile",
+            {"resolved": resolved_version, "profile": normalized_profile, "supported": sorted(profile_versions)},
+        )
+    expected_integrity = SCOPED_PACKAGE_INTEGRITIES.get(normalized_profile, {}).get(version)
+    if not expected_integrity or package_archive is None:
+        raise OracleCompatError(
+            "ORACLE_PACKAGE_ARCHIVE_REQUIRED",
+            "Scoped Oracle compatibility requires the exact published package archive",
+            {"profile": normalized_profile, "version": version},
+        )
+    if package_root is None:
+        raise OracleCompatError(
+            "ORACLE_PACKAGE_ROOT_REQUIRED",
+            "Scoped Oracle compatibility requires the exact installed package root",
+            {"profile": normalized_profile, "version": version},
+        )
+    _verify_scoped_node_runtime(normalized_profile)
+    roots = [package_root.expanduser()]
+    verified_roots: list[Path] = []
+    for root in roots:
+        verified_roots.append(
+            _verify_scoped_package_archive(
+                root,
+                package_archive,
+                expected_integrity=expected_integrity,
+                contracts=contracts,
+            )
+        )
+    result = _apply_oracle_compatibility(
+        version,
+        package_root=None,
+        backup_root=backup_root,
+        contracts=contracts,
+        patches=patch_root(version),
+        package_roots=verified_roots,
+    )
+    for root in verified_roots:
+        _verify_scoped_package_archive(
+            root,
+            package_archive,
+            expected_integrity=expected_integrity,
+            contracts=contracts,
+        )
+    return {**result, "profile": normalized_profile, "package_integrity": expected_integrity}
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     import argparse
 
-    parser = argparse.ArgumentParser(description="Apply the exact Oracle 0.17.1 ChatGPT compatibility patch.")
-    parser.add_argument("--resolved-version", default=f"oracle {SUPPORTED_VERSION}")
+    parser = argparse.ArgumentParser(description="Apply an exact, hash-gated Oracle ChatGPT compatibility patch.")
+    parser.add_argument("--resolved-version")
     parser.add_argument("--package-root", type=Path)
+    parser.add_argument("--package-archive", type=Path)
+    parser.add_argument("--profile", choices=sorted(SCOPED_PATCHES))
     args = parser.parse_args(argv)
     try:
-        result = ensure_oracle_compatibility(args.resolved_version, package_root=args.package_root)
+        if args.profile:
+            if not args.resolved_version:
+                raise OracleCompatError(
+                    "ORACLE_VERSION_REQUIRED",
+                    "Scoped Oracle compatibility requires an explicit resolved version",
+                    {"profile": args.profile},
+                )
+            result = ensure_scoped_oracle_compatibility(
+                args.resolved_version,
+                profile=args.profile,
+                package_root=args.package_root,
+                package_archive=args.package_archive,
+            )
+        else:
+            result = ensure_oracle_compatibility(
+                args.resolved_version or f"oracle {SUPPORTED_VERSION}",
+                package_root=args.package_root,
+            )
     except OracleCompatError as exc:
         result = {"ok": False, "error": {"code": exc.code, "message": str(exc), "evidence": exc.evidence}}
     print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/bin/oracle-compat/0.18.0/oracle-cli.followup-timeout.patch
+++ b/bin/oracle-compat/0.18.0/oracle-cli.followup-timeout.patch
@@ -1,0 +1,29 @@
+diff --git a/dist/bin/oracle-cli.js b/dist/bin/oracle-cli.js
+--- a/dist/bin/oracle-cli.js
++++ b/dist/bin/oracle-cli.js
+@@ -1330,10 +1330,23 @@ async function runRootCommand(options) {
+     const browserConfig = await (async () => {
+         if (sessionMode !== "browser")
+             return undefined;
++        const { buildBrowserConfig, resolveBrowserModelLabel } = await import("../src/cli/browserConfig.js");
+         if (browserFollowup) {
+-            return browserFollowup.browserConfig;
++            if (getSource("browserTimeout") !== "cli") {
++                return browserFollowup.browserConfig;
++            }
++            const cliConfig = await buildBrowserConfig({
++                ...options,
++                remoteHost: remoteHost ?? undefined,
++                model: activeModel,
++                browserRequestedModel: cliModelArg,
++                browserModelLabel: resolveBrowserModelLabel(cliModelArg, activeModel),
++            });
++            return {
++                ...browserFollowup.browserConfig,
++                timeoutMs: cliConfig.timeoutMs,
++            };
+         }
+-        const { buildBrowserConfig, resolveBrowserModelLabel } = await import("../src/cli/browserConfig.js");
+         const config = await buildBrowserConfig({
+             ...options,
+             remoteHost: remoteHost ?? undefined,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # 기술 변경 기록
 
+## 1.17.1 - WebJjonku Oracle 0.18 후속 실행 timeout 호환성
+
+- 일반 comprehensive 자동화는 계속 검증된 Oracle 0.17.1만 허용하고,
+  WebJjonku Linux 배포가 명시적으로 `webjjonku-linux` profile을 선택한 경우에만
+  Oracle 0.18.0의 후속 실행 timeout 전달 패치를 적용합니다.
+- 0.18.0 패치는 pristine·patched SHA-256과 npm integrity를 모두 확인하고,
+  명시한 `--browser-timeout`만 child follow-up에 전달합니다. profile 누락,
+  알 수 없는 버전, 해시 불일치는 브라우저 실행 전에 실패 폐쇄됩니다.
+- 범위 제한 프로필은 버전·설치 루트·archive를 모두 명시해야 하며,
+  Windows junction/reparse point와 archive 경로 탈출을 거부합니다. 공개
+  portability CI는 Windows·macOS·Ubuntu에서 실제 0.18.0 archive를 검증합니다.
+
 ## 1.17.0 - 재개 가능한 최초 설치 마법사와 커넥터 신원 가드
 
 - `onboard.py`에 `start`, `next`, `resume`, `confirm`, `record-final-gate`를

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",
@@ -39,6 +39,7 @@
     "bin/oracle-compat/0.17.1/thinkingTime.strict.pre-advanced-view-sibling.patch",
     "bin/oracle-compat/0.17.1/thinkingTime.strict.pre-stable-pro-proof.patch",
     "bin/oracle-compat/0.17.1/thinkingTime.strict.pre-menu-scoped-proof.patch",
+    "bin/oracle-compat/0.18.0/oracle-cli.followup-timeout.patch",
     "bin/chatgpt_oracle_state.py",
     "bin/chatgpt_oracle_profiles.py",
     "bin/chatgpt_oracle_dispatch.py",
@@ -171,7 +172,14 @@
       "tested_version": "0.17.1",
       "license": "MIT",
       "integrity": "sha512-bq4SqMvRtT5Im+R57UPSXTV5p/BFTU24OXgGXqx2ckABWFX9uLDuKeJLoOdfBm7RzllrzjrlSSGgiMsrrvh+9Q==",
-      "installation": "resolved by the invoking agent through explicit npx @steipete/oracle@0.17.1; unknown versions and hash mismatches fail closed"
+      "scoped_tested_versions": {
+        "webjjonku-linux": {
+          "version": "0.18.0",
+          "integrity": "sha512-o8KFd66zNt36jw5zdtQAV74bgrOlJibbyvnLsVikIWDamesYtez/dIUhQ4zqtD9jkx+7A6vcP9+JgcJt0H5pOw==",
+          "node": ">=24 <27"
+        }
+      },
+      "installation": "default comprehensive runs resolve explicit npx @steipete/oracle@0.17.1; Oracle 0.18.0 requires its exact npm archive plus the explicit webjjonku-linux compatibility profile, which verifies archive integrity and the complete published package payload before patching, while the invoking runtime lock owns the separately installed dependency tree; unknown versions, profiles, and hash mismatches fail closed"
     },
     "devspace": {
       "package": "@waishnav/devspace",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.19 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/scripts/prepare_oracle_018_ci.py
+++ b/scripts/prepare_oracle_018_ci.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Prepare the exact published Oracle 0.18.0 package for CI compatibility tests."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+
+ORACLE_VERSION = "0.18.0"
+ORACLE_INTEGRITY = "sha512-o8KFd66zNt36jw5zdtQAV74bgrOlJibbyvnLsVikIWDamesYtez/dIUhQ4zqtD9jkx+7A6vcP9+JgcJt0H5pOw=="
+MAX_FILES = 10_000
+MAX_BYTES = 100 * 1024 * 1024
+WINDOWS_RESERVED_NAMES = {"CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))}
+
+
+def integrity(path: Path) -> str:
+    digest = hashlib.sha512()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha512-" + base64.b64encode(digest.digest()).decode("ascii")
+
+
+def safe_member_parts(name: str) -> tuple[str, ...]:
+    if not name or "\\" in name or "\x00" in name or any(ord(character) < 32 for character in name):
+        raise RuntimeError("Oracle archive contains an unsafe path")
+    raw_parts = name.split("/")
+    if any(part in {"", ".", ".."} for part in raw_parts):
+        raise RuntimeError("Oracle archive contains an unsafe path")
+    path = PurePosixPath(name)
+    if path.is_absolute() or len(path.parts) < 2 or path.parts[0] != "package":
+        raise RuntimeError("Oracle archive contains an unsafe path")
+    for part in path.parts[1:]:
+        if ":" in part or part.endswith((" ", ".")):
+            raise RuntimeError("Oracle archive contains an unsafe path")
+        device_name = part.rstrip(" .").split(".", 1)[0].upper()
+        if device_name in WINDOWS_RESERVED_NAMES:
+            raise RuntimeError("Oracle archive contains an unsafe path")
+    return tuple(path.parts)
+
+
+def extract_verified(archive_bytes: bytes, destination: Path) -> Path:
+    count = 0
+    total = 0
+    destination.mkdir(parents=True, exist_ok=False)
+    destination = destination.resolve(strict=True)
+    seen: set[str] = set()
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as package:
+        for member in package:
+            parts = safe_member_parts(member.name)
+            collision_key = PurePosixPath(*parts).as_posix().casefold()
+            if collision_key in seen:
+                raise RuntimeError("Oracle archive contains duplicate or case-colliding entries")
+            seen.add(collision_key)
+            target = destination.joinpath(*parts)
+            canonical_target = target.resolve(strict=False)
+            if not canonical_target.is_relative_to(destination):
+                raise RuntimeError("Oracle archive path escapes the extraction directory")
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile() or len(parts) < 2:
+                raise RuntimeError("Oracle archive contains a non-file entry")
+            count += 1
+            total += int(member.size)
+            if count > MAX_FILES or total > MAX_BYTES:
+                raise RuntimeError("Oracle archive exceeds CI extraction limits")
+            source = package.extractfile(member)
+            if source is None:
+                raise RuntimeError("Oracle archive file is unreadable")
+            content = source.read()
+            if len(content) != member.size:
+                raise RuntimeError("Oracle archive file size is inconsistent")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("xb") as output:
+                output.write(content)
+            target.chmod(member.mode & 0o777)
+    package_root = destination / "package"
+    metadata = json.loads((package_root / "package.json").read_text(encoding="utf-8"))
+    if metadata.get("version") != ORACLE_VERSION:
+        raise RuntimeError("Oracle archive version does not match the CI contract")
+    return package_root
+
+
+def main() -> int:
+    npm = shutil.which("npm") or shutil.which("npm.cmd")
+    if not npm:
+        raise RuntimeError("npm is required to prepare the Oracle CI package")
+    runner_temp = Path(os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()).resolve()
+    stage = Path(tempfile.mkdtemp(prefix="oracle-018-ci-", dir=runner_temp))
+    packed = subprocess.run(
+        [npm, "pack", "--silent", "--pack-destination", str(stage), f"@steipete/oracle@{ORACLE_VERSION}"],
+        cwd=stage,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if packed.returncode != 0:
+        raise RuntimeError(f"npm pack failed: {packed.stderr.strip()[-1000:]}")
+    names = [line.strip() for line in packed.stdout.splitlines() if line.strip()]
+    if len(names) != 1 or Path(names[0]).name != names[0]:
+        raise RuntimeError("npm pack returned an unexpected archive name")
+    archive = stage / names[0]
+    if not archive.is_file() or archive.is_symlink() or archive.stat().st_size > MAX_BYTES:
+        raise RuntimeError("Oracle npm archive is not a bounded regular file")
+    archive_bytes = archive.read_bytes()
+    actual_integrity = "sha512-" + base64.b64encode(hashlib.sha512(archive_bytes).digest()).decode("ascii")
+    if actual_integrity != ORACLE_INTEGRITY:
+        raise RuntimeError("Oracle npm archive integrity does not match the CI contract")
+    package_root = extract_verified(archive_bytes, stage / "extracted")
+    github_env_value = os.environ.get("GITHUB_ENV", "")
+    if not github_env_value:
+        raise RuntimeError("GITHUB_ENV is required; this helper is CI-only")
+    github_env = Path(github_env_value)
+    for value in (package_root, archive):
+        if "\n" in str(value) or "\r" in str(value):
+            raise RuntimeError("CI package path contains a newline")
+    with github_env.open("a", encoding="utf-8", newline="\n") as output:
+        output.write(f"ORACLE_018_PACKAGE_ROOT={package_root}\n")
+        output.write(f"ORACLE_018_PACKAGE_ARCHIVE={archive}\n")
+    print(f"Prepared hash-verified Oracle {ORACLE_VERSION} for CI tests.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chatgpt_oracle_compat.py
+++ b/tests/test_chatgpt_oracle_compat.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import importlib.util
+import io
 import json
+import os
 import shutil
 import subprocess
 import sys
+import tarfile
 from pathlib import Path
 
 import pytest
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "bin" / "chatgpt_oracle_compat.py"
+CI_PREP_PATH = Path(__file__).resolve().parents[1] / "scripts" / "prepare_oracle_018_ci.py"
 
 
 def load_compat():
@@ -24,8 +29,31 @@ def load_compat():
     return module
 
 
+def load_ci_prepare():
+    name = "prepare_oracle_018_ci_test"
+    spec = importlib.util.spec_from_file_location(name, CI_PREP_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def digest(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
+
+
+def make_package_archive(path: Path, files: dict[str, bytes]) -> tuple[Path, str]:
+    archive = path / "oracle.tgz"
+    with tarfile.open(archive, mode="w:gz") as package:
+        for relative, content in sorted(files.items()):
+            member = tarfile.TarInfo(f"package/{relative}")
+            member.size = len(content)
+            member.mode = 0o644
+            member.mtime = 0
+            package.addfile(member, io.BytesIO(content))
+    integrity = "sha512-" + base64.b64encode(hashlib.sha512(archive.read_bytes()).digest()).decode("ascii")
+    return archive, integrity
 
 
 def test_exact_version_patch_is_hash_gated_idempotent_and_backed_up(tmp_path: Path) -> None:
@@ -100,6 +128,10 @@ def test_unknown_oracle_version_or_file_hash_fails_closed(tmp_path: Path) -> Non
     with pytest.raises(compat.OracleCompatError) as version:
         compat.ensure_oracle_compatibility("oracle 0.17.0", package_root=tmp_path)
     assert version.value.code == "ORACLE_VERSION_UNVALIDATED"
+    with pytest.raises(compat.OracleCompatError) as scoped_version_without_profile:
+        compat.ensure_oracle_compatibility("oracle 0.18.0", package_root=tmp_path)
+    assert scoped_version_without_profile.value.code == "ORACLE_VERSION_UNVALIDATED"
+    assert scoped_version_without_profile.value.evidence["supported"] == compat.SUPPORTED_VERSION
 
     package = tmp_path / "package"
     package.mkdir()
@@ -109,6 +141,192 @@ def test_unknown_oracle_version_or_file_hash_fails_closed(tmp_path: Path) -> Non
     with pytest.raises(compat.OracleCompatError) as mismatch:
         compat.ensure_oracle_compatibility("oracle 0.17.1", package_root=package)
     assert mismatch.value.code == "ORACLE_FILE_HASH_MISMATCH"
+
+
+def test_scoped_oracle_version_requires_its_profile_and_uses_its_own_contract(tmp_path: Path) -> None:
+    compat = load_compat()
+    package = tmp_path / "package"
+    package.mkdir()
+    package_json = json.dumps({"version": "0.18.0"}).encode("utf-8")
+    (package / "package.json").write_bytes(package_json)
+    target = package / "sample.txt"
+    target.write_bytes(b"before\n")
+    other = package / "other.js"
+    other.write_bytes(b"export const trusted = true;\n")
+    dependency = package / "node_modules" / "dependency" / "index.js"
+    dependency.parent.mkdir(parents=True)
+    dependency.write_bytes(b"export const externalDependency = true;\n")
+    patches = tmp_path / "patches"
+    patches.mkdir()
+    (patches / "sample.patch").write_text(
+        "diff --git a/sample.txt b/sample.txt\n--- a/sample.txt\n+++ b/sample.txt\n@@ -1 +1 @@\n-before\n+after\n",
+        encoding="utf-8",
+    )
+    compat.SCOPED_PATCHES = {
+        "webjjonku-linux": {
+            "0.18.0": {
+                "sample.txt": {
+                    "patch": "sample.patch",
+                    "pristine": digest(b"before\n"),
+                    "patched": digest(b"after\n"),
+                }
+            }
+        }
+    }
+    archive, integrity = make_package_archive(tmp_path, {
+        "package.json": package_json,
+        "sample.txt": b"before\n",
+        "other.js": b"export const trusted = true;\n",
+    })
+    compat.SCOPED_PACKAGE_INTEGRITIES = {"webjjonku-linux": {"0.18.0": integrity}}
+    compat.patch_root = lambda version=compat.SUPPORTED_VERSION: patches
+
+    with pytest.raises(compat.OracleCompatError) as default_path:
+        compat.ensure_oracle_compatibility("oracle 0.18.0", package_root=package)
+    assert default_path.value.code == "ORACLE_VERSION_UNVALIDATED"
+
+    with pytest.raises(compat.OracleCompatError) as unknown_profile:
+        compat.ensure_scoped_oracle_compatibility(
+            "oracle 0.18.0",
+            profile="other-linux",
+            package_root=package,
+            package_archive=archive,
+        )
+    assert unknown_profile.value.code == "ORACLE_COMPAT_PROFILE_UNVALIDATED"
+
+    with pytest.raises(compat.OracleCompatError) as missing_root:
+        compat.ensure_scoped_oracle_compatibility(
+            "oracle 0.18.0",
+            profile="webjjonku-linux",
+            package_archive=archive,
+        )
+    assert missing_root.value.code == "ORACLE_PACKAGE_ROOT_REQUIRED"
+
+    result = compat.ensure_scoped_oracle_compatibility(
+        "oracle 0.18.0",
+        profile="webjjonku-linux",
+        package_root=package,
+        package_archive=archive,
+        backup_root=tmp_path / "backup",
+    )
+
+    assert result["version"] == "0.18.0"
+    assert result["profile"] == "webjjonku-linux"
+    assert result["changed"] == ["sample.txt"]
+    assert result["package_integrity"] == integrity
+    assert target.read_bytes() == b"after\n"
+    assert dependency.is_file()
+    other.write_bytes(b"export const trusted = false;\n")
+    with pytest.raises(compat.OracleCompatError) as tree_mismatch:
+        compat.ensure_scoped_oracle_compatibility(
+            "oracle 0.18.0",
+            profile="webjjonku-linux",
+            package_root=package,
+            package_archive=archive,
+            backup_root=tmp_path / "backup",
+        )
+    assert tree_mismatch.value.code == "ORACLE_PACKAGE_TREE_MISMATCH"
+    other.write_bytes(b"export const trusted = true;\n")
+    (package / "injected.js").write_bytes(b"export const injected = true;\n")
+    with pytest.raises(compat.OracleCompatError) as extra_file:
+        compat.ensure_scoped_oracle_compatibility(
+            "oracle 0.18.0",
+            profile="webjjonku-linux",
+            package_root=package,
+            package_archive=archive,
+            backup_root=tmp_path / "backup",
+        )
+    assert extra_file.value.code == "ORACLE_PACKAGE_TREE_MISMATCH"
+    assert extra_file.value.evidence["path"] == "injected.js"
+
+
+def test_scoped_package_tree_rejects_directory_links_and_junctions(tmp_path: Path) -> None:
+    compat = load_compat()
+    package = tmp_path / "package"
+    package.mkdir()
+    external = tmp_path / "external"
+    external.mkdir()
+    link = package / "dist"
+    if os.name == "nt":
+        created = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(external)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert created.returncode == 0, created.stderr
+    else:
+        link.symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(compat.OracleCompatError) as unsafe_tree:
+        compat._scan_installed_package_tree(package.resolve(strict=True))
+    assert unsafe_tree.value.code == "ORACLE_PACKAGE_TREE_MISMATCH"
+    assert unsafe_tree.value.evidence["path"] == "dist"
+
+
+def test_ci_extractor_rejects_windows_escape_and_reserved_paths_before_writing(tmp_path: Path) -> None:
+    prepare = load_ci_prepare()
+    for index, unsafe_name in enumerate((r"package/a\..\..\..\escaped.txt", "package/CON.txt")):
+        stream = io.BytesIO()
+        with tarfile.open(fileobj=stream, mode="w:gz") as package:
+            content = b"unsafe\n"
+            member = tarfile.TarInfo(unsafe_name)
+            member.size = len(content)
+            package.addfile(member, io.BytesIO(content))
+        destination = tmp_path / f"extract-{index}"
+        with pytest.raises(RuntimeError, match="unsafe path"):
+            prepare.extract_verified(stream.getvalue(), destination)
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_scoped_cli_requires_explicit_version(capsys: pytest.CaptureFixture[str]) -> None:
+    compat = load_compat()
+    assert compat.main(["--profile", "webjjonku-linux"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "ORACLE_VERSION_REQUIRED"
+
+
+def test_scoped_profile_rejects_missing_node_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    compat = load_compat()
+    monkeypatch.setattr(compat.shutil, "which", lambda _name: None)
+    with pytest.raises(compat.OracleCompatError) as unsupported:
+        compat._verify_scoped_node_runtime("webjjonku-linux")
+    assert unsupported.value.code == "ORACLE_NODE_VERSION_UNSUPPORTED"
+    assert unsupported.value.evidence["required"] == ">=24 <27"
+
+
+def test_published_0180_followup_timeout_patch_preserves_parent_unless_cli_overrides(tmp_path: Path) -> None:
+    compat = load_compat()
+    configured = os.environ.get("ORACLE_018_PACKAGE_ROOT", "").strip()
+    configured_archive = os.environ.get("ORACLE_018_PACKAGE_ARCHIVE", "").strip()
+    source = Path(configured) if configured else Path("__oracle_018_cache_unset__")
+    archive = Path(configured_archive) if configured_archive else Path("__oracle_018_archive_unset__")
+    if not source.is_dir() or not archive.is_file():
+        pytest.skip("published Oracle 0.18.0 package root and archive are unavailable")
+    package = tmp_path / "oracle"
+    shutil.copytree(source, package)
+
+    result = compat.ensure_scoped_oracle_compatibility(
+        "oracle 0.18.0",
+        profile="webjjonku-linux",
+        package_root=package,
+        package_archive=archive,
+        backup_root=tmp_path / "backup",
+    )
+
+    relative = "dist/bin/oracle-cli.js"
+    assert relative in set(result["changed"]) | set(result["already_patched"])
+    target = package / relative
+    source_text = target.read_text(encoding="utf-8")
+    assert 'getSource("browserTimeout") !== "cli"' in source_text
+    assert "...browserFollowup.browserConfig" in source_text
+    assert "timeoutMs: cliConfig.timeoutMs" in source_text
+    assert compat.sha256_file(target) == compat.SCOPED_PATCHES["webjjonku-linux"]["0.18.0"][relative]["patched"]
+    node = shutil.which("node")
+    assert node is not None
+    syntax = subprocess.run([node, "--check", str(target)], capture_output=True, text=True, check=False)
+    assert syntax.returncode == 0, syntax.stderr
 
 
 def test_published_0171_patch_requires_extra_high_and_pro_selection_proof(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds an explicit webjjonku-linux Oracle 0.18.0 profile while keeping the default comprehensive path pinned to 0.17.1. The profile verifies the official npm archive and published payload, rejects links, junctions and unsafe archive paths, requires Node 24 and explicit version/root/archive inputs, and patches only follow-up timeout inheritance. Portability CI now exercises the official package on Windows, macOS, and Ubuntu. Local validation: 10 focused tests, fast gate, docs contract, portability, and golden-path smoke passed.