### PR TITLE
Handle direct DevSpace model-option pre-submit failures

### DIFF
--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -201,6 +201,10 @@ ORACLE_MODEL_SWITCHER_PRE_SUBMIT_RE = re.compile(
     r".*?No cookies were applied;",
     re.IGNORECASE | re.DOTALL,
 )
+ORACLE_MODEL_OPTION_MISSING_PRE_SUBMIT_RE = re.compile(
+    r'^Unable to find model option matching "(?P<desired>[^"\r\n]{1,160})" '
+    r'in the model switcher\. Available: (?P<available>[^\r\n]{1,1000})\.$'
+)
 ORACLE_THINKING_TIME_PRE_SUBMIT_RE = re.compile(
     r"Thinking time: (?:selection unverified \(requested |unknown outcome selecting )"
     r"(?P<requested>[^);]+)\)?; refusing to submit without confirmed (?P<required>[^.]+)\.",
@@ -3339,15 +3343,61 @@ def _direct_devspace_no_submission_evidence(
         f"ERROR: {ORACLE_PROMPT_NOT_OBSERVED_MARKER}",
         f"User error (browser-automation): {ORACLE_PROMPT_NOT_OBSERVED_MARKER}",
     }
+    prompt_marker_valid = (
+        bool(marker_lines)
+        and marker_lines.issubset(allowed_marker_lines)
+        and stdout_text.count(ORACLE_PROMPT_NOT_OBSERVED_MARKER) == len(marker_lines)
+    )
+    lines = stdout_text.splitlines()
+    model_option_error = ""
+    model_option_match: re.Match[str] | None = None
+    if len(lines) >= 2 and lines[-1].startswith("User error (browser-automation): "):
+        model_option_error = lines[-1].removeprefix("User error (browser-automation): ")
+        if lines[-2] == f"ERROR: {model_option_error}":
+            model_option_match = ORACLE_MODEL_OPTION_MISSING_PRE_SUBMIT_RE.fullmatch(
+                model_option_error
+            )
+    model_option_valid = model_option_match is not None
     if (
         not locator
-        or not marker_lines
-        or not marker_lines.issubset(allowed_marker_lines)
-        or stdout_text.count(ORACLE_PROMPT_NOT_OBSERVED_MARKER) != len(marker_lines)
+        or prompt_marker_valid == model_option_valid
         or f"Session: {locator}" not in stdout_text
         or CHATGPT_CONVERSATION_URL_RE.search(stdout_text)
     ):
         return None
+    desired_model = ""
+    if model_option_match is not None:
+        desired_model = model_option_match.group("desired")
+        expected_head = [
+            f"Session: {locator}",
+            "Mode: browser foreground",
+            "Models: 1",
+            "Detach: no",
+            f"Reattach: oracle session {locator}",
+        ]
+        expected_guidance = [
+            "This run can take up to an hour (usually ~10 minutes).",
+            "[browser] Browser control: launch Chrome in hidden-window mode; may focus/control the browser UI.",
+            "[browser] Browser guidance: On macOS, Oracle launches Chrome off-screen while keeping the page rendered.",
+            "[browser] Browser guidance: For the calmest shared-desktop flow, prefer --browser-attach-running or --remote-chrome.",
+        ]
+        if (
+            len(lines) != 13
+            or re.fullmatch(r".{1,4} oracle 0\.17\.1 .{2,120}", lines[0]) is None
+            or lines[1:6] != expected_head
+            or re.fullmatch(
+                rf"Launching browser mode \(target={re.escape(desired_model)}; "
+                rf"requested={re.escape(str(profile['model']))}\) with ~[1-9][0-9]* tokens\.",
+                lines[6],
+            )
+            is None
+            or lines[7:11] != expected_guidance
+            or lines[-2:] != [
+                f"ERROR: {model_option_error}",
+                f"User error (browser-automation): {model_option_error}",
+            ]
+        ):
+            return None
     mission = state.get("mission") if isinstance(state.get("mission"), dict) else {}
     source_path = Path(str(mission.get("path") or ""))
     transport_path = Path(str(mission.get("transport_path") or ""))
@@ -3406,6 +3456,85 @@ def _direct_devspace_no_submission_evidence(
         "stdout_sha256": hashlib.sha256(recovery_stdout).hexdigest(),
         "stderr_sha256": hashlib.sha256(recovery_stderr).hexdigest(),
     }]
+    selector_meta_evidence: dict[str, Any] = {}
+    if model_option_match is not None:
+        session_root = Path(
+            os.environ.get("ORACLE_SESSION_ROOT") or (Path.home() / ".oracle" / "sessions")
+        ).resolve()
+        meta_path = session_root / locator / "meta.json"
+        if meta_path.is_symlink():
+            return None
+        try:
+            meta_bytes = meta_path.read_bytes()
+            meta_text = meta_bytes.decode("utf-8", errors="strict")
+            meta = json.loads(meta_text)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        browser = meta.get("browser") if isinstance(meta.get("browser"), dict) else {}
+        config = browser.get("config") if isinstance(browser.get("config"), dict) else {}
+        runtime = browser.get("runtime") if isinstance(browser.get("runtime"), dict) else {}
+        error = meta.get("error") if isinstance(meta.get("error"), dict) else {}
+        details = error.get("details") if isinstance(error.get("details"), dict) else {}
+        details_runtime = details.get("runtime") if isinstance(details.get("runtime"), dict) else {}
+        options = meta.get("options") if isinstance(meta.get("options"), dict) else {}
+        option_browser = (
+            options.get("browserConfig")
+            if isinstance(options.get("browserConfig"), dict)
+            else {}
+        )
+        try:
+            copy_profile = Path(str(profile.get("copy_profile") or "")).resolve()
+            config_profile = Path(str(config.get("copyProfileSource") or "")).resolve()
+            option_profile = Path(str(option_browser.get("copyProfileSource") or "")).resolve()
+            meta_cwd = Path(str(meta.get("cwd") or "")).resolve()
+            meta_output = Path(str(options.get("writeOutputPath") or "")).resolve()
+        except OSError:
+            return None
+        model_id = str(profile.get("model") or "")
+        if (
+            not str(profile.get("copy_profile") or "").strip()
+            or not copy_profile.is_absolute()
+            or meta.get("id") != locator
+            or meta.get("status") != "error"
+            or meta.get("model") != model_id
+            or meta.get("mode") != "browser"
+            or not str(meta.get("completedAt") or "").strip()
+            or meta_cwd != project_root
+            or meta_output != output.resolve()
+            or config_profile != copy_profile
+            or option_profile != copy_profile
+            or config.get("desiredModel") != desired_model
+            or option_browser.get("desiredModel") != desired_model
+            or config.get("modelStrategy") != profile.get("model_strategy")
+            or option_browser.get("modelStrategy") != profile.get("model_strategy")
+            or config.get("thinkingTime") != profile.get("thinking_time")
+            or option_browser.get("thinkingTime") != profile.get("thinking_time")
+            or config.get("researchMode") != profile.get("research")
+            or option_browser.get("researchMode") != profile.get("research")
+            or options.get("model") != model_id
+            or options.get("models") != [model_id]
+            or options.get("effectiveModelId") != model_id
+            or options.get("slug") != locator
+            or options.get("mode") != "browser"
+            or runtime.get("promptSubmitted") is not False
+            or runtime.get("tabUrl") != "https://chatgpt.com/"
+            or details_runtime.get("promptSubmitted") not in {None, False}
+            or error.get("category") != "browser-automation"
+            or error.get("message") != model_option_error
+            or details.get("stage") != "execute-browser"
+            or str(meta.get("errorMessage") or "") != model_option_error
+            or CHATGPT_CONVERSATION_URL_RE.search(meta_text)
+        ):
+            return None
+        selector_meta_evidence = {
+            "pre_submit_marker": "oracle-model-option-missing/v1",
+            "desired_model": desired_model,
+            "oracle_meta_path": str(meta_path),
+            "oracle_meta_sha256": hashlib.sha256(meta_bytes).hexdigest(),
+            "oracle_meta_stage": "execute-browser",
+            "prompt_submitted": False,
+            "tab_url": "https://chatgpt.com/",
+        }
     evidence = {
         "settlement_eligibility": "oracle-direct-devspace/v1",
         "project_root": str(project_root),
@@ -3424,6 +3553,7 @@ def _direct_devspace_no_submission_evidence(
         "recovery_evidence": recovery_records,
         "output_absent": True,
         "conversation_url_absent": True,
+        **selector_meta_evidence,
         "_source_mission_path": str(source_path),
         "_transport_mission_path": str(transport_path),
     }
@@ -3603,6 +3733,11 @@ def proven_user_confirmed_no_submission(state_path: Path) -> dict[str, Any] | No
             "source_mission_sha256", "transport_mission_path", "transport_mission_sha256",
             "oracle_version",
         )
+        if current.get("pre_submit_marker") == "oracle-model-option-missing/v1":
+            required += (
+                "pre_submit_marker", "desired_model", "oracle_meta_path",
+                "oracle_meta_sha256", "oracle_meta_stage", "prompt_submitted", "tab_url",
+            )
     elif current.get("settlement_eligibility") in {
         "oracle-followup-pre-submit-ui/v1",
         "oracle-followup-pre-submit-ui/v2",
@@ -3749,8 +3884,10 @@ def settle_user_confirmed_no_submission(
             )
             if evidence.get("settlement_eligibility") == "oracle-pre-submit-host/v1"
             else "user-confirmed-no-submission-after-model-selector-failure"
-            if evidence.get("pre_submit_marker")
-            == "oracle-model-selector-button-missing/v1"
+            if evidence.get("pre_submit_marker") in {
+                "oracle-model-selector-button-missing/v1",
+                "oracle-model-option-missing/v1",
+            }
             else "user-confirmed-no-submission-after-prompt-timeout"
         ),
         "user_confirmed_no_submission": {

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -630,6 +630,112 @@ def model_selector_button_pre_submit_popen(
     return popen
 
 
+def model_option_missing_pre_submit_popen(
+    session_root: Path,
+    *,
+    variation: str | None = None,
+):
+    def popen(command, **kwargs):
+        slug = command[command.index("--slug") + 1]
+        output_path = Path(command[command.index("--write-output") + 1]).resolve()
+        expected_profile = (Path.home() / ".oracle" / "browser-profile").resolve()
+        model_id = "gpt-5.5-instant"
+        desired_model = "GPT-5.5 Instant"
+        error_message = (
+            'Unable to find model option matching "GPT-5.5 Instant" in the model switcher. '
+            "Available: Advanced, ModelGPT-5.6 Sol, EffortPro."
+        )
+        emitted_error = (
+            'Unable to find model option matching "GPT-5.6 Sol" in the model switcher. '
+            "Available: Advanced, ModelGPT-5.6 Sol, EffortPro."
+            if variation == "different-error"
+            else error_message
+        )
+        lines = [
+            "? oracle 0.17.1 deterministic fixture",
+            f"Session: {slug}",
+            "Mode: browser foreground",
+            "Models: 1",
+            "Detach: no",
+            f"Reattach: oracle session {slug}",
+            f"Launching browser mode (target={desired_model}; requested={model_id}) with ~246 tokens.",
+            "This run can take up to an hour (usually ~10 minutes).",
+            "[browser] Browser control: launch Chrome in hidden-window mode; may focus/control the browser UI.",
+            "[browser] Browser guidance: On macOS, Oracle launches Chrome off-screen while keeping the page rendered.",
+            "[browser] Browser guidance: For the calmest shared-desktop flow, prefer --browser-attach-running or --remote-chrome.",
+            f"ERROR: {emitted_error}",
+            f"User error (browser-automation): {emitted_error}",
+        ]
+        kwargs["stdout"].write(("\n".join(lines) + "\n").encode("utf-8"))
+        kwargs["stdout"].flush()
+        tab_url = (
+            "https://chatgpt.com/c/existing-conversation"
+            if variation == "conversation-url"
+            else "https://chatgpt.com/"
+        )
+        prompt_submitted = variation == "prompt-submitted"
+        meta_model = "gpt-5.6" if variation == "model-mismatch" else model_id
+        meta = {
+            "id": slug,
+            "createdAt": "2026-08-24T02:33:07.000Z",
+            "startedAt": "2026-08-24T02:33:08.000Z",
+            "completedAt": "2026-08-24T02:34:16.027Z",
+            "status": "error",
+            "model": meta_model,
+            "cwd": str(Path(kwargs["cwd"]).resolve()),
+            "mode": "browser",
+            "browser": {
+                "config": {
+                    "copyProfileSource": str(expected_profile),
+                    "desiredModel": desired_model,
+                    "modelStrategy": "select",
+                    "thinkingTime": "light",
+                    "researchMode": "off",
+                },
+                "runtime": {
+                    "chromePid": 16424,
+                    "chromePort": 9222,
+                    "chromeHost": "127.0.0.1",
+                    "tabUrl": tab_url,
+                    "promptSubmitted": prompt_submitted,
+                    "controllerPid": 27784,
+                },
+            },
+            "options": {
+                "model": model_id,
+                "models": [model_id],
+                "effectiveModelId": model_id,
+                "slug": slug,
+                "mode": "browser",
+                "writeOutputPath": str(output_path),
+                "browserConfig": {
+                    "copyProfileSource": str(expected_profile),
+                    "desiredModel": desired_model,
+                    "modelStrategy": "select",
+                    "thinkingTime": "light",
+                    "researchMode": "off",
+                },
+            },
+            "errorMessage": error_message,
+            "error": {
+                "category": "browser-automation",
+                "message": error_message,
+                "details": {
+                    "stage": "different-stage" if variation == "different-stage" else "execute-browser",
+                },
+            },
+        }
+        if variation != "missing-meta":
+            meta_path = session_root / slug / "meta.json"
+            meta_path.parent.mkdir(parents=True, exist_ok=True)
+            meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        if variation == "output-present":
+            output_path.write_text("contradictory output", encoding="utf-8")
+        return Process(1, [])
+
+    return popen
+
+
 def isolated_default_oracle_profile(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3335,6 +3441,129 @@ def test_user_confirmation_cannot_replace_missing_recovery_evidence(tmp_path: Pa
             reason="user said no submission",
         )
     assert exc.value.code == "NO_SUBMISSION_EVIDENCE_INCOMPLETE"
+
+
+def test_direct_devspace_model_option_missing_is_hash_bound_before_user_settlement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    isolated_default_oracle_profile(tmp_path, monkeypatch)
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    failed = execute_run(
+        runner,
+        manifest(
+            tmp_path,
+            model="gpt-5.5-instant",
+            model_strategy="select",
+            thinking_time="light",
+            research="off",
+        ),
+        run_factory=version_0171_runner,
+        popen_factory=model_option_missing_pre_submit_popen(session_root),
+    )
+    run_dir = Path(failed["run_dir"])
+    state_path = run_dir / "state.json"
+    slug = runner.STATE.load_state(state_path)["oracle"]["slug"]
+    (run_dir / "recovery-harvest-stdout.log").write_text(
+        f'No live ChatGPT tab matched session "{slug}". Attempting recovery.\n',
+        encoding="utf-8",
+    )
+    (run_dir / "recovery-harvest-stderr.log").write_text(
+        "Cannot recover conversation: session metadata has no recoverable ChatGPT conversation URL.\n",
+        encoding="utf-8",
+    )
+
+    settled = runner.settle_user_confirmed_no_submission(
+        run_dir,
+        confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
+        reason="user confirmed the unsupported model test never submitted a prompt",
+    )
+    proof = runner.STATE.proven_user_confirmed_no_submission(state_path)
+    receipt = json.loads(
+        (run_dir / "user-confirmed-no-submission.json").read_text(encoding="utf-8")
+    )
+
+    assert settled["ok"] is True
+    assert settled["safe_for_fresh_run"] is True
+    assert settled["result"]["session_authority"] == "pre_submit"
+    assert settled["result"]["task_outcome_reason"] == (
+        "user-confirmed-no-submission-after-model-selector-failure"
+    )
+    assert proof is not None
+    assert proof["pre_submit_marker"] == "oracle-model-option-missing/v1"
+    assert proof["desired_model"] == "GPT-5.5 Instant"
+    assert proof["prompt_submitted"] is False
+    assert proof["tab_url"] == "https://chatgpt.com/"
+    assert receipt["oracle_meta_sha256"] == hashlib.sha256(
+        (session_root / slug / "meta.json").read_bytes()
+    ).hexdigest()
+
+    meta_path = session_root / slug / "meta.json"
+    tampered = json.loads(meta_path.read_text(encoding="utf-8"))
+    tampered["browser"]["runtime"]["promptSubmitted"] = True
+    meta_path.write_text(json.dumps(tampered), encoding="utf-8")
+    assert runner.STATE.proven_user_confirmed_no_submission(state_path) is None
+
+
+@pytest.mark.parametrize(
+    "variation",
+    (
+        "prompt-submitted",
+        "conversation-url",
+        "different-stage",
+        "different-error",
+        "model-mismatch",
+        "output-present",
+        "missing-meta",
+    ),
+)
+def test_direct_devspace_model_option_missing_keeps_lock_on_incomplete_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    variation: str,
+) -> None:
+    runner = load_runner()
+    isolated_default_oracle_profile(tmp_path, monkeypatch)
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    failed = execute_run(
+        runner,
+        manifest(
+            tmp_path,
+            model="gpt-5.5-instant",
+            model_strategy="select",
+            thinking_time="light",
+            research="off",
+        ),
+        run_factory=version_0171_runner,
+        popen_factory=model_option_missing_pre_submit_popen(
+            session_root,
+            variation=variation,
+        ),
+    )
+    run_dir = Path(failed["run_dir"])
+    state_path = run_dir / "state.json"
+    slug = runner.STATE.load_state(state_path)["oracle"]["slug"]
+    (run_dir / "recovery-harvest-stdout.log").write_text(
+        f'No live ChatGPT tab matched session "{slug}". Attempting recovery.\n',
+        encoding="utf-8",
+    )
+    (run_dir / "recovery-harvest-stderr.log").write_text(
+        "Cannot recover conversation: session metadata has no recoverable ChatGPT conversation URL.\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(runner.STATE.OracleStateError) as exc:
+        runner.settle_user_confirmed_no_submission(
+            run_dir,
+            confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
+            reason="user confirmation cannot override contradictory model selector evidence",
+        )
+
+    assert exc.value.code == "NO_SUBMISSION_EVIDENCE_INCOMPLETE"
+    assert runner.STATE.load_state(state_path)["session_authority"] == "submitted_unknown"
 
 
 def test_direct_devspace_prompt_not_observed_recovery_is_hash_bound_before_user_settlement(tmp_path: Path) -> None:


### PR DESCRIPTION
Treats direct DevSpace model-option selection failures as terminal pre-submit outcomes, preserves the failure diagnostics, and adds regression coverage for the affected Oracle runner path. Testing: full test suite passed with 1188 passed and 11 skipped.