### PR TITLE
Promote DevSpace 1.0.8 with guarded runtime compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -31,7 +31,7 @@ body:
     id: dependencies
     attributes:
       label: Oracle and DevSpace versions
-      placeholder: Oracle 0.18.0, DevSpace 1.0.7
+      placeholder: Oracle 0.18.0, DevSpace 1.0.8
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/release-portability.yml
+++ b/.github/workflows/release-portability.yml
@@ -20,7 +20,7 @@ jobs:
         with: { node-version: '24.19.0' }
       - run: python -m pip install "pytest>=8,<10"
       - run: python scripts/prepare_oracle_018_ci.py
-      - run: python scripts/prepare_devspace_107_ci.py
+      - run: python scripts/prepare_devspace_108_ci.py
       - run: python scripts/check_portability.py --root .
       - run: python scripts/check_docs.py --root .
       - run: python scripts/run_fast_gate.py --enforce-budget

--- a/README.en.md
+++ b/README.en.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/ventianima-lab/codex-web-gpt-automation"></a>
   <img alt="Platforms" src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS-334155">
   <img alt="Oracle" src="https://img.shields.io/badge/Oracle-0.18.0-8B5CF6">
-  <img alt="DevSpace" src="https://img.shields.io/badge/DevSpace-1.0.7-14B8A6">
+  <img alt="DevSpace" src="https://img.shields.io/badge/DevSpace-1.0.8-14B8A6">
 </p>
 
 <p align="center">
@@ -182,7 +182,7 @@ This project follows [Semantic Versioning](https://semver.org/) using
 `install-manifest.json`, the Git tag, and the GitHub Release must identify the
 same version. Read the [changelog](docs/CHANGELOG.md) before upgrading.
 
-The current tested baseline is Oracle `0.18.0`, DevSpace `1.0.7`, Node.js
+The current tested baseline is Oracle `0.18.0`, DevSpace `1.0.8`, Node.js
 `>=24 <27`, Windows 11, and macOS 12 or newer. Official npm `latest` releases
 become candidates immediately, but only an isolated archive, patch,
 no-submission, and cross-platform validation plus review can promote them to
@@ -194,7 +194,7 @@ candidates have standing approval only after all gates pass; major/breaking,
 permission/OAuth, patch-conflict, failed, ambiguous, and unsafe-restart cases
 still require explicit user approval. Its checked-in contract is audited by
 `python scripts/verify_upstream_runtime_maintainer.py` and is never auto-registered
-on downstream machines. Oracle `0.17.1` and DevSpace `1.0.4` remain rollback LKG and exact
+on downstream machines. Oracle `0.17.1` and DevSpace `1.0.7` remain rollback LKG and exact
 legacy-recovery versions, not defaults for new work. See the
 [upstream runtime policy](docs/UPSTREAM_RUNTIME_POLICY.md).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/github/license/ventianima-lab/codex-web-gpt-automation"></a>
   <img alt="Platforms" src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS-334155">
   <img alt="Oracle" src="https://img.shields.io/badge/Oracle-0.18.0-8B5CF6">
-  <img alt="DevSpace" src="https://img.shields.io/badge/DevSpace-1.0.7-14B8A6">
+  <img alt="DevSpace" src="https://img.shields.io/badge/DevSpace-1.0.8-14B8A6">
 </p>
 
 <p align="center">
@@ -186,7 +186,7 @@ python "$env:USERPROFILE\.codex\bin\chatgpt_oracle_dispatch.py" `
 GitHub Release가 같은 버전을 가리켜야 합니다. 업그레이드 전에는
 [변경 기록](docs/CHANGELOG.md)을 확인하세요.
 
-현재 기본 검증 기준은 Oracle `0.18.0`, DevSpace `1.0.7`, Node.js `>=24 <27`,
+현재 기본 검증 기준은 Oracle `0.18.0`, DevSpace `1.0.8`, Node.js `>=24 <27`,
 Windows 11 및 macOS 12 이상입니다. 공식 npm `latest`는 즉시 후보로 감지하지만,
 격리된 archive·패치·무전송·교차 플랫폼 검증과 리뷰를 통과한 버전만 current로
 승격합니다. 6시간 감시자는 이슈만 만들고 호스트를 변경하지 않습니다. 별도의 예약된
@@ -194,7 +194,7 @@ Codex 유지관리 자동화가 24시간 안에 검증을 시작해 검증 PR·C
 창의 단일 DevSpace 재시작을 맡고, 차단이 없으면 48시간 내 승격을 목표로 합니다. 안정판
 patch/minor는 모든 게이트가 통과하면 별도 사용자 확인 없이 승인됩니다. major,
 권한/OAuth 변경, 패치 충돌, 실패 또는 모호한 결과만 명시적 사용자 승인이
-필요합니다. 직전 Oracle `0.17.1`과 DevSpace `1.0.4`는 롤백 LKG 및 과거 실행
+필요합니다. 직전 Oracle `0.17.1`과 DevSpace `1.0.7`은 롤백 LKG 및 과거 실행
 복구용으로 보존하며 신규 작업의 기본값으로 사용하지 않습니다. 자세한 계약은
 [업스트림 런타임 정책](docs/UPSTREAM_RUNTIME_POLICY.md)을 참고하세요.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,7 +3,7 @@
 This repository ships no copy of agbrowse, the Oracle package, DevSpace,
 Codex, CodexPro, browser binaries, or account data. It does ship narrow
 textual compatibility patches for hash-verified Oracle 0.18.0 and DevSpace
-1.0.7, plus Oracle 0.17.1 and DevSpace 1.0.4 rollback-LKG assets and the frozen
+1.0.8, plus Oracle 0.17.1 and DevSpace 1.0.7 rollback-LKG assets and the frozen
 legacy Oracle 0.16.1 recovery lineage.
 
 - `hehee9/multi-gpt@4f5e130` is MIT-licensed. Its attribution and the recorded `server.mjs` hash must be preserved when its upstream-compatible integration is changed.
@@ -26,9 +26,9 @@ legacy Oracle 0.16.1 recovery lineage.
   `bin/oracle-compat/0.16.1` remains frozen for exact legacy recovery. All retain
   the following upstream MIT notice.
 - `@waishnav/devspace` is an external MIT-licensed MCP workspace server. The
-  tested version is 1.0.7, with 1.0.4 retained as rollback LKG. Setup resolves it externally; this repository does
+  tested version is 1.0.8, with 1.0.7 retained as rollback LKG. Setup resolves it externally; this repository does
   not vendor its source. The derivative patch instruction under
-  `bin/devspace-compat/1.0.7` retains the upstream MIT license and is applied
+  `bin/devspace-compat/1.0.8` retains the upstream MIT license and is applied
   only when both the package version and exact source hash match.
 - OMO Codex Light (`lazycodex-ai`) and Tailscale are optional external
   installations. Their executables and source are not redistributed here.

--- a/bin/chatgpt_devspace_compat.py
+++ b/bin/chatgpt_devspace_compat.py
@@ -17,6 +17,16 @@ SUPPORTED_VERSION = "1.0.8"
 # old package would hide an incomplete rollback from the service health gates.
 LEGACY_LKG_VERSION = "1.0.7"
 CREATE_NO_WINDOW = 0x08000000
+NATIVE_DEPENDENCY_NAME = "better-sqlite3"
+NATIVE_DEPENDENCY_VERSION = "12.11.1"
+NATIVE_DEPENDENCY_INTEGRITY = (
+    "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/"
+    "HgASQkNKsWFpseIO9beg5xxpYhbIfA=="
+)
+NATIVE_DEPENDENCY_RESOLVED = (
+    "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz"
+)
+NATIVE_DEPENDENCY_INSTALL_SCRIPT = "prebuild-install || node-gyp rebuild --release"
 PATCHES = {
     "dist/artifact-tools.js": {
         "patch": "artifact-audit-readonly.patch",
@@ -119,6 +129,163 @@ def resolve_service_stop_roots() -> list[Path]:
             {"versions": [SUPPORTED_VERSION, LEGACY_LKG_VERSION]},
         )
     return list(dict.fromkeys(roots))
+
+
+def _json_object(path: Path, *, code: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DevSpaceCompatError(code, f"{path.name} is unreadable", {"path": str(path)}) from exc
+    if not isinstance(value, dict):
+        raise DevSpaceCompatError(code, f"{path.name} must contain a JSON object", {"path": str(path)})
+    return value
+
+
+def validate_native_dependency(package_root: Path) -> dict[str, Any]:
+    """Bind a native rebuild to the exact tested npx package tree only."""
+    root = package_root.expanduser().resolve(strict=True)
+    if package_version(root) != SUPPORTED_VERSION:
+        raise DevSpaceCompatError(
+            "DEVSPACE_NATIVE_DEPENDENCY_INVALID",
+            "native preparation accepts only the tested DevSpace package",
+            {"root": str(root), "version": package_version(root)},
+        )
+    node_modules = root.parent.parent
+    try:
+        workspace = node_modules.parent.resolve(strict=True)
+        dependency = (node_modules / NATIVE_DEPENDENCY_NAME).resolve(strict=True)
+    except OSError as exc:
+        raise DevSpaceCompatError(
+            "DEVSPACE_NATIVE_DEPENDENCY_INVALID",
+            "tested native dependency is missing from the exact npx package tree",
+            {"root": str(root), "dependency": NATIVE_DEPENDENCY_NAME},
+        ) from exc
+    if not dependency.is_relative_to(workspace):
+        raise DevSpaceCompatError(
+            "DEVSPACE_NATIVE_DEPENDENCY_INVALID",
+            "native dependency escapes the exact npx package tree",
+            {"root": str(root), "dependency": str(dependency)},
+        )
+    metadata = _json_object(dependency / "package.json", code="DEVSPACE_NATIVE_DEPENDENCY_INVALID")
+    lock = _json_object(workspace / "package-lock.json", code="DEVSPACE_NATIVE_LOCK_INVALID")
+    packages = lock.get("packages")
+    entry = packages.get(f"node_modules/{NATIVE_DEPENDENCY_NAME}") if isinstance(packages, dict) else None
+    actual = {
+        "name": metadata.get("name"),
+        "version": metadata.get("version"),
+        "install_script": (metadata.get("scripts") or {}).get("install")
+        if isinstance(metadata.get("scripts"), dict)
+        else None,
+        "lock_version": entry.get("version") if isinstance(entry, dict) else None,
+        "lock_integrity": entry.get("integrity") if isinstance(entry, dict) else None,
+        "lock_resolved": entry.get("resolved") if isinstance(entry, dict) else None,
+        "lock_has_install_script": entry.get("hasInstallScript") if isinstance(entry, dict) else None,
+    }
+    expected = {
+        "name": NATIVE_DEPENDENCY_NAME,
+        "version": NATIVE_DEPENDENCY_VERSION,
+        "install_script": NATIVE_DEPENDENCY_INSTALL_SCRIPT,
+        "lock_version": NATIVE_DEPENDENCY_VERSION,
+        "lock_integrity": NATIVE_DEPENDENCY_INTEGRITY,
+        "lock_resolved": NATIVE_DEPENDENCY_RESOLVED,
+        "lock_has_install_script": True,
+    }
+    if actual != expected or lock.get("lockfileVersion") != 3:
+        raise DevSpaceCompatError(
+            "DEVSPACE_NATIVE_DEPENDENCY_INVALID",
+            "DevSpace native dependency does not match the tested lock contract",
+            {"root": str(root), "expected": expected, "actual": actual},
+        )
+    return {"root": root, "workspace": workspace, "dependency": dependency}
+
+
+def _native_command(
+    argv: Sequence[str], *, cwd: Path, runner: Any, code: str, message: str, timeout_seconds: int = 180
+) -> subprocess.CompletedProcess[str]:
+    completed = runner(
+        list(argv), cwd=str(cwd), capture_output=True, text=True, encoding="utf-8",
+        errors="replace", check=False, timeout=timeout_seconds, **_git_kwargs(),
+    )
+    if completed.returncode != 0:
+        raise DevSpaceCompatError(code, message, {"stderr": (completed.stderr or "").strip()[-1200:]})
+    return completed
+
+
+def prepare_native_runtime(*, package_root: Path | None = None, runner: Any = subprocess.run) -> dict[str, Any]:
+    """Prime the exact pinned package and approve/rebuild only its native dependency."""
+    roots = resolve_package_roots() if package_root is None else [package_root.expanduser().resolve(strict=True)]
+    npm = shutil.which("npm") or shutil.which("npm.cmd")
+    if not npm:
+        raise DevSpaceCompatError("DEVSPACE_NPM_MISSING", "npm is required for native preparation")
+    checks: list[dict[str, Any]] = []
+    for root in roots:
+        layout = validate_native_dependency(root)
+        try:
+            native = check_native_runtime(package_root=root, runner=runner)
+        except DevSpaceCompatError as exc:
+            if exc.code != "DEVSPACE_NATIVE_BINDING_UNAVAILABLE":
+                raise
+        else:
+            checks.append({"root": str(root), "status": "already-loadable", "native_runtime": native})
+            continue
+        version_result = _native_command(
+            [npm, "--version"], cwd=layout["workspace"], runner=runner,
+            code="DEVSPACE_NPM_VERSION_UNAVAILABLE", message="npm version could not be determined",
+        )
+        npm_version = (version_result.stdout or "").strip()
+        try:
+            npm_major = int(npm_version.split(".", 1)[0])
+        except ValueError as exc:
+            raise DevSpaceCompatError("DEVSPACE_NPM_VERSION_UNAVAILABLE", "npm returned an invalid version") from exc
+        if npm_major < 12:
+            raise DevSpaceCompatError(
+                "DEVSPACE_NPM_VERSION_UNSUPPORTED", "bounded install-script approval requires npm 12 or newer",
+                {"version": npm_version},
+            )
+        policy_path = layout["workspace"] / "package.json"
+        before = _json_object(policy_path, code="DEVSPACE_NATIVE_POLICY_INVALID")
+        before_policy = before.get("allowScripts") or {}
+        if not isinstance(before_policy, dict):
+            raise DevSpaceCompatError("DEVSPACE_NATIVE_POLICY_INVALID", "npx allowScripts policy must be a JSON object")
+        target = f"{NATIVE_DEPENDENCY_NAME}@{NATIVE_DEPENDENCY_VERSION}"
+        conflicts = sorted(
+            key for key in before_policy
+            if key != target and (key == NATIVE_DEPENDENCY_NAME or key.startswith(f"{NATIVE_DEPENDENCY_NAME}@"))
+        )
+        if conflicts:
+            raise DevSpaceCompatError(
+                "DEVSPACE_NATIVE_POLICY_INVALID", "existing native approval policy conflicts with the exact tested version",
+                {"target": target, "conflicts": conflicts},
+            )
+        approval_added = before_policy.get(target) is not True
+        if approval_added:
+            _native_command(
+                [npm, "install-scripts", "approve", target, "--allow-scripts-pin", "--json"],
+                cwd=layout["workspace"], runner=runner, code="DEVSPACE_NATIVE_APPROVAL_FAILED",
+                message="bounded native install-script approval failed",
+            )
+        after = _json_object(policy_path, code="DEVSPACE_NATIVE_POLICY_INVALID")
+        after_policy = after.get("allowScripts")
+        if not isinstance(after_policy, dict) or after_policy.get(target) is not True:
+            raise DevSpaceCompatError("DEVSPACE_NATIVE_APPROVAL_SCOPE_CHANGED", "exact native approval was not persisted")
+        if ({key: value for key, value in before.items() if key != "allowScripts"} !=
+                {key: value for key, value in after.items() if key != "allowScripts"} or
+                any(key != target and after_policy.get(key) != value for key, value in before_policy.items()) or
+                any(key != target and key not in before_policy for key in after_policy)):
+            raise DevSpaceCompatError(
+                "DEVSPACE_NATIVE_APPROVAL_SCOPE_CHANGED", "native approval changed unrelated install-script policy"
+            )
+        _native_command(
+            [npm, "rebuild", target, "--foreground-scripts", "--ignore-scripts=false"],
+            cwd=layout["workspace"], runner=runner, code="DEVSPACE_NATIVE_REBUILD_FAILED",
+            message="bounded better-sqlite3 rebuild failed", timeout_seconds=600,
+        )
+        native = check_native_runtime(package_root=root, runner=runner)
+        checks.append({
+            "root": str(root), "status": "rebuilt-and-loadable", "npm_version": npm_version,
+            "approval_added": approval_added, "native_runtime": native,
+        })
+    return {"ok": True, "version": SUPPORTED_VERSION, "checks": checks}
 
 
 def check_native_runtime(
@@ -546,6 +713,10 @@ def stop_exact_devspace_service(
     service_probe=current_devspace_service_identity,
     stopper: Any | None = None,
     package_roots: Sequence[Path] | None = None,
+    windows_runner: Any = subprocess.run,
+    platform_name: str | None = None,
+    sleeper: Any = time.sleep,
+    stop_timeout_seconds: float = 10.0,
 ) -> dict[str, Any]:
     identity = service_probe(local_port)
     if identity is None:
@@ -553,9 +724,10 @@ def stop_exact_devspace_service(
     roots = list(package_roots or resolve_service_stop_roots())
     identity = _assert_devspace_service_identity(identity, roots)
     pid = int(identity["pid"])
+    stop_evidence: dict[str, Any] = {"mode": "injected"}
     if stopper is not None:
         stopper(pid)
-    elif os.name != "nt":
+    elif (platform_name or os.name) != "nt":
         path = Path(__file__).resolve().with_name("codexpro_posix_process.py")
         spec = importlib.util.spec_from_file_location("codexpro_posix_process_stop_runtime", path)
         if spec is None or spec.loader is None:
@@ -566,25 +738,88 @@ def stop_exact_devspace_service(
             module.terminate_exact_process(identity)
         except module.ProcessIdentityError as exc:
             raise DevSpaceCompatError("DEVSPACE_SERVICE_STOP_FAILED", str(exc), {"pid": pid}) from exc
+        stop_evidence = {"mode": "posix-exact-terminate"}
     else:
+        started_at = int(identity.get("started_at_unix_ns") or 0)
+        if pid <= 0 or started_at <= 0:
+            raise DevSpaceCompatError(
+                "DEVSPACE_SERVICE_STOP_FAILED",
+                "exact Windows service identity is missing PID/start evidence",
+                {"pid": identity.get("pid"), "started_at_unix_ns": identity.get("started_at_unix_ns")},
+            )
         script = (
-            f"Stop-Process -Id {pid} -Force -ErrorAction Stop; "
-            f"Wait-Process -Id {pid} -ErrorAction SilentlyContinue"
+            f"$targetPid={pid};$expectedStart=[int64]{started_at};$port={int(local_port)};"
+            "function Get-Target {"
+            "$p=Get-CimInstance Win32_Process -Filter \"ProcessId=$targetPid\" -ErrorAction SilentlyContinue;"
+            "if($null -eq $p){return $null};"
+            "$s=[DateTimeOffset]::new($p.CreationDate.ToUniversalTime()).ToUnixTimeMilliseconds()*1000000;"
+            "if([int64]$s -ne $expectedStart){return $null};return $p};"
+            "$initial=Get-Target;$stale=($null -eq $initial);$forced=$false;"
+            "if(!$stale){"
+            "Stop-Process -Id $targetPid -ErrorAction SilentlyContinue;"
+            "for($i=0;$i -lt 50 -and $null -ne (Get-Target);$i++){Start-Sleep -Milliseconds 100};"
+            "if($null -ne (Get-Target)){"
+            "$forced=$true;Stop-Process -Id $targetPid -Force -ErrorAction SilentlyContinue;"
+            "for($i=0;$i -lt 50 -and $null -ne (Get-Target);$i++){Start-Sleep -Milliseconds 100}}};"
+            "$alive=($null -ne (Get-Target));"
+            "$listener=Get-NetTCPConnection -State Listen -LocalPort $port -ErrorAction SilentlyContinue | Select-Object -First 1;"
+            "$released=($null -eq $listener);$ok=(!$alive -and $released);"
+            "[pscustomobject]@{ok=$ok;pid=$targetPid;stale_pid=$stale;forced=$forced;"
+            "process_exited=(!$alive);listener_released=$released;"
+            "listener_pid=$(if($listener){[int]$listener.OwningProcess}else{$null})}|ConvertTo-Json -Compress;"
+            "if($ok){exit 0}else{exit 4}"
         )
-        completed = subprocess.run(
+        completed = windows_runner(
             ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
+            timeout=max(15.0, stop_timeout_seconds + 5.0),
             **_git_kwargs(),
         )
+        try:
+            stop_evidence = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise DevSpaceCompatError(
+                "DEVSPACE_SERVICE_STOP_FAILED", "exact Windows stop did not return structured evidence",
+                {"pid": pid, "exit_code": completed.returncode, "stdout": (completed.stdout or "").strip()[-1200:]},
+            ) from exc
         if completed.returncode != 0:
             raise DevSpaceCompatError(
                 "DEVSPACE_SERVICE_STOP_FAILED",
                 "the exact DevSpace service could not be stopped",
-                {"pid": pid, "stderr": (completed.stderr or "").strip()[-1200:]},
+                {"pid": pid, "exit_code": completed.returncode, "stop": stop_evidence,
+                 "stderr": (completed.stderr or "").strip()[-1200:]},
             )
-    return {"ok": True, "stopped": True, "pid": pid}
+        if not isinstance(stop_evidence, dict) or not stop_evidence.get("ok"):
+            raise DevSpaceCompatError(
+                "DEVSPACE_SERVICE_STOP_FAILED",
+                "exact Windows stop evidence did not prove process exit and listener release",
+                {"pid": pid, "stop": stop_evidence},
+            )
+
+    deadline = time.monotonic() + max(0.0, stop_timeout_seconds)
+    while True:
+        remaining = service_probe(local_port)
+        if remaining is None:
+            break
+        remaining_pid = int(remaining.get("pid") or 0)
+        if remaining_pid != pid:
+            raise DevSpaceCompatError(
+                "DEVSPACE_SERVICE_PORT_REBOUND",
+                "the DevSpace port was rebound before exact stop verification completed",
+                {"expected_pid": pid, "listener_pid": remaining_pid},
+            )
+        if time.monotonic() >= deadline:
+            raise DevSpaceCompatError(
+                "DEVSPACE_SERVICE_STOP_FAILED",
+                "the exact DevSpace process did not release its listener before timeout",
+                {"pid": pid, "timeout_seconds": stop_timeout_seconds},
+            )
+        sleeper(min(0.1, max(0.0, deadline - time.monotonic())))
+    return {"ok": True, "stopped": True, "pid": pid, "stop": stop_evidence}
 
 
 def _git_kwargs() -> dict[str, Any]:
@@ -801,6 +1036,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--package-root", type=Path)
     parser.add_argument("--confirm-service-restarted", action="store_true")
     parser.add_argument("--stop-exact-service", action="store_true")
+    parser.add_argument("--prepare-native-runtime", action="store_true")
     parser.add_argument("--check-native-runtime", action="store_true")
     parser.add_argument("--check-oauth-refresh-replay", action="store_true")
     parser.add_argument("--allow-package-absent", action="store_true")
@@ -810,6 +1046,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         selected = sum(bool(value) for value in (
             args.confirm_service_restarted,
             args.stop_exact_service,
+            args.prepare_native_runtime,
             args.check_native_runtime,
             args.check_oauth_refresh_replay,
         ))
@@ -818,7 +1055,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "DEVSPACE_COMPAT_ACTION_CONFLICT",
                 "choose only one DevSpace compatibility action",
             )
-        if args.check_native_runtime:
+        if args.prepare_native_runtime:
+            result = prepare_native_runtime(package_root=args.package_root)
+        elif args.check_native_runtime:
             result = check_native_runtime(
                 package_root=args.package_root,
                 allow_package_absent=args.allow_package_absent,

--- a/bin/chatgpt_devspace_compat.py
+++ b/bin/chatgpt_devspace_compat.py
@@ -11,11 +11,11 @@ import time
 from pathlib import Path
 from typing import Any, Sequence
 
-SUPPORTED_VERSION = "1.0.7"
-# 1.0.4 remains the last-known-good rollback artifact.  It is intentionally
+SUPPORTED_VERSION = "1.0.8"
+# 1.0.7 remains the last-known-good rollback artifact.  It is intentionally
 # not accepted by the updater: applying current compatibility patches to an
 # old package would hide an incomplete rollback from the service health gates.
-LEGACY_LKG_VERSION = "1.0.4"
+LEGACY_LKG_VERSION = "1.0.7"
 CREATE_NO_WINDOW = 0x08000000
 PATCHES = {
     "dist/artifact-tools.js": {
@@ -30,10 +30,10 @@ PATCHES = {
     },
     "dist/server.js": {
         "patch": "workspace-write-and-read-bridge.patch",
-        "pristine": "42d340924421182eea7f2580f96c8d1d5aae459061a6a90804e6900905ef2d72",
-        "patched": "3b258463fcd5a31b754727545ac2b6ecbc0dd922bee568573a8e5a0643842bfc",
+        "pristine": "bf3db902241b631d7c6fbaf12385243b46b4f2d4bb776b6ea7ca6c9d429a3263",
+        "patched": "1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c",
         "upgrades": {
-            "259b5810206bc87e1e16e7963d084f4c90adc19ea9f54b4655d90ad51e49a967": "tool-read-receipts.patch",
+            "659cb1011cd7ab7fb75debb21a44f030001797c2160a42beac527354be93e497": "tool-read-receipts.patch",
         },
     },
     "dist/workspaces.js": {
@@ -794,7 +794,7 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     parser = argparse.ArgumentParser(
         description=(
-            "Apply the exact DevSpace 1.0.7 bounded workspace and OAuth refresh "
+            "Apply the exact DevSpace 1.0.8 bounded workspace and OAuth refresh "
             "compatibility patches."
         )
     )

--- a/bin/chatgpt_oracle_comprehensive.py
+++ b/bin/chatgpt_oracle_comprehensive.py
@@ -38,6 +38,7 @@ PRO_OUTPUT_PREFIX_KEYS = (
 PRO_OUTPUT_RECOVERY_SCHEMA = "codex.chatgpt.oracle-pro-output-recovery/v1"
 STATE_SCHEMA = "codex.chatgpt.oracle-comprehensive-state/v1"
 SCOPE_SCHEMA = "codex.chatgpt.oracle-comprehensive-scope/v1"
+MISSING_LAYOUT_PRE_SUBMIT_SCHEMA = "codex.chatgpt.oracle-missing-layout-pre-submit/v1"
 USER_STOP_SETTLEMENT_SCHEMA = "codex.chatgpt.oracle-comprehensive-user-stop/v1"
 USER_STOP_COMPLETION_SCHEMA = "codex.chatgpt.oracle-comprehensive-user-stop-completion/v1"
 USER_STOP_CONFIRMATION = "user-confirmed-provider-stop"
@@ -1865,6 +1866,123 @@ def _is_unambiguous_pre_submit_failure(run_dir: Path) -> bool:
     return any(marker in text for marker in UNAMBIGUOUS_PRE_SUBMIT_MARKERS)
 
 
+def _missing_layout_pre_submit_proof(
+    stored: dict[str, Any],
+    *,
+    config: dict[str, Any],
+    workflow_id: str,
+) -> dict[str, Any] | None:
+    """Classify an absent bound run layout without inferring non-submission.
+
+    A missing run directory proves neither browser non-submission nor a safe
+    replacement by itself.  Keep the exact manifest binding for diagnosis, but
+    leave fresh-run authority fail-closed until a durable pre-submit run-state
+    proof exists.
+    """
+    attempt_id = str(stored.get("current_attempt_id") or "").strip()
+    run_id = str(stored.get("oracle_run_id") or "").strip()
+    raw_run_dir = str(stored.get("oracle_run_dir") or "").strip()
+    raw_manifest = str(stored.get("oracle_manifest_path") or "").strip()
+    if not attempt_id or run_id != attempt_id or not raw_run_dir or not raw_manifest:
+        return None
+    if str(stored.get("workflow_id") or "") != workflow_id:
+        return None
+
+    run_dir = Path(raw_run_dir).expanduser()
+    manifest_path = Path(raw_manifest).expanduser()
+    if (
+        not run_dir.is_absolute()
+        or run_dir.exists()
+        or run_dir.is_symlink()
+        or not manifest_path.is_absolute()
+        or manifest_path.is_symlink()
+        or not manifest_path.is_file()
+    ):
+        return None
+    receipt_path = Path(str(stored.get("receipt_path") or "")).expanduser()
+    if receipt_path.is_file():
+        return None
+
+    augmented_candidate = Path(str(stored.get("current_augmented_mission_path") or "")).expanduser()
+    binding_candidate = Path(str(stored.get("current_binding_source_path") or "")).expanduser()
+    current_candidate = Path(str(stored.get("current_mission_path") or "")).expanduser()
+    if any(path.is_symlink() for path in (augmented_candidate, binding_candidate, current_candidate)):
+        return None
+    try:
+        oracle_config = RUNNER.STATE.load_manifest(manifest_path)
+        expected_layout = RUNNER.STATE.create_layout(oracle_config, run_id=attempt_id)
+        augmented_mission = augmented_candidate.resolve(strict=True)
+        binding_source = binding_candidate.resolve(strict=True)
+        current_mission = current_candidate.resolve(strict=True)
+    except (OSError, ValueError, TypeError, RUNNER.STATE.OracleStateError):
+        return None
+    if not all(path.is_file() for path in (augmented_mission, binding_source, current_mission)):
+        return None
+    if (
+        expected_layout.run_dir.resolve() != run_dir.resolve()
+        or str(getattr(oracle_config, "requested_run_id", "") or "") != attempt_id
+        or Path(oracle_config.project_root).resolve() != config["project_root"]
+        or Path(oracle_config.mission_path).resolve() != augmented_mission
+        or binding_source != current_mission
+        or str(getattr(oracle_config, "mission_sha256", "") or "") != sha(augmented_mission)
+        or str(stored.get("current_augmented_mission_sha256") or "") != sha(augmented_mission)
+        or str(stored.get("current_input_sha256") or "") != sha(binding_source)
+        or str(stored.get("current_binding_source_sha256") or "") != sha(binding_source)
+    ):
+        return None
+
+    for record in stored.get("records") or []:
+        if not isinstance(record, dict):
+            return None
+        record_run_id = str(record.get("run_id") or "").strip()
+        record_run_dir = str(record.get("run_dir") or "").strip()
+        same_run = record_run_id == attempt_id
+        if record_run_dir:
+            try:
+                same_run = same_run or Path(record_run_dir).resolve() == run_dir.resolve()
+            except OSError:
+                return None
+        if not same_run:
+            continue
+        if "ok" in record or record.get("recovered") is not True:
+            return None
+        if record.get("recovery_status") not in {None, ""}:
+            return None
+
+    return {
+        "schema": MISSING_LAYOUT_PRE_SUBMIT_SCHEMA,
+        "kind": "oracle-layout-not-created",
+        "safe_for_fresh_run": False,
+        "workflow_id": workflow_id,
+        "attempt_id": attempt_id,
+        "run_dir": str(run_dir.resolve()),
+        "oracle_manifest_path": str(manifest_path.resolve()),
+        "reason": "the exact bound Oracle layout was never created and no execution result was recorded",
+    }
+
+
+def _missing_layout_pre_submit_record(
+    proof: dict[str, Any],
+    *,
+    stage: str,
+    input_sha256: str,
+    failure_code: str,
+    failure_evidence: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "stage": stage,
+        "run_id": proof["attempt_id"],
+        "run_dir": proof["run_dir"],
+        "pre_submit_failure": True,
+        "pre_submit_retry_consumed": False,
+        "input_mission_sha256": input_sha256,
+        "failure_code": failure_code,
+        "failure_evidence": dict(failure_evidence or {}),
+        "settlement": "oracle-layout-not-created-pre-submit",
+        "settlement_proof": proof,
+    }
+
+
 def _pre_submit_retry_count(
     records: list[dict[str, Any]],
     *,
@@ -2370,14 +2488,45 @@ def _run_workflow_locked(
             stored_records = list(stored.get("records") or [])
             stored_stage = str(stored["current_stage"])
             stored_input_sha = str(stored.get("current_input_sha256") or "")
-            if (
-                _pre_submit_retry_count(
-                    stored_records,
+            retry_count = _pre_submit_retry_count(
+                stored_records,
+                stage=stored_stage,
+                input_sha256=stored_input_sha,
+                current_run_dir=persisted_run_dir,
+                legacy_total=pre_submit_retries,
+            )
+            missing_layout_proof = _missing_layout_pre_submit_proof(
+                stored,
+                config=config,
+                workflow_id=workflow_id,
+            )
+            if retry_count < 1 and missing_layout_proof is not None:
+                source = Path(str(stored["current_mission_path"])).resolve(strict=True)
+                retry_record = _missing_layout_pre_submit_record(
+                    missing_layout_proof,
                     stage=stored_stage,
                     input_sha256=stored_input_sha,
-                    current_run_dir=persisted_run_dir,
-                    legacy_total=pre_submit_retries,
-                ) < 1
+                    failure_code="ORACLE_LAYOUT_NOT_CREATED_PRE_SUBMIT",
+                )
+                blocked = {
+                    "schema": STATE_SCHEMA,
+                    "status": "attention_required",
+                    "workflow_id": workflow_id,
+                    "manifest_sha256": config["manifest_sha256"],
+                    "next_index": int(stored["next_index"]),
+                    "records": stored_records + [retry_record],
+                    "pre_submit_retries": pre_submit_retries,
+                    "blocker": "the exact Oracle run layout is absent; no durable pre-submit evidence authorizes a replacement",
+                }
+                _write_workflow_state(state_path, config, blocked)
+                return {
+                    "ok": False,
+                    **blocked,
+                    "safe_for_fresh_run": False,
+                    "settlement": "oracle-layout-not-created-pre-submit",
+                }
+            if (
+                retry_count < 1
                 and persisted_run_dir.is_dir()
                 and _is_unambiguous_pre_submit_failure(persisted_run_dir)
                 and _user_confirmed_retry_binding_matches(
@@ -2551,7 +2700,43 @@ def _run_workflow_locked(
             "oracle_run_id": attempt_id, "oracle_run_dir": str(oracle_layout.run_dir), "oracle_manifest_path": str(oracle_manifest),
             "next_index": index, "records": records, "pre_submit_retries": stage_pre_submit_retries,
         })
-        run = oracle_execute(oracle_manifest, dry_run=False)
+        try:
+            run = oracle_execute(oracle_manifest, dry_run=False)
+        except RUNNER.OracleRunError as error:
+            if error.code != "DEVSPACE_EXACT_ROOT_UNAVAILABLE" or oracle_layout.run_dir.exists():
+                raise
+            current = _json(state_path)
+            proof = _missing_layout_pre_submit_proof(
+                current,
+                config=config,
+                workflow_id=workflow_id,
+            )
+            if proof is None:
+                raise
+            retry_record = _missing_layout_pre_submit_record(
+                proof,
+                stage=stage,
+                input_sha256=input_sha,
+                failure_code=error.code,
+                failure_evidence=error.evidence,
+            )
+            blocked = {
+                "schema": STATE_SCHEMA,
+                "status": "attention_required",
+                "workflow_id": workflow_id,
+                "manifest_sha256": config["manifest_sha256"],
+                "next_index": index,
+                "records": records + [retry_record],
+                "pre_submit_retries": stage_pre_submit_retries,
+                "blocker": "the exact Oracle run layout is absent; no durable pre-submit evidence authorizes a replacement",
+            }
+            _write_workflow_state(state_path, config, blocked)
+            return {
+                "ok": False,
+                **blocked,
+                "safe_for_fresh_run": False,
+                "settlement": "oracle-layout-not-created-pre-submit",
+            }
         records.append({"stage": stage, "run_dir": run.get("run_dir"), "ok": bool(run.get("ok"))})
         if stage == "pro" and run.get("ok") and not receipt_path.is_file():
             _materialize_pro_receipt(

--- a/bin/chatgpt_oracle_diagnose.py
+++ b/bin/chatgpt_oracle_diagnose.py
@@ -38,6 +38,7 @@ SCHEMA = "codex.chatgpt.oracle-diagnosis/v1"
 # never reached the composer must never be reported as a recovery defect.
 PRE_SUBMIT_HOST = "pre-submit-host-environment"
 PRE_SUBMIT_UI = "pre-submit-ui-contract"
+OWNERSHIP_CONFLICT = "submission-ownership-conflict"
 BROWSER_LIFETIME = "browser-lifetime-lost"
 PROVIDER_INCOMPLETE = "post-submit-provider-incomplete"
 RECOVERY_BINDING = "post-submit-recovery-binding"
@@ -53,6 +54,7 @@ BUCKETS = (
     ACTIVE,
     PRE_SUBMIT_HOST,
     PRE_SUBMIT_UI,
+    OWNERSHIP_CONFLICT,
     BROWSER_LIFETIME,
     PROVIDER_INCOMPLETE,
     RECOVERY_BINDING,
@@ -61,6 +63,16 @@ BUCKETS = (
 )
 
 SIGNATURE_RULES: tuple[tuple[str, str, str], ...] = (
+    (
+        "project submit mutex could not be acquired",
+        OWNERSHIP_CONFLICT,
+        "project-submit-mutex-held",
+    ),
+    (
+        "PROJECT_SESSION_STILL_LIVE",
+        OWNERSHIP_CONFLICT,
+        "same-task-project-session-still-live",
+    ),
     ("rsync", PRE_SUBMIT_HOST, "oracle-profile-copy-requires-rsync"),
     ("cannot be combined with", PRE_SUBMIT_HOST, "oracle-launch-flags-mutually-exclusive"),
     ("app mention suggestion did not appear", PRE_SUBMIT_UI, "app-mention-suggestion-absent"),
@@ -82,6 +94,7 @@ SIGNATURE_RULES: tuple[tuple[str, str, str], ...] = (
 REMEDIATION = {
     PRE_SUBMIT_HOST: "Fix the local launch contract; no web submission occurred, so a fresh run is safe.",
     PRE_SUBMIT_UI: "Relax or realign the ChatGPT UI contract; no web submission occurred, so a fresh run is safe.",
+    OWNERSHIP_CONFLICT: "Another run owns the task or submit mutex; inspect and resolve that exact owner before any fresh run.",
     BROWSER_LIFETIME: "Keep the Oracle-owned browser alive for the run; recover the exact slug before any retry.",
     PROVIDER_INCOMPLETE: "Resume the exact slug with live recovery; never resubmit.",
     RECOVERY_BINDING: "Reopen only the persisted exact conversation URL; never resubmit.",
@@ -219,8 +232,18 @@ def classify_run(
         return {"bucket": ACTIVE, "signature": "explicitly-abandoned"}
     if outcome in {"not_executed", "blocked"} and has_output:
         evidence_text = "\n".join((stdout_text, transcript_text, output_text))
+        read_route_refresh = STATE.terminal_devspace_read_route_refresh_evidence(
+            state, output_text
+        )
+        terminal_nonexecution = STATE.terminal_devspace_nonexecution_evidence(
+            state, output_text
+        )
         if STATE.recursive_self_observation_evidence(state, output_text) is not None:
             signature = "post-submit-recursive-self-observation"
+        elif read_route_refresh is not None:
+            signature = str(read_route_refresh["signature"])
+        elif terminal_nonexecution is not None:
+            signature = str(terminal_nonexecution["signature"])
         elif "OAuth token request failed" in evidence_text and "503" in evidence_text:
             signature = "registered-app-oauth-token-request-503"
         elif _same_workspace_read_network_failure_evidence(evidence_text):
@@ -292,7 +315,10 @@ def diagnose(state_root: Path | None = None) -> dict[str, Any]:
         output_path = Path(str(artifacts.get("output") or (run_dir / "output.md")))
         verdict = classify_run(
             state,
-            stdout_text=_read_text(run_dir / "stdout.log"),
+            stdout_text="\n".join((
+                _read_text(run_dir / "stdout.log"),
+                _read_text(run_dir / "stderr.log"),
+            )),
             has_output=_output_is_nonempty(output_path),
             transcript_text=_read_text(run_dir / "transcript.md"),
             output_text=_read_text(output_path),

--- a/bin/chatgpt_oracle_incident.py
+++ b/bin/chatgpt_oracle_incident.py
@@ -39,6 +39,8 @@ STATE = DIAGNOSE.STATE
 LEGACY_SCHEMA = "codex.chatgpt.oracle-incident/v1"
 SCHEMA = "codex.chatgpt.oracle-incident/v2"
 OPERATIONAL_INSTRUCTION_SCHEMA = "codex.chatgpt.oracle-operational-instruction/v1"
+WORKFLOW_STATE_SCHEMA = "codex.chatgpt.oracle-comprehensive-state/v1"
+MISSING_LAYOUT_PRE_SUBMIT_SCHEMA = "codex.chatgpt.oracle-missing-layout-pre-submit/v1"
 
 # Exactly one role may edit automation sources.
 MAINTENANCE_OWNER = "automation-maintenance-session"
@@ -70,6 +72,15 @@ class IncidentError(RuntimeError):
 
     def envelope(self) -> dict[str, Any]:
         return {"ok": False, "error": {"code": self.code, "message": str(self), "evidence": self.evidence}}
+
+
+def _validate_reporter_role(reporter_role: str) -> None:
+    if reporter_role != REPORTER_ROLE:
+        raise IncidentError(
+            "INCIDENT_REPORTER_ROLE_INVALID",
+            f"an incident packet is reported by {REPORTER_ROLE}",
+            {"reporter_role": reporter_role},
+        )
 
 
 def _report_identity(state: dict[str, Any]) -> tuple[str | None, str | None, str]:
@@ -106,6 +117,10 @@ def _operational_instruction(
         action = "none"
         reason = "exact-run-already-terminal"
         executable = False
+    elif lifecycle == "pre_submit_settled" and owner is not None and evaluator == owner:
+        action = "rerun-settled-workflow"
+        reason = "workflow-proof-confirms-oracle-layout-was-never-created"
+        executable = True
     elif owner is None:
         action = "none"
         reason = "legacy-run-has-no-task-recovery-authority"
@@ -128,18 +143,16 @@ def _operational_instruction(
         "action": action,
         "reason": reason,
         "executable_by_evaluated_thread": executable,
-        "fresh_state_check_required": action == "inspect-owned-exact-run",
+        "fresh_state_check_required": action in {
+            "inspect-owned-exact-run",
+            "rerun-settled-workflow",
+        },
     }
 
 
 def build_packet(run_dir: Path, *, reporter_role: str = REPORTER_ROLE) -> dict[str, Any]:
     """Build one incident packet from persisted run evidence only."""
-    if reporter_role != REPORTER_ROLE:
-        raise IncidentError(
-            "INCIDENT_REPORTER_ROLE_INVALID",
-            f"an incident packet is reported by {REPORTER_ROLE}",
-            {"reporter_role": reporter_role},
-        )
+    _validate_reporter_role(reporter_role)
     directory = run_dir.expanduser().resolve(strict=True)
     state_path = directory / "state.json"
     if not state_path.is_file():
@@ -153,7 +166,10 @@ def build_packet(run_dir: Path, *, reporter_role: str = REPORTER_ROLE) -> dict[s
     output_path = Path(str(artifacts.get("output") or (directory / "output.md")))
     verdict = DIAGNOSE.classify_run(
         state,
-        stdout_text=DIAGNOSE._read_text(directory / "stdout.log"),
+        stdout_text="\n".join((
+            DIAGNOSE._read_text(directory / "stdout.log"),
+            DIAGNOSE._read_text(directory / "stderr.log"),
+        )),
         has_output=DIAGNOSE._output_is_nonempty(output_path),
         transcript_text=DIAGNOSE._read_text(directory / "transcript.md"),
         output_text=DIAGNOSE._read_text(output_path),
@@ -179,13 +195,79 @@ def build_packet(run_dir: Path, *, reporter_role: str = REPORTER_ROLE) -> dict[s
         if owner_thread is not None
         else []
     )
+    # A diagnostic bucket is not authority to replace a run.  In particular,
+    # ``submitted_unknown`` can resemble a host/UI failure while still retaining
+    # a possible browser submission.  Require the state module's exact durable
+    # pre-submit proof before a same-task packet may say a fresh run is safe.
+    pre_submit_authority = (
+        STATE.proven_pre_submit_failure(state_path)
+        or STATE.proven_pre_submit_session_absence(state_path)
+    )
     recursive_authority = STATE.proven_recursive_self_observation_fresh_run_authority(
         state_path
+    )
+    terminal_nonexecution_authority = (
+        STATE.proven_terminal_devspace_nonexecution_fresh_run_authority(state_path)
+    )
+    read_route_refresh_authority = (
+        STATE.proven_terminal_devspace_read_route_refresh_fresh_run_authority(
+            state_path
+        )
+    )
+    if (
+        (
+            terminal_nonexecution_authority is not None
+            and terminal_nonexecution_authority.get("authorized_source_thread_id")
+            == evaluated_from_thread
+        )
+        or (
+            read_route_refresh_authority is not None
+            and read_route_refresh_authority.get("authorized_source_thread_id")
+            == evaluated_from_thread
+        )
+    ):
+        owners = STATE.unresolved_project_sessions(
+            directory.parent,
+            project_root,
+            exclude_run_id=str(state.get("run_id") or ""),
+            source_thread_id=evaluated_from_thread,
+        )
+    pre_submit_fresh_safe = (
+        ownership_scope == "same-task"
+        and bucket in {DIAGNOSE.PRE_SUBMIT_HOST, DIAGNOSE.PRE_SUBMIT_UI}
+        and pre_submit_authority is not None
+        and not owners
     )
     recursive_fresh_safe = (
         str(verdict["signature"]) == "post-submit-recursive-self-observation"
         and recursive_authority is not None
         and not owners
+    )
+    terminal_nonexecution_fresh_safe = (
+        str(verdict["signature"])
+        in STATE.TERMINAL_DEVSPACE_NONEXECUTION_SIGNATURES
+        and terminal_nonexecution_authority is not None
+        and terminal_nonexecution_authority.get("signature")
+        == str(verdict["signature"])
+        and terminal_nonexecution_authority.get("authorized_source_thread_id")
+        == evaluated_from_thread
+        and not owners
+    )
+    read_route_refresh_fresh_safe = (
+        str(verdict["signature"])
+        == STATE.TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SIGNATURE
+        and read_route_refresh_authority is not None
+        and read_route_refresh_authority.get("signature")
+        == str(verdict["signature"])
+        and read_route_refresh_authority.get("authorized_source_thread_id")
+        == evaluated_from_thread
+        and not owners
+    )
+    fresh_run_authority = (
+        read_route_refresh_authority
+        or terminal_nonexecution_authority
+        or recursive_authority
+        or (pre_submit_authority if pre_submit_fresh_safe else None)
     )
     return {
         "schema": SCHEMA,
@@ -212,17 +294,21 @@ def build_packet(run_dir: Path, *, reporter_role: str = REPORTER_ROLE) -> dict[s
             evaluator=evaluated_from_thread,
             scope=ownership_scope,
         ),
-        # Only a proven pre-submit failure is safe to retry: nothing reached the
-        # composer, so a fresh run cannot duplicate a live web submission.
+        # Pre-submit proof remains the normal fresh-run authority. The only
+        # terminal exceptions are exact task-bound append-only receipts.
         "safe_for_fresh_run": (
-            ownership_scope == "same-task"
-            and (
-                (bucket in {DIAGNOSE.PRE_SUBMIT_HOST, DIAGNOSE.PRE_SUBMIT_UI} and not owners)
-                or recursive_fresh_safe
+            (
+                ownership_scope == "same-task"
+                and (
+                    pre_submit_fresh_safe
+                    or recursive_fresh_safe
+                    or read_route_refresh_fresh_safe
+                )
             )
+            or terminal_nonexecution_fresh_safe
         ),
         "unresolved_owners": owners,
-        "fresh_run_authority": recursive_authority,
+        "fresh_run_authority": fresh_run_authority,
         "remediation": DIAGNOSE.REMEDIATION.get(bucket, ""),
         "evidence_paths": sorted(
             str(path)
@@ -234,6 +320,134 @@ def build_packet(run_dir: Path, *, reporter_role: str = REPORTER_ROLE) -> dict[s
             )
             if path.is_file()
         ),
+    }
+
+
+def build_missing_layout_packet(
+    workflow_state_path: Path,
+    *,
+    reporter_role: str = REPORTER_ROLE,
+) -> dict[str, Any]:
+    """Report an exact missing-layout incident without granting replacement authority."""
+    _validate_reporter_role(reporter_role)
+    path = workflow_state_path.expanduser().resolve(strict=True)
+    try:
+        workflow = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise IncidentError(
+            "INCIDENT_WORKFLOW_STATE_INVALID",
+            "the comprehensive workflow state is not valid UTF-8 JSON",
+            {"workflow_state_path": str(path)},
+        ) from error
+    if not isinstance(workflow, dict) or workflow.get("schema") != WORKFLOW_STATE_SCHEMA:
+        raise IncidentError(
+            "INCIDENT_WORKFLOW_STATE_INVALID",
+            f"workflow state schema must be {WORKFLOW_STATE_SCHEMA}",
+            {"workflow_state_path": str(path)},
+        )
+    records = workflow.get("records") if isinstance(workflow.get("records"), list) else []
+    settlement = next(
+        (
+            record
+            for record in reversed(records)
+            if isinstance(record, dict)
+            and record.get("settlement") == "oracle-layout-not-created-pre-submit"
+        ),
+        None,
+    )
+    proof = settlement.get("settlement_proof") if isinstance(settlement, dict) else None
+    if (
+        not isinstance(proof, dict)
+        or proof.get("schema") != MISSING_LAYOUT_PRE_SUBMIT_SCHEMA
+        or proof.get("kind") != "oracle-layout-not-created"
+        or proof.get("safe_for_fresh_run") is not False
+        or str(proof.get("workflow_id") or "") != str(workflow.get("workflow_id") or "")
+        or str(proof.get("attempt_id") or "") != str(settlement.get("run_id") or "")
+        or str(proof.get("run_dir") or "") != str(settlement.get("run_dir") or "")
+    ):
+        raise IncidentError(
+            "INCIDENT_MISSING_LAYOUT_PROOF_INVALID",
+            "workflow state lacks an exact missing-layout pre-submit settlement proof",
+            {"workflow_state_path": str(path)},
+        )
+    run_dir = Path(str(proof["run_dir"])).expanduser()
+    manifest_path = Path(str(proof.get("oracle_manifest_path") or "")).expanduser()
+    if not run_dir.is_absolute() or run_dir.exists() or run_dir.is_symlink():
+        raise IncidentError(
+            "INCIDENT_MISSING_LAYOUT_PROOF_INVALID",
+            "the settled Oracle run directory must remain absent",
+            {"run_dir": str(run_dir)},
+        )
+    try:
+        manifest_path = manifest_path.resolve(strict=True)
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        project_root = Path(str(manifest.get("project_root") or "")).expanduser().resolve(strict=True)
+    except (OSError, UnicodeDecodeError, TypeError, json.JSONDecodeError) as error:
+        raise IncidentError(
+            "INCIDENT_MISSING_LAYOUT_BINDING_INVALID",
+            "the settled attempt's Oracle manifest binding is unavailable",
+            {"oracle_manifest_path": str(manifest_path)},
+        ) from error
+    attempt_id = str(proof["attempt_id"])
+    manifest_run_id = str(manifest.get("run_id") or manifest.get("requested_run_id") or "")
+    if not isinstance(manifest, dict) or manifest_run_id != attempt_id or not project_root.is_dir():
+        raise IncidentError(
+            "INCIDENT_MISSING_LAYOUT_BINDING_INVALID",
+            "the settled attempt does not match its Oracle manifest",
+            {"oracle_manifest_path": str(manifest_path), "attempt_id": attempt_id},
+        )
+    owner = str(workflow.get("source_thread_id") or "").strip().casefold() or None
+    evaluator = STATE.current_source_thread_id()
+    if evaluator is None:
+        raise IncidentError(
+            "INCIDENT_EVALUATED_FROM_THREAD_REQUIRED",
+            "a v2 incident report requires the exact evaluating Codex task ID",
+            {"attempt_id": attempt_id, "owner_source_thread_id": owner},
+        )
+    scope = "legacy-unbound" if owner is None else "same-task" if owner == evaluator else "foreign-task"
+    owners = (
+        STATE.unresolved_project_sessions(
+            run_dir.resolve().parent,
+            project_root,
+            exclude_run_id=attempt_id,
+            source_thread_id=owner,
+        )
+        if owner is not None
+        else []
+    )
+    state_stub = {
+        "run_id": attempt_id,
+        "source_thread_id": owner,
+        "oracle": {"slug": f"oracle-settled-{attempt_id[:10]}"},
+    }
+    return {
+        "schema": SCHEMA,
+        "run_dir": str(run_dir.resolve()),
+        "project_root": str(project_root),
+        "bucket": DIAGNOSE.PRE_SUBMIT_HOST,
+        "signature": "oracle-layout-not-created-pre-submit",
+        "lifecycle": "attention_required",
+        "authority_source": "workflow-missing-layout-unproven",
+        "conversation_url": "",
+        "reporter_role": reporter_role,
+        "repair_owner": MAINTENANCE_OWNER,
+        "reporter_may_edit_automation_sources": False,
+        "run_owner_source_thread_id": owner,
+        "evaluated_from_thread": evaluator,
+        "target_source_thread_id": owner,
+        "ownership_scope": scope,
+        "operational_instruction": _operational_instruction(
+            state_stub,
+            lifecycle="attention_required",
+            owner=owner,
+            evaluator=evaluator,
+            scope=scope,
+        ),
+        "safe_for_fresh_run": False,
+        "unresolved_owners": owners,
+        "fresh_run_authority": None,
+        "remediation": DIAGNOSE.REMEDIATION.get(DIAGNOSE.PRE_SUBMIT_HOST, ""),
+        "evidence_paths": [str(path), str(manifest_path)],
     }
 
 
@@ -348,6 +562,13 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:
                 False,
                 False,
             )
+        elif lifecycle == "pre_submit_settled" and scope == "same-task":
+            expected_instruction = (
+                "rerun-settled-workflow",
+                "workflow-proof-confirms-oracle-layout-was-never-created",
+                True,
+                True,
+            )
         elif scope == "legacy-unbound":
             expected_instruction = (
                 "none",
@@ -385,6 +606,47 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:
                 "the operational action must match the exact lifecycle and task ownership scope",
                 {"expected": expected_instruction, "actual": actual_instruction},
             )
+        if packet.get("safe_for_fresh_run") is True and packet.get("bucket") in {
+            DIAGNOSE.PRE_SUBMIT_HOST,
+            DIAGNOSE.PRE_SUBMIT_UI,
+        }:
+            state_path = Path(str(packet["run_dir"])) / "state.json"
+            proof = (
+                STATE.proven_pre_submit_failure(state_path)
+                or STATE.proven_pre_submit_session_absence(state_path)
+            )
+            if proof is None or packet.get("fresh_run_authority") != proof:
+                raise IncidentError(
+                    "INCIDENT_FRESH_RUN_AUTHORITY_INVALID",
+                    "pre-submit fresh-run authority requires exact durable state evidence",
+                )
+        if packet.get("safe_for_fresh_run") is True and packet.get("bucket") == DIAGNOSE.TASK_NOT_EXECUTED:
+            state_path = Path(str(packet["run_dir"])) / "state.json"
+            signature = str(packet.get("signature") or "")
+            if signature == "post-submit-recursive-self-observation":
+                proof = STATE.proven_recursive_self_observation_fresh_run_authority(state_path)
+            elif signature in STATE.TERMINAL_DEVSPACE_NONEXECUTION_SIGNATURES:
+                proof = STATE.proven_terminal_devspace_nonexecution_fresh_run_authority(state_path)
+                if proof is not None and proof.get("authorized_source_thread_id") != evaluator:
+                    proof = None
+            elif signature == STATE.TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SIGNATURE:
+                proof = STATE.proven_terminal_devspace_read_route_refresh_fresh_run_authority(
+                    state_path
+                )
+                if proof is not None and proof.get("authorized_source_thread_id") != evaluator:
+                    proof = None
+            else:
+                proof = None
+            claimed = packet.get("fresh_run_authority")
+            if (
+                proof is None
+                or not isinstance(claimed, dict)
+                or claimed.get("sha256") != proof.get("sha256")
+            ):
+                raise IncidentError(
+                    "INCIDENT_FRESH_RUN_AUTHORITY_INVALID",
+                    "terminal fresh-run authority requires a revalidated, exact append-only receipt",
+                )
     return packet
 
 
@@ -392,7 +654,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Build or validate one Oracle incident packet.")
     commands = parser.add_subparsers(dest="command", required=True)
     report = commands.add_parser("report")
-    report.add_argument("--run-dir", type=Path, required=True)
+    source = report.add_mutually_exclusive_group(required=True)
+    source.add_argument("--run-dir", type=Path)
+    source.add_argument("--workflow-state", type=Path)
     check = commands.add_parser("validate")
     check.add_argument("--packet", type=Path, required=True)
     return parser
@@ -402,7 +666,11 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         if args.command == "report":
-            packet = validate_packet(build_packet(args.run_dir))
+            packet = validate_packet(
+                build_packet(args.run_dir)
+                if args.run_dir is not None
+                else build_missing_layout_packet(args.workflow_state)
+            )
         else:
             packet = validate_packet(
                 json.loads(args.packet.expanduser().resolve(strict=True).read_text(encoding="utf-8"))

--- a/bin/chatgpt_oracle_run.py
+++ b/bin/chatgpt_oracle_run.py
@@ -2985,6 +2985,457 @@ def settle_recursive_self_observation_fresh_run(
     return {**preview, "settlement": proven, "settlement_sha256": proven["sha256"]}
 
 
+def settle_terminal_devspace_nonexecution_fresh_run(
+    run_dir: Path,
+    *,
+    confirmation: str,
+    reason: str,
+    expected_state_sha256: str,
+    expected_output_sha256: str,
+    expected_transcript_sha256: str,
+    expected_stdout_sha256: str,
+    expected_stderr_sha256: str,
+    expected_mission_sha256: str,
+    dry_run: bool = False,
+    process_alive: Callable[[int], bool] = process_is_alive,
+) -> dict[str, Any]:
+    """Append authority for a bounded terminal DevSpace failure with no task work."""
+    if (
+        confirmation.strip().casefold()
+        != STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION
+    ):
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_CONFIRMATION_REQUIRED",
+            "confirmation does not authorize a fresh run after terminal DevSpace nonexecution",
+        )
+    normalized_reason = reason.strip()
+    if not normalized_reason:
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_REASON_REQUIRED",
+            "an explicit user-authority reason is required",
+        )
+    authorized_thread = STATE.current_source_thread_id()
+    if authorized_thread is None:
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_TASK_REQUIRED",
+            "settlement must be issued from one exact Codex task",
+        )
+    directory = run_dir.expanduser().resolve(strict=True)
+    state_path = directory / "state.json"
+    if state_path.is_symlink() or state_path.resolve(strict=True) != (directory / "state.json"):
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_STATE_UNSAFE",
+            "state must be the regular state.json in the exact run directory",
+        )
+    state = STATE.load_state(state_path)
+    owner_thread = STATE.source_thread_id_from_state(state)
+    if owner_thread is not None and owner_thread != authorized_thread:
+        raise OracleRunError(
+            "FOREIGN_TASK_SESSION",
+            "a task may not settle another task's terminal nonexecution",
+            {
+                "owner_source_thread_id": owner_thread,
+                "caller_source_thread_id": authorized_thread,
+                "run_id": state.get("run_id"),
+            },
+        )
+    artifacts = state.get("artifacts") if isinstance(state.get("artifacts"), dict) else {}
+    raw_paths = {
+        "output": Path(str(artifacts.get("output") or directory / "output.md")),
+        "transcript": Path(str(artifacts.get("transcript") or directory / "transcript.md")),
+        "stdout": Path(str(artifacts.get("stdout") or directory / "stdout.log")),
+        "stderr": Path(str(artifacts.get("stderr") or directory / "stderr.log")),
+        "mission": directory / "mission.md",
+    }
+    expected_paths = {name: directory / f"{name}.md" for name in ("output", "transcript", "mission")}
+    expected_paths.update({"stdout": directory / "stdout.log", "stderr": directory / "stderr.log"})
+    resolved_paths: dict[str, Path] = {}
+    try:
+        for name, raw in raw_paths.items():
+            resolved = raw.resolve(strict=True)
+            if raw.is_symlink() or not resolved.is_file() or resolved != expected_paths[name].resolve():
+                raise OSError(f"unsafe {name} path")
+            resolved_paths[name] = resolved
+    except OSError as exc:
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_ARTIFACT_UNSAFE",
+            "state, mission, and stream artifacts must be regular files in the exact run",
+        ) from exc
+    actual_hashes = {
+        "state_sha256": STATE.sha256_file(state_path),
+        **{
+            f"{name}_sha256": STATE.sha256_file(path)
+            for name, path in resolved_paths.items()
+        },
+    }
+    expected_hashes = {
+        "state_sha256": expected_state_sha256.strip().casefold(),
+        "output_sha256": expected_output_sha256.strip().casefold(),
+        "transcript_sha256": expected_transcript_sha256.strip().casefold(),
+        "stdout_sha256": expected_stdout_sha256.strip().casefold(),
+        "stderr_sha256": expected_stderr_sha256.strip().casefold(),
+        "mission_sha256": expected_mission_sha256.strip().casefold(),
+    }
+    if any(actual_hashes[key] != expected_hashes[key] for key in actual_hashes):
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_HASH_MISMATCH",
+            "exact terminal run artifacts changed before authority settlement",
+            {"expected": expected_hashes, "actual": actual_hashes},
+        )
+    mission = state.get("mission") if isinstance(state.get("mission"), dict) else {}
+    if mission.get("sha256") != actual_hashes["mission_sha256"]:
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_MISSION_MISMATCH",
+            "the persisted mission copy no longer matches the run's mission binding",
+        )
+    output_text = resolved_paths["output"].read_text(encoding="utf-8", errors="strict")
+    evidence = STATE.terminal_devspace_nonexecution_evidence(state, output_text)
+    if evidence is None:
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_EVIDENCE_REQUIRED",
+            "terminal output lacks bounded DevSpace failure and explicit nonexecution proof",
+        )
+    active_pids = [pid for pid in run_owned_process_ids(directory, state) if process_alive(pid)]
+    if active_pids:
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_PROCESS_ACTIVE",
+            "run-owned Oracle or recovery process is still active",
+            {"active_pids": active_pids},
+        )
+    project_root = Path(str(state.get("project_root") or "")).expanduser().resolve(strict=True)
+    owners = STATE.unresolved_project_sessions(
+        directory.parent,
+        project_root,
+        exclude_run_id=str(state.get("run_id") or ""),
+        source_thread_id=authorized_thread,
+    )
+    if owners:
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_OWNER_ACTIVE",
+            "another exact same-task project session still owns submission authority",
+            {"owners": owners},
+        )
+    existing = STATE.proven_terminal_devspace_nonexecution_fresh_run_authority(state_path)
+    if existing is not None:
+        if existing.get("authorized_source_thread_id") != authorized_thread:
+            raise OracleRunError(
+                "TERMINAL_DEVSPACE_NONEXECUTION_AUTHORITY_CONFLICT",
+                "append-only fresh-run authority belongs to a different Codex task",
+            )
+        return {
+            "ok": True,
+            "status": "terminal_devspace_nonexecution_fresh_run_authorized",
+            "safe_for_fresh_run": True,
+            "scope_released": True,
+            "auto_retry": False,
+            "submission_action": "none",
+            "run_dir": str(directory),
+            "settlement": existing,
+        }
+    oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
+    receipt = {
+        "schema": STATE.TERMINAL_DEVSPACE_NONEXECUTION_SETTLEMENT_SCHEMA,
+        "confirmation": STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,
+        "reason": normalized_reason,
+        "authorized_source_thread_id": authorized_thread,
+        "historical_owner_scope": "same-task" if owner_thread == authorized_thread else "legacy-unbound",
+        "run_id": state.get("run_id"),
+        "project_root": str(project_root),
+        "slug": oracle.get("slug"),
+        "transport": state.get("transport"),
+        "task_outcome": state.get("task_outcome"),
+        "signature": evidence["signature"],
+        **actual_hashes,
+        "auto_retry": False,
+        "submission_action": "none",
+        "authorized_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    receipt_path = directory / "settlements" / "terminal-devspace-nonexecution-fresh-run.json"
+    preview = {
+        "ok": True,
+        "status": "dry-run" if dry_run else "terminal_devspace_nonexecution_fresh_run_authorized",
+        "safe_for_fresh_run": True,
+        "scope_released": True,
+        "auto_retry": False,
+        "submission_action": "none",
+        "run_dir": str(directory),
+        "settlement_path": str(receipt_path),
+        "settlement_payload": receipt,
+    }
+    if dry_run:
+        return preview
+    if receipt_path.parent.exists() and (
+        receipt_path.parent.is_symlink() or receipt_path.parent.resolve().parent != directory
+    ):
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_SETTLEMENT_PATH_UNSAFE",
+            "append-only settlement directory is outside the exact run",
+        )
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(receipt, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    try:
+        with receipt_path.open("xb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except FileExistsError as exc:
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_SETTLEMENT_EXISTS",
+            "append-only settlement path already exists but did not validate",
+            {"path": str(receipt_path)},
+        ) from exc
+    proven = STATE.proven_terminal_devspace_nonexecution_fresh_run_authority(state_path)
+    if proven is None:
+        raise OracleRunError(
+            "TERMINAL_DEVSPACE_NONEXECUTION_SETTLEMENT_INVALID",
+            "written append-only settlement failed revalidation",
+        )
+    return {**preview, "settlement": proven, "settlement_sha256": proven["sha256"]}
+
+
+def settle_terminal_devspace_read_route_refresh_fresh_run(
+    run_dir: Path,
+    *,
+    confirmation: str,
+    reason: str,
+    expected_state_sha256: str,
+    expected_output_sha256: str,
+    expected_transcript_sha256: str,
+    expected_stdout_sha256: str,
+    expected_stderr_sha256: str,
+    expected_mission_sha256: str,
+    dry_run: bool = False,
+    process_alive: Callable[[int], bool] = process_is_alive,
+) -> dict[str, Any]:
+    """Authorize one fresh probe after a user-completed app-tool refresh."""
+    if (
+        confirmation.strip().casefold()
+        != STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH
+    ):
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_CONFIRMATION_REQUIRED",
+            "confirmation does not authorize a fresh probe after the app-tool refresh",
+        )
+    normalized_reason = reason.strip()
+    if not normalized_reason:
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_REASON_REQUIRED",
+            "an explicit user-authority reason is required",
+        )
+    authorized_thread = STATE.current_source_thread_id()
+    if authorized_thread is None:
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_TASK_REQUIRED",
+            "settlement must be issued from one exact Codex task",
+        )
+    directory = run_dir.expanduser().resolve(strict=True)
+    state_path = directory / "state.json"
+    if state_path.is_symlink() or state_path.resolve(strict=True) != (directory / "state.json"):
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_STATE_UNSAFE",
+            "state must be the regular state.json in the exact run directory",
+        )
+    state = STATE.load_state(state_path)
+    owner_thread = STATE.source_thread_id_from_state(state)
+    if owner_thread != authorized_thread:
+        raise OracleRunError(
+            "FOREIGN_TASK_SESSION",
+            "a task may settle only its own exact read-route canary",
+            {
+                "owner_source_thread_id": owner_thread or "legacy-unbound",
+                "caller_source_thread_id": authorized_thread,
+                "run_id": state.get("run_id"),
+            },
+        )
+    artifacts = state.get("artifacts") if isinstance(state.get("artifacts"), dict) else {}
+    raw_paths = {
+        "output": Path(str(artifacts.get("output") or directory / "output.md")),
+        "transcript": Path(str(artifacts.get("transcript") or directory / "transcript.md")),
+        "stdout": Path(str(artifacts.get("stdout") or directory / "stdout.log")),
+        "stderr": Path(str(artifacts.get("stderr") or directory / "stderr.log")),
+        "mission": directory / "mission.md",
+    }
+    expected_paths = {name: directory / f"{name}.md" for name in ("output", "transcript", "mission")}
+    expected_paths.update({"stdout": directory / "stdout.log", "stderr": directory / "stderr.log"})
+    resolved_paths: dict[str, Path] = {}
+    try:
+        for name, raw in raw_paths.items():
+            resolved = raw.resolve(strict=True)
+            if raw.is_symlink() or not resolved.is_file() or resolved != expected_paths[name].resolve():
+                raise OSError(f"unsafe {name} path")
+            resolved_paths[name] = resolved
+    except OSError as exc:
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_ARTIFACT_UNSAFE",
+            "state, mission, and stream artifacts must be regular files in the exact run",
+        ) from exc
+    actual_hashes = {
+        "state_sha256": STATE.sha256_file(state_path),
+        **{
+            f"{name}_sha256": STATE.sha256_file(path)
+            for name, path in resolved_paths.items()
+        },
+    }
+    expected_hashes = {
+        "state_sha256": expected_state_sha256.strip().casefold(),
+        "output_sha256": expected_output_sha256.strip().casefold(),
+        "transcript_sha256": expected_transcript_sha256.strip().casefold(),
+        "stdout_sha256": expected_stdout_sha256.strip().casefold(),
+        "stderr_sha256": expected_stderr_sha256.strip().casefold(),
+        "mission_sha256": expected_mission_sha256.strip().casefold(),
+    }
+    if any(actual_hashes[key] != expected_hashes[key] for key in actual_hashes):
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_HASH_MISMATCH",
+            "exact terminal canary artifacts changed before authority settlement",
+            {"expected": expected_hashes, "actual": actual_hashes},
+        )
+    mission = state.get("mission") if isinstance(state.get("mission"), dict) else {}
+    mission_text = resolved_paths["mission"].read_text(encoding="utf-8", errors="strict")
+    if (
+        mission.get("sha256") != actual_hashes["mission_sha256"]
+        or not STATE.terminal_devspace_read_route_refresh_mission_contract(mission_text)
+    ):
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_MISSION_MISMATCH",
+            "the immutable mission is not the bounded read-only qualification contract",
+        )
+    output_text = resolved_paths["output"].read_text(encoding="utf-8", errors="strict")
+    evidence = STATE.terminal_devspace_read_route_refresh_evidence(state, output_text)
+    if evidence is None:
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_EVIDENCE_REQUIRED",
+            "terminal output does not prove the exact read-only read_chunk exposure failure",
+        )
+    active_pids = [pid for pid in run_owned_process_ids(directory, state) if process_alive(pid)]
+    if active_pids:
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_PROCESS_ACTIVE",
+            "run-owned Oracle or recovery process is still active",
+            {"active_pids": active_pids},
+        )
+    project_root = Path(str(state.get("project_root") or "")).expanduser().resolve(strict=True)
+    owners = STATE.unresolved_project_sessions(
+        directory.parent,
+        project_root,
+        exclude_run_id=str(state.get("run_id") or ""),
+        source_thread_id=authorized_thread,
+    )
+    if owners:
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_OWNER_ACTIVE",
+            "another exact same-task project session still owns submission authority",
+            {"owners": owners},
+        )
+    existing = STATE.proven_terminal_devspace_read_route_refresh_fresh_run_authority(
+        state_path
+    )
+    if existing is not None:
+        if existing.get("authorized_source_thread_id") != authorized_thread:
+            raise OracleRunError(
+                "DEVSPACE_READ_ROUTE_REFRESH_AUTHORITY_CONFLICT",
+                "append-only fresh-run authority belongs to a different Codex task",
+            )
+        return {
+            "ok": True,
+            "status": "terminal_devspace_read_route_refresh_fresh_run_authorized",
+            "safe_for_fresh_run": True,
+            "scope_released": True,
+            "auto_retry": False,
+            "submission_action": "none",
+            "run_dir": str(directory),
+            "settlement": existing,
+        }
+    settlement_name = "terminal-devspace-read-route-refresh-fresh-run.json"
+    for sibling_state in sorted(directory.parent.glob("*/state.json"), key=lambda path: str(path)):
+        if sibling_state.parent.resolve() == directory:
+            continue
+        sibling_receipt = sibling_state.parent / "settlements" / settlement_name
+        if not sibling_receipt.exists():
+            continue
+        prior = STATE.proven_terminal_devspace_read_route_refresh_fresh_run_authority(
+            sibling_state
+        )
+        if prior is None:
+            raise OracleRunError(
+                "DEVSPACE_READ_ROUTE_REFRESH_PRIOR_SETTLEMENT_INVALID",
+                "a prior read-route refresh receipt exists but no longer validates",
+                {"path": str(sibling_receipt)},
+            )
+        if (
+            str(prior.get("project_root") or "").casefold() == str(project_root).casefold()
+            and prior.get("authorized_source_thread_id") == authorized_thread
+        ):
+            raise OracleRunError(
+                "DEVSPACE_READ_ROUTE_REFRESH_RETRY_ALREADY_USED",
+                "the one authorized post-refresh probe was already released for this task and project",
+                {"prior_run_id": prior.get("run_id"), "prior_receipt": prior.get("path")},
+            )
+    oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
+    receipt = {
+        "schema": STATE.TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SETTLEMENT_SCHEMA,
+        "confirmation": STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH,
+        "reason": normalized_reason,
+        "authorized_source_thread_id": authorized_thread,
+        "run_id": state.get("run_id"),
+        "project_root": str(project_root),
+        "slug": oracle.get("slug"),
+        "transport": state.get("transport"),
+        "task_outcome": state.get("task_outcome"),
+        "app_name": state.get("app_name"),
+        "workspace_id": evidence["workspace_id"],
+        "signature": evidence["signature"],
+        "retry_ordinal": 1,
+        **actual_hashes,
+        "auto_retry": False,
+        "submission_action": "none",
+        "authorized_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    }
+    receipt_path = directory / "settlements" / settlement_name
+    preview = {
+        "ok": True,
+        "status": "dry-run" if dry_run else "terminal_devspace_read_route_refresh_fresh_run_authorized",
+        "safe_for_fresh_run": True,
+        "scope_released": True,
+        "auto_retry": False,
+        "submission_action": "none",
+        "run_dir": str(directory),
+        "settlement_path": str(receipt_path),
+        "settlement_payload": receipt,
+    }
+    if dry_run:
+        return preview
+    if receipt_path.parent.exists() and (
+        receipt_path.parent.is_symlink() or receipt_path.parent.resolve().parent != directory
+    ):
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_SETTLEMENT_PATH_UNSAFE",
+            "append-only settlement directory is outside the exact run",
+        )
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(receipt, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    try:
+        with receipt_path.open("xb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except FileExistsError as exc:
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_SETTLEMENT_EXISTS",
+            "append-only settlement path already exists but did not validate",
+            {"path": str(receipt_path)},
+        ) from exc
+    proven = STATE.proven_terminal_devspace_read_route_refresh_fresh_run_authority(
+        state_path
+    )
+    if proven is None:
+        raise OracleRunError(
+            "DEVSPACE_READ_ROUTE_REFRESH_SETTLEMENT_INVALID",
+            "written append-only settlement failed revalidation",
+        )
+    return {**preview, "settlement": proven, "settlement_sha256": proven["sha256"]}
+
+
 def recover_run(
     run_dir: Path,
     *,
@@ -3781,6 +4232,40 @@ def build_parser() -> argparse.ArgumentParser:
     )
     recursive_parser.add_argument("--reason", required=True)
     recursive_parser.add_argument("--dry-run", action="store_true")
+    terminal_nonexecution_parser = commands.add_parser(
+        "settle-terminal-devspace-nonexecution"
+    )
+    terminal_nonexecution_parser.add_argument("--run-dir", type=Path, required=True)
+    terminal_nonexecution_parser.add_argument("--expected-state-sha256", required=True)
+    terminal_nonexecution_parser.add_argument("--expected-output-sha256", required=True)
+    terminal_nonexecution_parser.add_argument("--expected-transcript-sha256", required=True)
+    terminal_nonexecution_parser.add_argument("--expected-stdout-sha256", required=True)
+    terminal_nonexecution_parser.add_argument("--expected-stderr-sha256", required=True)
+    terminal_nonexecution_parser.add_argument("--expected-mission-sha256", required=True)
+    terminal_nonexecution_parser.add_argument(
+        "--confirmation",
+        choices=(STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,),
+        required=True,
+    )
+    terminal_nonexecution_parser.add_argument("--reason", required=True)
+    terminal_nonexecution_parser.add_argument("--dry-run", action="store_true")
+    read_route_refresh_parser = commands.add_parser(
+        "settle-terminal-devspace-read-route-refresh"
+    )
+    read_route_refresh_parser.add_argument("--run-dir", type=Path, required=True)
+    read_route_refresh_parser.add_argument("--expected-state-sha256", required=True)
+    read_route_refresh_parser.add_argument("--expected-output-sha256", required=True)
+    read_route_refresh_parser.add_argument("--expected-transcript-sha256", required=True)
+    read_route_refresh_parser.add_argument("--expected-stdout-sha256", required=True)
+    read_route_refresh_parser.add_argument("--expected-stderr-sha256", required=True)
+    read_route_refresh_parser.add_argument("--expected-mission-sha256", required=True)
+    read_route_refresh_parser.add_argument(
+        "--confirmation",
+        choices=(STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH,),
+        required=True,
+    )
+    read_route_refresh_parser.add_argument("--reason", required=True)
+    read_route_refresh_parser.add_argument("--dry-run", action="store_true")
     return parser
 
 
@@ -3857,7 +4342,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 reason=args.reason,
                 execution_evidence=evidence,
             )
-        else:
+        elif args.command == "settle-recursive-self-observation":
             payload = settle_recursive_self_observation_fresh_run(
                 args.run_dir,
                 confirmation=args.confirmation,
@@ -3865,6 +4350,32 @@ def main(argv: Sequence[str] | None = None) -> int:
                 expected_state_sha256=args.expected_state_sha256,
                 expected_output_sha256=args.expected_output_sha256,
                 expected_transcript_sha256=args.expected_transcript_sha256,
+                dry_run=args.dry_run,
+            )
+        elif args.command == "settle-terminal-devspace-nonexecution":
+            payload = settle_terminal_devspace_nonexecution_fresh_run(
+                args.run_dir,
+                confirmation=args.confirmation,
+                reason=args.reason,
+                expected_state_sha256=args.expected_state_sha256,
+                expected_output_sha256=args.expected_output_sha256,
+                expected_transcript_sha256=args.expected_transcript_sha256,
+                expected_stdout_sha256=args.expected_stdout_sha256,
+                expected_stderr_sha256=args.expected_stderr_sha256,
+                expected_mission_sha256=args.expected_mission_sha256,
+                dry_run=args.dry_run,
+            )
+        else:
+            payload = settle_terminal_devspace_read_route_refresh_fresh_run(
+                args.run_dir,
+                confirmation=args.confirmation,
+                reason=args.reason,
+                expected_state_sha256=args.expected_state_sha256,
+                expected_output_sha256=args.expected_output_sha256,
+                expected_transcript_sha256=args.expected_transcript_sha256,
+                expected_stdout_sha256=args.expected_stdout_sha256,
+                expected_stderr_sha256=args.expected_stderr_sha256,
+                expected_mission_sha256=args.expected_mission_sha256,
                 dry_run=args.dry_run,
             )
     except STATE.OracleStateError as exc:

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -181,6 +181,25 @@ USER_AUTHORIZED_FRESH_AFTER_RECURSIVE_SELF_OBSERVATION = (
 RECURSIVE_SELF_OBSERVATION_SETTLEMENT_SCHEMA = (
     "codex.chatgpt.oracle-recursive-self-observation-settlement/v1"
 )
+USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION = (
+    "user-authorized-fresh-run-after-terminal-devspace-nonexecution"
+)
+TERMINAL_DEVSPACE_NONEXECUTION_SETTLEMENT_SCHEMA = (
+    "codex.chatgpt.oracle-terminal-devspace-nonexecution-settlement/v1"
+)
+TERMINAL_DEVSPACE_NONEXECUTION_SIGNATURES = frozenset((
+    "terminal-devspace-checkout-502-no-execution",
+    "terminal-devspace-app-tools-unavailable-no-execution",
+))
+USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH = (
+    "user-authorized-fresh-run-after-devspace-read-route-refresh"
+)
+TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SETTLEMENT_SCHEMA = (
+    "codex.chatgpt.oracle-terminal-devspace-read-route-refresh-settlement/v1"
+)
+TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SIGNATURE = (
+    "terminal-devspace-read-chunk-unavailable-after-read-only-probe"
+)
 ORACLE_RECOVERY_STATE_RE = re.compile(r"(?im)^\s*State:\s*[a-z][a-z0-9_-]*\s*$")
 ORACLE_PROFILE_COPY_EBUSY_RE = re.compile(
     r"(?im)^(?:ERROR:\s*|User error \(browser-automation\):\s*)?"
@@ -1871,6 +1890,201 @@ def recursive_self_observation_evidence(
     }
 
 
+def terminal_devspace_nonexecution_evidence(
+    state: dict[str, Any], output_text: str
+) -> dict[str, str] | None:
+    """Recognize a bounded terminal DevSpace failure with explicit nonexecution.
+
+    This signature is intentionally narrower than a generic BLOCKED answer.  A
+    fresh run is safe only when the durable answer binds the exact project and
+    either reports the registered-app checkout 502 with explicit no-work proof,
+    or reports that the exact app exposed no workspace tools and explicitly
+    confirms that it attempted no connector/shell/web fallback and read or
+    modified neither the mission nor AGENTS.md.
+    """
+    run_id = str(state.get("run_id") or "").strip()
+    project_root = str(state.get("project_root") or "").strip()
+    transport = str(state.get("transport") or "").strip().casefold()
+    outcome = str(state.get("task_outcome") or "").strip().casefold()
+    oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
+    slug = str(oracle.get("slug") or "").strip()
+    text = str(output_text or "")
+    folded = text.casefold()
+    marker_matches = TASK_OUTCOME_RE.findall(text)
+    final_nonempty = next((line.strip() for line in reversed(text.splitlines()) if line.strip()), "")
+    expected_marker = {
+        "blocked": "TASK_OUTCOME: BLOCKED",
+        "not_executed": "TASK_OUTCOME: NOT_EXECUTED",
+    }.get(outcome)
+    outage = (
+        "502 upstream or external service errors" in folded
+        and "checkout" in folded
+        and ("workspace id" in folded or "workspaceid" in folded)
+    )
+    korean_nonexecution = all(
+        needle in folded
+        for needle in ("미션 파일을 읽거나", "명령 실행", "파일 변경", "수행하지 않았습니다")
+    )
+    english_nonexecution = all(
+        any(needle in folded for needle in alternatives)
+        for alternatives in (
+            ("did not read the mission", "didn't read the mission"),
+            ("did not run commands", "didn't run commands", "no commands were run"),
+            ("did not change files", "didn't change files", "no files were changed"),
+        )
+    )
+    app_name = str(state.get("app_name") or "").strip().casefold()
+    korean_tools_unavailable = all(
+        needle in folded
+        for needle in (
+            "workspace 도구가 노출되어 있지 않아",
+            "열 수 없습니다",
+            "다른 workspace 커넥터·셸·웹·oracle 우회는 시도하지 않았",
+            "미션 파일이나 agents.md도 읽거나 수정하지 않았",
+        )
+    )
+    english_tools_unavailable = all(
+        any(needle in folded for needle in alternatives)
+        for alternatives in (
+            ("workspace tools are not available", "workspace tools are not exposed"),
+            ("could not open", "unable to open"),
+            ("did not try another connector", "did not attempt another connector"),
+            ("did not use the shell", "did not attempt a shell"),
+            ("did not read or modify the mission", "read or modified neither the mission"),
+        )
+    )
+    tools_unavailable = (
+        bool(app_name)
+        and app_name in folded
+        and (korean_tools_unavailable or english_tools_unavailable)
+    )
+    if (
+        not run_id
+        or not slug
+        or not project_root
+        or project_root.casefold() not in folded
+        or transport not in DEVSPACE_TRANSPORTS
+        or state.get("terminal_harvested") is not True
+        or str(state.get("session_authority") or "") != "terminal"
+        or outcome not in {"blocked", "not_executed"}
+        or len(marker_matches) != 1
+        or marker_matches[0].casefold() != outcome
+        or final_nonempty != expected_marker
+        or not (
+            (outage and (korean_nonexecution or english_nonexecution))
+            or tools_unavailable
+        )
+    ):
+        return None
+    signature = (
+        "terminal-devspace-app-tools-unavailable-no-execution"
+        if tools_unavailable
+        else "terminal-devspace-checkout-502-no-execution"
+    )
+    return {
+        "run_id": run_id,
+        "slug": slug,
+        "signature": signature,
+        "transport": transport,
+        "task_outcome": outcome,
+    }
+
+
+def terminal_devspace_read_route_refresh_evidence(
+    state: dict[str, Any], output_text: str
+) -> dict[str, str] | None:
+    """Recognize one exact read-only canary stopped before its command.
+
+    This is not generic BLOCKED authority.  It covers only the first regular
+    DevSpace qualification attempt that opened and read the bound workspace,
+    found ``read_chunk`` absent from the configured app, and explicitly ran no
+    command and performed no write.  A user-completed app-tool refresh may then
+    authorize one fresh probe through a separate append-only receipt.
+    """
+    run_id = str(state.get("run_id") or "").strip()
+    project_root = str(state.get("project_root") or "").strip()
+    app_name = str(state.get("app_name") or "").strip().casefold()
+    transport = str(state.get("transport") or "").strip().casefold()
+    outcome = str(state.get("task_outcome") or "").strip().casefold()
+    oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
+    profile = state.get("profile") if isinstance(state.get("profile"), dict) else {}
+    slug = str(oracle.get("slug") or "").strip()
+    text = str(output_text or "")
+    folded = text.casefold()
+    marker_matches = TASK_OUTCOME_RE.findall(text)
+    final_nonempty = next((line.strip() for line in reversed(text.splitlines()) if line.strip()), "")
+    project_candidates = {
+        project_root.casefold(),
+        project_root.replace("\\", "\\\\").casefold(),
+    }
+    workspace_ids = re.findall(
+        r"(?im)^\s*\*\s*workspace id:\s*`(?P<workspace>ws_[a-z0-9]+)`\s*$",
+        text,
+    )
+    required_korean = (
+        f"* 앱: `{app_name}`",
+        "* 모드: `checkout`",
+        "* 적용 `agents.md`: 전체 확인 완료",
+        "* 미션 파일: 전체 확인 완료",
+        "* 보고서 첫 markdown heading:",
+        "* 저장소 쓰기 작업: 없음",
+        "금지된 oracle controller/run 관련 파일·상태·프로세스: 검사하거나 호출하지 않음",
+        f"현재 `{app_name}` 앱이 이 workspace에서 노출한 도구에 `read_chunk`가 없으며",
+        "`chunk` 관련 도구가 반환되지 않았습니다",
+        "따라서 다음 단계인 정확히 한 번의 `git status --short --branch` 명령도 실행하지 않았습니다",
+        "* 명령 실행: **안 함**",
+        "* exit code: **미확인**",
+        "* command output: **없음**",
+    )
+    if (
+        not run_id
+        or not slug
+        or not project_root
+        or not app_name
+        or not any(candidate and candidate in folded for candidate in project_candidates)
+        or transport != "devspace"
+        or str(profile.get("model") or "").casefold() != "gpt-5.6"
+        or str(profile.get("model_strategy") or "") != "select"
+        or str(profile.get("thinking_time") or "") != "extra-high"
+        or state.get("terminal_harvested") is not True
+        or str(state.get("session_authority") or "") != "terminal"
+        or outcome != "blocked"
+        or len(marker_matches) != 1
+        or marker_matches[0].casefold() != outcome
+        or final_nonempty != "TASK_OUTCOME: BLOCKED"
+        or len(workspace_ids) != 1
+        or not all(needle in folded for needle in required_korean)
+    ):
+        return None
+    return {
+        "run_id": run_id,
+        "slug": slug,
+        "signature": TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SIGNATURE,
+        "transport": transport,
+        "task_outcome": outcome,
+        "app_name": app_name,
+        "workspace_id": workspace_ids[0],
+    }
+
+
+def terminal_devspace_read_route_refresh_mission_contract(mission_text: str) -> bool:
+    """Require the exact read-only qualification boundary before settlement."""
+    folded = str(mission_text or "").casefold()
+    return all(
+        needle in folded
+        for needle in (
+            "read_chunk",
+            "offsetbytes=0",
+            "eof=true",
+            "git status --short --branch",
+            "run exactly one command",
+            "run no other command",
+            "do not create, edit, delete, rename, stage, commit",
+            "if any required operation fails, report the concrete blocker and stop",
+        )
+    )
+
+
 def proven_recursive_self_observation_fresh_run_authority(
     state_path: Path,
 ) -> dict[str, Any] | None:
@@ -1901,10 +2115,11 @@ def proven_recursive_self_observation_fresh_run_authority(
         output_text = output_path.read_text(encoding="utf-8", errors="strict")
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, OracleStateError, ValueError):
         return None
+    if not isinstance(receipt, dict):
+        return None
     oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
     if (
-        not isinstance(receipt, dict)
-        or receipt.get("schema") != RECURSIVE_SELF_OBSERVATION_SETTLEMENT_SCHEMA
+        receipt.get("schema") != RECURSIVE_SELF_OBSERVATION_SETTLEMENT_SCHEMA
         or receipt.get("confirmation")
         != USER_AUTHORIZED_FRESH_AFTER_RECURSIVE_SELF_OBSERVATION
         or not str(receipt.get("reason") or "").strip()
@@ -1924,6 +2139,186 @@ def proven_recursive_self_observation_fresh_run_authority(
     ):
         return None
     return {**receipt, "path": str(receipt_path), "sha256": hashlib.sha256(receipt_bytes).hexdigest()}
+
+
+def proven_terminal_devspace_nonexecution_fresh_run_authority(
+    state_path: Path,
+) -> dict[str, Any] | None:
+    """Revalidate a task-bound, append-only terminal nonexecution authority."""
+    directory = state_path.parent.resolve(strict=True)
+    receipt_path = directory / "settlements" / "terminal-devspace-nonexecution-fresh-run.json"
+    if not receipt_path.is_file() or receipt_path.is_symlink():
+        return None
+
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError(f"duplicate settlement key: {key}")
+            value[key] = item
+        return value
+
+    try:
+        receipt_bytes = receipt_path.read_bytes()
+        receipt = json.loads(
+            receipt_bytes.decode("utf-8", errors="strict"),
+            object_pairs_hook=reject_duplicate_keys,
+        )
+        state = load_state(state_path)
+        artifacts = state.get("artifacts") if isinstance(state.get("artifacts"), dict) else {}
+        output_path = Path(str(artifacts.get("output") or directory / "output.md")).resolve(strict=True)
+        transcript_path = Path(
+            str(artifacts.get("transcript") or directory / "transcript.md")
+        ).resolve(strict=True)
+        stdout_path = Path(str(artifacts.get("stdout") or directory / "stdout.log")).resolve(strict=True)
+        stderr_path = Path(str(artifacts.get("stderr") or directory / "stderr.log")).resolve(strict=True)
+        mission_path = (directory / "mission.md").resolve(strict=True)
+        output_text = output_path.read_text(encoding="utf-8", errors="strict")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, OracleStateError, ValueError):
+        return None
+    if not isinstance(receipt, dict):
+        return None
+    oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
+    mission = state.get("mission") if isinstance(state.get("mission"), dict) else {}
+    exact_paths = {
+        "output": (output_path, directory / "output.md"),
+        "transcript": (transcript_path, directory / "transcript.md"),
+        "stdout": (stdout_path, directory / "stdout.log"),
+        "stderr": (stderr_path, directory / "stderr.log"),
+        "mission": (mission_path, directory / "mission.md"),
+    }
+    if any(
+        actual != expected.resolve() or expected.is_symlink() or not actual.is_file()
+        for actual, expected in exact_paths.values()
+    ) or state_path.is_symlink() or state_path.resolve(strict=True) != (directory / "state.json"):
+        return None
+    evidence = terminal_devspace_nonexecution_evidence(state, output_text)
+    authorized_thread = str(receipt.get("authorized_source_thread_id") or "").strip().casefold()
+    if (
+        receipt.get("schema") != TERMINAL_DEVSPACE_NONEXECUTION_SETTLEMENT_SCHEMA
+        or receipt.get("confirmation")
+        != USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION
+        or not str(receipt.get("reason") or "").strip()
+        or SOURCE_THREAD_ID_RE.fullmatch(authorized_thread) is None
+        or receipt.get("run_id") != state.get("run_id")
+        or receipt.get("project_root") != state.get("project_root")
+        or receipt.get("slug") != oracle.get("slug")
+        or receipt.get("transport") != state.get("transport")
+        or receipt.get("task_outcome") != state.get("task_outcome")
+        or receipt.get("signature") not in TERMINAL_DEVSPACE_NONEXECUTION_SIGNATURES
+        or receipt_path.resolve(strict=True).parent.parent != directory
+        or receipt.get("state_sha256") != sha256_file(state_path)
+        or receipt.get("output_sha256") != sha256_file(output_path)
+        or receipt.get("transcript_sha256") != sha256_file(transcript_path)
+        or receipt.get("stdout_sha256") != sha256_file(stdout_path)
+        or receipt.get("stderr_sha256") != sha256_file(stderr_path)
+        or receipt.get("mission_sha256") != sha256_file(mission_path)
+        or receipt.get("mission_sha256") != mission.get("sha256")
+        or evidence is None
+        or receipt.get("signature") != evidence.get("signature")
+        or receipt.get("auto_retry") is not False
+        or receipt.get("submission_action") != "none"
+    ):
+        return None
+    return {
+        **receipt,
+        "authorized_source_thread_id": authorized_thread,
+        "path": str(receipt_path),
+        "sha256": hashlib.sha256(receipt_bytes).hexdigest(),
+    }
+
+
+def proven_terminal_devspace_read_route_refresh_fresh_run_authority(
+    state_path: Path,
+) -> dict[str, Any] | None:
+    """Revalidate one task-bound, append-only read-route refresh authority."""
+    directory = state_path.parent.resolve(strict=True)
+    receipt_path = directory / "settlements" / "terminal-devspace-read-route-refresh-fresh-run.json"
+    if not receipt_path.is_file() or receipt_path.is_symlink():
+        return None
+
+    def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        value: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in value:
+                raise ValueError(f"duplicate settlement key: {key}")
+            value[key] = item
+        return value
+
+    try:
+        receipt_bytes = receipt_path.read_bytes()
+        receipt = json.loads(
+            receipt_bytes.decode("utf-8", errors="strict"),
+            object_pairs_hook=reject_duplicate_keys,
+        )
+        state = load_state(state_path)
+        artifacts = state.get("artifacts") if isinstance(state.get("artifacts"), dict) else {}
+        output_path = Path(str(artifacts.get("output") or directory / "output.md")).resolve(strict=True)
+        transcript_path = Path(
+            str(artifacts.get("transcript") or directory / "transcript.md")
+        ).resolve(strict=True)
+        stdout_path = Path(str(artifacts.get("stdout") or directory / "stdout.log")).resolve(strict=True)
+        stderr_path = Path(str(artifacts.get("stderr") or directory / "stderr.log")).resolve(strict=True)
+        mission_path = (directory / "mission.md").resolve(strict=True)
+        output_text = output_path.read_text(encoding="utf-8", errors="strict")
+        mission_text = mission_path.read_text(encoding="utf-8", errors="strict")
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, OracleStateError, ValueError):
+        return None
+    if not isinstance(receipt, dict):
+        return None
+    oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
+    mission = state.get("mission") if isinstance(state.get("mission"), dict) else {}
+    exact_paths = {
+        "output": (output_path, directory / "output.md"),
+        "transcript": (transcript_path, directory / "transcript.md"),
+        "stdout": (stdout_path, directory / "stdout.log"),
+        "stderr": (stderr_path, directory / "stderr.log"),
+        "mission": (mission_path, directory / "mission.md"),
+    }
+    if any(
+        actual != expected.resolve() or expected.is_symlink() or not actual.is_file()
+        for actual, expected in exact_paths.values()
+    ) or state_path.is_symlink() or state_path.resolve(strict=True) != (directory / "state.json"):
+        return None
+    evidence = terminal_devspace_read_route_refresh_evidence(state, output_text)
+    authorized_thread = str(receipt.get("authorized_source_thread_id") or "").strip().casefold()
+    if (
+        receipt.get("schema") != TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SETTLEMENT_SCHEMA
+        or receipt.get("confirmation")
+        != USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH
+        or not str(receipt.get("reason") or "").strip()
+        or SOURCE_THREAD_ID_RE.fullmatch(authorized_thread) is None
+        or source_thread_id_from_state(state) != authorized_thread
+        or receipt.get("run_id") != state.get("run_id")
+        or receipt.get("project_root") != state.get("project_root")
+        or receipt.get("slug") != oracle.get("slug")
+        or receipt.get("transport") != state.get("transport")
+        or receipt.get("task_outcome") != state.get("task_outcome")
+        or receipt.get("app_name") != state.get("app_name")
+        or receipt.get("signature") != TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SIGNATURE
+        or receipt.get("retry_ordinal") != 1
+        or receipt_path.resolve(strict=True).parent.parent != directory
+        or receipt.get("state_sha256") != sha256_file(state_path)
+        or receipt.get("output_sha256") != sha256_file(output_path)
+        or receipt.get("transcript_sha256") != sha256_file(transcript_path)
+        or receipt.get("stdout_sha256") != sha256_file(stdout_path)
+        or receipt.get("stderr_sha256") != sha256_file(stderr_path)
+        or receipt.get("mission_sha256") != sha256_file(mission_path)
+        or receipt.get("mission_sha256") != mission.get("sha256")
+        or evidence is None
+        or receipt.get("signature") != evidence.get("signature")
+        or receipt.get("workspace_id") != evidence.get("workspace_id")
+        or not terminal_devspace_read_route_refresh_mission_contract(mission_text)
+        or receipt.get("auto_retry") is not False
+        or receipt.get("submission_action") != "none"
+    ):
+        return None
+    return {
+        **receipt,
+        "authorized_source_thread_id": authorized_thread,
+        "path": str(receipt_path),
+        "sha256": hashlib.sha256(receipt_bytes).hexdigest(),
+    }
 
 
 def _state_has_conversation_url(state: dict[str, Any]) -> bool:

--- a/bin/codex_web_gpt_onboarding.py
+++ b/bin/codex_web_gpt_onboarding.py
@@ -256,6 +256,7 @@ def onboarding_plan(
             "environment": {
                 "DEVSPACE_TOOL_MODE": "full",
                 "DEVSPACE_OAUTH_SCOPES": "devspace,offline_access",
+                "DEVSPACE_SUBAGENTS": "false",
             },
         },
         {

--- a/bin/codexpro_macos_launchd.py
+++ b/bin/codexpro_macos_launchd.py
@@ -53,13 +53,14 @@ def service_plists(
         "devspace": {
             **common,
             "Label": LABELS["devspace"],
-            "ProgramArguments": [npx, "--yes", "@waishnav/devspace@1.0.7", "serve"],
+            "ProgramArguments": [npx, "--yes", "@waishnav/devspace@1.0.8", "serve"],
             "RunAtLoad": True,
             "KeepAlive": {"SuccessfulExit": False},
             "ThrottleInterval": 15,
             "EnvironmentVariables": {
                 "DEVSPACE_TOOL_MODE": "full",
                 "DEVSPACE_OAUTH_SCOPES": "devspace,offline_access",
+                "DEVSPACE_SUBAGENTS": "false",
                 "PATH": str(Path(npx).parent) + ":/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
             },
             "WorkingDirectory": str(project_root),

--- a/bin/devspace-compat/1.0.8/artifact-audit-readonly.patch
+++ b/bin/devspace-compat/1.0.8/artifact-audit-readonly.patch
@@ -1,0 +1,16 @@
+diff --git a/dist/artifact-tools.js b/dist/artifact-tools.js
+--- a/dist/artifact-tools.js
++++ b/dist/artifact-tools.js
+@@ -31,4 +31,4 @@ export function isArtifactDownloadSupportedPlatform(platform = process.platform
+     return ARTIFACT_DOWNLOAD_PLATFORMS.has(platform);
+ }
+-export function registerArtifactTools(server, { config, workspaces, incomingArtifactAdapters = [], }) {
++export function registerArtifactTools(server, { config, workspaces, incomingArtifactAdapters = [], beforeMutation = () => {}, }) {
+     const incomingRegistry = new IncomingArtifactAdapterRegistry(incomingArtifactAdapters);
+@@ -48,4 +48,5 @@ export function registerArtifactTools(server, { config, workspaces, incomingArti
+         _meta: { "openai/fileParams": ["file"] },
+         annotations: ARTIFACT_WRITE_ANNOTATIONS,
+-    }, async (input) => executeArtifactTool(config, input, async () => {
++    }, async (input, { _meta }) => executeArtifactTool(config, input, async () => {
++        beforeMutation(input, _meta);
+         const workspace = workspaces.getWorkspace(input.workspaceId);

--- a/bin/devspace-compat/1.0.8/oauth-refresh-replay.patch
+++ b/bin/devspace-compat/1.0.8/oauth-refresh-replay.patch
@@ -1,0 +1,108 @@
+diff --git a/dist/oauth-provider.js b/dist/oauth-provider.js
+index e0c32d9..e55d95c 100644
+--- a/dist/oauth-provider.js
++++ b/dist/oauth-provider.js
+@@ -3,6 +3,8 @@ import { AccessDeniedError, InvalidGrantError, InvalidRequestError, InvalidToken
+ import { checkResourceAllowed, resourceUrlFromServerUrl } from "@modelcontextprotocol/sdk/shared/auth-utils.js";
+ import { SqliteOAuthClientsStore, SqliteOAuthStore } from "./oauth-store.js";
+ const CODE_TTL_MS = 5 * 60 * 1000;
++const REFRESH_REPLAY_GRACE_MS = 30 * 1000;
++const MAX_REFRESH_REPLAYS = 32;
+ function randomToken() {
+     return randomBytes(32).toString("base64url");
+ }
+@@ -79,6 +81,7 @@ export class SingleUserOAuthProvider {
+     config;
+     clientsStore;
+     codes = new Map();
++    refreshReplays = new Map();
+     oauthStore;
+     resourceServerUrl;
+     constructor(config, resourceServerUrl, stateDir) {
+@@ -144,9 +147,25 @@ export class SingleUserOAuthProvider {
+         return this.issueTokens(client.client_id, record.params.scopes ?? this.config.scopes, record.params.resource);
+     }
+     async exchangeRefreshToken(client, refreshToken, scopes, resource) {
++        const nowMs = Date.now();
+         const refreshTokenHash = hashToken(refreshToken);
++        this.pruneRefreshReplays(nowMs);
+         const record = this.oauthStore.getRefreshToken(refreshTokenHash);
+-        if (!record || record.clientId !== client.client_id || record.expiresAt < Math.floor(Date.now() / 1000)) {
++        if (!record) {
++            const replay = this.refreshReplays.get(refreshTokenHash);
++            const requestedScopes = scopes ?? replay?.scopes;
++            const requestedResource = resource?.href ?? replay?.resource;
++            if (replay &&
++                replay.expiresAtMs >= nowMs &&
++                replay.clientId === client.client_id &&
++                requestedScopes &&
++                sameStringSet(requestedScopes, replay.scopes) &&
++                requestedResource === replay.resource) {
++                return { ...replay.tokens };
++            }
++            throw new InvalidGrantError("Invalid refresh token");
++        }
++        if (record.clientId !== client.client_id || record.expiresAt < Math.floor(nowMs / 1000)) {
+             throw new InvalidGrantError("Invalid refresh token");
+         }
+         if (resource && !checkResourceAllowed({ requestedResource: resource, configuredResource: this.resourceServerUrl })) {
+@@ -156,7 +175,22 @@ export class SingleUserOAuthProvider {
+         if (!requestedScopes.every((scope) => record.scopes.includes(scope))) {
+             throw new AccessDeniedError("Refresh token cannot grant requested scopes");
+         }
+-        return this.issueTokens(client.client_id, requestedScopes, resource ?? (record.resource ? new URL(record.resource) : undefined), refreshTokenHash);
++        const effectiveResource = resource ?? (record.resource ? new URL(record.resource) : undefined);
++        const tokens = this.issueTokens(client.client_id, requestedScopes, effectiveResource, refreshTokenHash);
++        this.refreshReplays.set(refreshTokenHash, {
++            clientId: client.client_id,
++            scopes: [...requestedScopes],
++            resource: effectiveResource?.href,
++            expiresAtMs: nowMs + REFRESH_REPLAY_GRACE_MS,
++            tokens: { ...tokens },
++        });
++        while (this.refreshReplays.size > MAX_REFRESH_REPLAYS) {
++            const oldest = this.refreshReplays.keys().next().value;
++            if (oldest === undefined)
++                break;
++            this.refreshReplays.delete(oldest);
++        }
++        return tokens;
+     }
+     async verifyAccessToken(token) {
+         const record = this.oauthStore.getAccessToken(hashToken(token));
+@@ -175,10 +209,25 @@ export class SingleUserOAuthProvider {
+         const hashed = hashToken(request.token);
+         this.oauthStore.deleteAccessToken(hashed);
+         this.oauthStore.deleteRefreshToken(hashed);
++        for (const [consumedHash, replay] of this.refreshReplays) {
++            if (consumedHash === hashed ||
++                hashToken(replay.tokens.access_token) === hashed ||
++                hashToken(replay.tokens.refresh_token) === hashed) {
++                this.refreshReplays.delete(consumedHash);
++            }
++        }
+     }
+     close() {
++        this.refreshReplays.clear();
+         this.oauthStore.close();
+     }
++    pruneRefreshReplays(nowMs) {
++        for (const [consumedHash, replay] of this.refreshReplays) {
++            if (replay.expiresAtMs < nowMs) {
++                this.refreshReplays.delete(consumedHash);
++            }
++        }
++    }
+     validCodeRecord(client, authorizationCode) {
+         const record = this.codes.get(authorizationCode);
+         if (!record || record.clientId !== client.client_id || record.expiresAtMs < Date.now()) {
+@@ -232,6 +281,9 @@ function authorizationFormFields(client, params) {
+         resource: params.resource?.href,
+     };
+ }
++function sameStringSet(left, right) {
++    return left.length === right.length && left.every((value) => right.includes(value));
++}
+ function hashToken(token) {
+     return createHash("sha256").update(token).digest("base64url");
+ }

--- a/bin/devspace-compat/1.0.8/tool-read-receipts.patch
+++ b/bin/devspace-compat/1.0.8/tool-read-receipts.patch
@@ -1,0 +1,251 @@
+diff --git a/dist/server.js b/dist/server.js
+index 9987ca0..5ad9984 100644
+--- a/dist/server.js
++++ b/dist/server.js
+@@ -1,6 +1,7 @@
+ import { createHash, randomUUID } from "node:crypto";
+ import { createReadStream, readFileSync } from "node:fs";
+ import { access, lstat, mkdir, open, realpath, rename, stat, unlink } from "node:fs/promises";
++import { homedir } from "node:os";
+ import { isAbsolute, join, relative, resolve, sep } from "node:path";
+ import { fileURLToPath } from "node:url";
+ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+@@ -102,6 +103,69 @@ const toolNames = {
+     shell: "bash",
+ };
+ const MAX_READ_CHUNK_BYTES = 24 * 1024;
++const AUDIT_NONCE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$/;
++function validateAuditNonce(auditNonce) {
++    if (auditNonce === undefined) return undefined;
++    if (typeof auditNonce !== "string" || !AUDIT_NONCE_PATTERN.test(auditNonce)) throw new Error("auditNonce must be 16-128 ASCII letters, digits, dot, underscore, colon, or hyphen");
++    return auditNonce;
++}
++function requestedReceiptPath(path) {
++    if (typeof path !== "string" || path === "" || isAbsolute(path) || /^[A-Za-z]:[\/]/.test(path) || path.startsWith("\\")) return null;
++    return path.replaceAll("\\", "/");
++}
++function toolReadReceiptRoot() { return join(homedir(), ".devspace", "state", "tool-read-receipts"); }
++const auditReadonlyScopes = new Map();
++const AUDIT_RECEIPT_SEQUENCE = ["open_workspace", "read", "read_chunk"];
++function auditReadonlyScopeId(_meta) {
++    const scope = openAiConversationScopeId(_meta);
++    return typeof scope === "string" && scope.trim() !== "" ? scope : null;
++}
++function registerAuditReadonlyWorkspaceOpen(_meta, auditNonce) {
++    const scope = auditReadonlyScopeId(_meta);
++    if (auditNonce === undefined) {
++        if (!scope) return null;
++        const existing = auditReadonlyScopes.get(scope);
++        if (existing?.auditNonce) throw new Error("open_workspace without auditNonce is disabled for this audit-readonly conversation scope");
++        if (!existing) auditReadonlyScopes.set(scope, { auditNonce: null, nextReceiptStep: null, priorTool: "open_workspace" });
++        return scope;
++    }
++    const nonce = validateAuditNonce(auditNonce);
++    if (!scope) throw new Error("auditNonce requires a nonempty OpenAI conversation scope");
++    const existing = auditReadonlyScopes.get(scope);
++    if (existing?.auditNonce === null) throw new Error("auditNonce open_workspace must precede every ordinary workspace, process, or mutation tool in its conversation scope");
++    if (existing?.auditNonce && existing.auditNonce !== nonce) throw new Error("auditNonce does not match the audit-readonly conversation scope");
++    if (!existing) auditReadonlyScopes.set(scope, { auditNonce: nonce, nextReceiptStep: 1, priorTool: null });
++    return scope;
++}
++function assertAuditReadonly(_meta, tool) {
++    const scope = auditReadonlyScopeId(_meta);
++    if (!scope) return;
++    const existing = auditReadonlyScopes.get(scope);
++    if (existing?.auditNonce) throw new Error(`${tool} is disabled for this audit-readonly conversation scope`);
++    if (!existing) auditReadonlyScopes.set(scope, { auditNonce: null, nextReceiptStep: null, priorTool: tool });
++}
++function reserveAuditReceipt(_meta, auditNonce, tool) {
++    if (auditNonce === undefined) return { conversationScopeId: openAiConversationScopeId(_meta) ?? null, auditStep: null };
++    const nonce = validateAuditNonce(auditNonce);
++    const scope = auditReadonlyScopeId(_meta);
++    const state = scope ? auditReadonlyScopes.get(scope) : null;
++    if (!scope || !state?.auditNonce || state.auditNonce !== nonce) throw new Error("audit receipt requires the exact auditNonce open_workspace conversation scope");
++    const step = state.nextReceiptStep;
++    if (!Number.isInteger(step) || AUDIT_RECEIPT_SEQUENCE[step - 1] !== tool) throw new Error(`audit receipt tool order invalid: expected ${AUDIT_RECEIPT_SEQUENCE[step - 1] ?? "no-more-tools"}, received ${tool}`);
++    state.nextReceiptStep += 1;
++    return { conversationScopeId: scope, auditStep: step };
++}
++export async function writeToolReadReceipt({ auditNonce, auditStep = null, tool, workspaceId, canonicalRoot, requestedRelativePath = null, readChunkSha256 = null, readChunkOffsetBytes = null, readChunkBytesReturned = null, readChunkTotalBytes = null, readChunkEof = null, conversationScopeId = null, }, receiptRoot = toolReadReceiptRoot()) {
++    if (auditNonce === undefined) return null;
++    if (!Number.isInteger(auditStep) || auditStep < 1 || auditStep > 3) throw new Error("auditStep must be an integer from 1 through 3");
++    const receipt = { schema: "codex.devspace.tool-read-receipt/v1", receiptId: randomUUID(), auditNonce: validateAuditNonce(auditNonce) ?? null, auditStep, tool, workspaceId, canonicalRoot, requestedRelativePath, readChunkSha256, readChunkOffsetBytes, readChunkBytesReturned, readChunkTotalBytes, readChunkEof, conversationScopeId, timestamp: new Date().toISOString() };
++    await mkdir(receiptRoot, { recursive: true });
++    const receiptPath = join(receiptRoot, receipt.receiptId + ".json");
++    const handle = await open(receiptPath, "wx", 0o600);
++    try { await handle.writeFile(JSON.stringify(receipt) + "\n", "utf8"); await handle.sync(); }
++    finally { await handle.close(); }
++    return { receiptId: receipt.receiptId, receiptPath, receipt };
++}
+ export async function readUtf8Chunk(path, offsetBytes, limitBytes) {
+     const handle = await open(path, "r");
+     try {
+@@ -771,7 +835,8 @@ function registerCodexProcessTools(server, config, workspaces, processSessions)
+         outputSchema: processOutputSchema(),
+         ...toolWidgetDescriptorMeta(config, "shell"),
+         annotations: SHELL_TOOL_ANNOTATIONS,
+-    }, async ({ workspaceId, cmd, tty, columns, rows, workingDirectory, yieldTimeMs, maxOutputTokens }) => {
++    }, async ({ workspaceId, cmd, tty, columns, rows, workingDirectory, yieldTimeMs, maxOutputTokens }, { _meta }) => {
++        assertAuditReadonly(_meta, "exec_command");
+         const startedAt = performance.now();
+         const workspace = workspaces.getWorkspace(workspaceId);
+         const cwd = workspaces.resolveWorkingDirectory(workspace, workingDirectory);
+@@ -830,7 +895,8 @@ function registerCodexProcessTools(server, config, workspaces, processSessions)
+         outputSchema: processOutputSchema(),
+         ...toolWidgetDescriptorMeta(config, "shell"),
+         annotations: SHELL_TOOL_ANNOTATIONS,
+-    }, async ({ workspaceId, sessionId, chars, columns, rows, yieldTimeMs, maxOutputTokens }) => {
++    }, async ({ workspaceId, sessionId, chars, columns, rows, yieldTimeMs, maxOutputTokens }, { _meta }) => {
++        assertAuditReadonly(_meta, "write_stdin");
+         const startedAt = performance.now();
+         workspaces.getWorkspace(workspaceId);
+         const snapshot = await processSessions.write({
+@@ -905,6 +971,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+                 .string()
+                 .optional()
+                 .describe("Git ref to base a worktree on. Only used with mode=\"worktree\". Defaults to HEAD."),
++            auditNonce: z.string().regex(AUDIT_NONCE_PATTERN).optional().describe("Optional 16-128 character audit nonce for a local immutable tool-read receipt."),
+         },
+         outputSchema: {
+             workspaceId: z.string(),
+@@ -931,7 +998,8 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+         },
+         ...toolWidgetDescriptorMeta(config, "workspace"),
+         annotations: { readOnlyHint: true },
+-    }, async ({ path, mode, baseRef }, { _meta }) => {
++    }, async ({ path, mode, baseRef, auditNonce }, { _meta }) => {
++        registerAuditReadonlyWorkspaceOpen(_meta, auditNonce);
+         const startedAt = performance.now();
+         const { workspace, agentsFiles, availableAgentsFiles, workspaceReused, includeBootstrapContext, } = await workspaces.openWorkspace({ path, mode, baseRef }, { conversationScopeId: openAiConversationScopeId(_meta) });
+         if (config.widgets === "changes") {
+@@ -1014,6 +1082,9 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+                 ].filter(Boolean).join("\n"),
+             },
+         ];
++        const auditReceipt = reserveAuditReceipt(_meta, auditNonce, toolNames.openWorkspace);
++        const auditReceiptResult = await writeToolReadReceipt({ auditNonce, auditStep: auditReceipt.auditStep, tool: toolNames.openWorkspace, workspaceId: workspace.id, canonicalRoot: await realpath(workspace.root), conversationScopeId: auditReceipt.conversationScopeId });
++        if (auditReceiptResult) resultContent.push(textBlock(`Audit receipt ID: ${auditReceiptResult.receiptId}`));
+         logToolCall(config, {
+             tool: "open_workspace",
+             workspaceId: workspace.id,
+@@ -1102,11 +1173,12 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+                 .positive()
+                 .optional()
+                 .describe("Maximum number of lines to read."),
++            auditNonce: z.string().regex(AUDIT_NONCE_PATTERN).optional().describe("Optional 16-128 character audit nonce for a local immutable tool-read receipt."),
+         },
+         outputSchema: resultOutputSchema(),
+         ...toolWidgetDescriptorMeta(config, "read"),
+         annotations: { readOnlyHint: true },
+-    }, async ({ workspaceId, ...input }) => {
++    }, async ({ workspaceId, auditNonce, ...input }, { _meta }) => {
+         const startedAt = performance.now();
+         const workspace = workspaces.getWorkspace(workspaceId);
+         const readPath = workspaces.resolveReadPath(workspace, input.path);
+@@ -1124,6 +1196,9 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             return response;
+         }
+         workspaces.markReadPathLoaded(workspace, readPath);
++        const auditReceipt = reserveAuditReceipt(_meta, auditNonce, toolNames.read);
++        const auditReceiptResult = await writeToolReadReceipt({ auditNonce, auditStep: auditReceipt.auditStep, tool: toolNames.read, workspaceId, canonicalRoot: await realpath(workspace.root), requestedRelativePath: requestedReceiptPath(input.path), conversationScopeId: auditReceipt.conversationScopeId });
++        if (auditReceiptResult) response.content.push(textBlock(`Audit receipt ID: ${auditReceiptResult.receiptId}`));
+         const summary = {
+             ...textSummary(response.content),
+             offset: input.offset ?? 1,
+@@ -1160,6 +1235,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             path: z.string().describe("Regular UTF-8 file path, relative to the workspace root."),
+             offsetBytes: z.number().int().nonnegative().default(0).describe("Zero-based UTF-8 byte boundary. Reuse nextOffsetBytes from the previous response."),
+             limitBytes: z.number().int().positive().max(MAX_READ_CHUNK_BYTES).default(MAX_READ_CHUNK_BYTES).describe(`Maximum bytes to return, capped at ${MAX_READ_CHUNK_BYTES}.`),
++            auditNonce: z.string().regex(AUDIT_NONCE_PATTERN).optional().describe("Optional 16-128 character audit nonce for a local immutable tool-read receipt."),
+         },
+         outputSchema: {
+             content: z.string(),
+@@ -1172,16 +1248,18 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+         },
+         ...toolWidgetDescriptorMeta(config, "read"),
+         annotations: { readOnlyHint: true },
+-    }, async ({ workspaceId, path, offsetBytes, limitBytes }) => {
++    }, async ({ workspaceId, path, offsetBytes, limitBytes, auditNonce }, { _meta }) => {
+         const startedAt = performance.now();
+         const workspace = workspaces.getWorkspace(workspaceId);
+         const readPath = workspaces.resolveReadPath(workspace, path);
+         try {
+             const result = await readUtf8Chunk(readPath.absolutePath, offsetBytes, limitBytes);
+             workspaces.markReadPathLoaded(workspace, readPath);
++            const auditReceipt = reserveAuditReceipt(_meta, auditNonce, toolNames.readChunk);
++            const auditReceiptResult = await writeToolReadReceipt({ auditNonce, auditStep: auditReceipt.auditStep, tool: toolNames.readChunk, workspaceId, canonicalRoot: await realpath(workspace.root), requestedRelativePath: requestedReceiptPath(path), readChunkSha256: result.eof ? result.sha256 : null, readChunkOffsetBytes: result.offsetBytes, readChunkBytesReturned: result.bytesReturned, readChunkTotalBytes: result.totalBytes, readChunkEof: result.eof, conversationScopeId: auditReceipt.conversationScopeId });
+             logToolCall(config, { tool: toolNames.readChunk, workspaceId, path, success: true, durationMs: Math.round(performance.now() - startedAt) });
+             return {
+-                content: [textBlock(result.content)], structuredContent: result,
++                content: [textBlock(result.content), ...(auditReceiptResult ? [textBlock(`Audit receipt ID: ${auditReceiptResult.receiptId}`)] : [])], structuredContent: result,
+                 _meta: { tool: toolNames.readChunk, card: { workspaceId, path, summary: { offsetBytes: result.offsetBytes, bytesReturned: result.bytesReturned, totalBytes: result.totalBytes, eof: result.eof, sha256: result.sha256 } } },
+             };
+         }
+@@ -1207,7 +1285,8 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             outputSchema: resultOutputSchema(),
+             ...toolWidgetDescriptorMeta(config, "write"),
+             annotations: WRITE_TOOL_ANNOTATIONS,
+-        }, async ({ workspaceId, ...input }) => {
++        }, async ({ workspaceId, ...input }, { _meta }) => {
++            assertAuditReadonly(_meta, toolNames.write);
+             const startedAt = performance.now();
+             const workspace = workspaces.getWorkspace(workspaceId);
+             workspaces.resolvePath(workspace, input.path);
+@@ -1280,7 +1359,8 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             }),
+             ...toolWidgetDescriptorMeta(config, "edit"),
+             annotations: EDIT_TOOL_ANNOTATIONS,
+-        }, async ({ workspaceId, ...input }) => {
++        }, async ({ workspaceId, ...input }, { _meta }) => {
++            assertAuditReadonly(_meta, toolNames.edit);
+             const startedAt = performance.now();
+             const workspace = workspaces.getWorkspace(workspaceId);
+             workspaces.resolvePath(workspace, input.path);
+@@ -1354,7 +1434,8 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             }),
+             ...toolWidgetDescriptorMeta(config, "edit"),
+             annotations: EDIT_TOOL_ANNOTATIONS,
+-        }, async ({ workspaceId, patch }) => {
++        }, async ({ workspaceId, patch }, { _meta }) => {
++            assertAuditReadonly(_meta, "apply_patch");
+             const startedAt = performance.now();
+             const workspace = workspaces.getWorkspace(workspaceId);
+             const applied = await applyPatch(workspace.root, patch);
+@@ -1647,7 +1728,8 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             outputSchema: resultOutputSchema(),
+             ...toolWidgetDescriptorMeta(config, "shell"),
+             annotations: SHELL_TOOL_ANNOTATIONS,
+-        }, async ({ workspaceId, workingDirectory, ...input }) => {
++        }, async ({ workspaceId, workingDirectory, ...input }, { _meta }) => {
++            assertAuditReadonly(_meta, toolNames.shell);
+             const startedAt = performance.now();
+             const workspace = workspaces.getWorkspace(workspaceId);
+             const cwd = workspaces.resolveWorkingDirectory(workspace, workingDirectory);
+@@ -1710,7 +1792,8 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             }),
+             ...toolWidgetDescriptorMeta(config, "edit"),
+             annotations: DELETE_TOOL_ANNOTATIONS,
+-        }, async ({ workspaceId, path }) => {
++        }, async ({ workspaceId, path }, { _meta }) => {
++            assertAuditReadonly(_meta, toolNames.delete);
+             const startedAt = performance.now();
+             const workspace = workspaces.getWorkspace(workspaceId);
+             let deletion;
+@@ -1772,7 +1855,8 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             }),
+             ...toolWidgetDescriptorMeta(config, "edit"),
+             annotations: TRASH_TOOL_ANNOTATIONS,
+-        }, async ({ workspaceId, path }) => {
++        }, async ({ workspaceId, path }, { _meta }) => {
++            assertAuditReadonly(_meta, toolNames.trash);
+             const startedAt = performance.now();
+             const workspace = workspaces.getWorkspace(workspaceId);
+             let trash;
+@@ -1825,6 +1909,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             config,
+             workspaces,
+             incomingArtifactAdapters,
++            beforeMutation: (_input, _meta) => assertAuditReadonly(_meta, "download_artifact"),
+         });
+     }
+     return server;

--- a/bin/devspace-compat/1.0.8/workspace-write-and-read-bridge.patch
+++ b/bin/devspace-compat/1.0.8/workspace-write-and-read-bridge.patch
@@ -1,0 +1,585 @@
+diff --git a/dist/server.js b/dist/server.js
+index ae78eb6..9987ca0 100644
+--- a/dist/server.js
++++ b/dist/server.js
+@@ -1,6 +1,7 @@
+-import { randomUUID } from "node:crypto";
+-import { readFileSync } from "node:fs";
+-import { access, realpath } from "node:fs/promises";
++import { createHash, randomUUID } from "node:crypto";
++import { createReadStream, readFileSync } from "node:fs";
++import { access, lstat, mkdir, open, realpath, rename, stat, unlink } from "node:fs/promises";
++import { isAbsolute, join, relative, resolve, sep } from "node:path";
+ import { fileURLToPath } from "node:url";
+ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+ import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
+@@ -47,6 +48,18 @@ const EDIT_TOOL_ANNOTATIONS = {
+     idempotentHint: false,
+     openWorldHint: false,
+ };
++const DELETE_TOOL_ANNOTATIONS = {
++    readOnlyHint: false,
++    destructiveHint: true,
++    idempotentHint: false,
++    openWorldHint: false,
++};
++const TRASH_TOOL_ANNOTATIONS = {
++    readOnlyHint: false,
++    destructiveHint: true,
++    idempotentHint: false,
++    openWorldHint: false,
++};
+ const SHELL_TOOL_ANNOTATIONS = {
+     readOnlyHint: false,
+     destructiveHint: true,
+@@ -78,13 +91,70 @@ function toolWidgetDescriptorMeta(config, kind) {
+ const toolNames = {
+     openWorkspace: "open_workspace",
+     read: "read",
++    readChunk: "read_chunk",
+     write: "write",
+     edit: "edit",
++    delete: "delete_file",
++    trash: "trash_file",
+     grep: "grep",
+     glob: "glob",
+     ls: "ls",
+     shell: "bash",
+ };
++const MAX_READ_CHUNK_BYTES = 24 * 1024;
++export async function readUtf8Chunk(path, offsetBytes, limitBytes) {
++    const handle = await open(path, "r");
++    try {
++        const before = await handle.stat();
++        if (!before.isFile())
++            throw new Error("read_chunk requires a regular file");
++        if (offsetBytes > before.size)
++            throw new Error("offsetBytes exceeds file size");
++        const hash = createHash("sha256");
++        const hashBuffer = Buffer.allocUnsafe(64 * 1024);
++        let hashOffset = 0;
++        while (hashOffset < before.size) {
++            const { bytesRead } = await handle.read(hashBuffer, 0, Math.min(hashBuffer.length, before.size - hashOffset), hashOffset);
++            if (bytesRead <= 0)
++                throw new Error("file changed while hashing");
++            hash.update(hashBuffer.subarray(0, bytesRead));
++            hashOffset += bytesRead;
++        }
++        const requested = Math.min(limitBytes, before.size - offsetBytes);
++        const chunk = Buffer.alloc(requested);
++        const { bytesRead } = requested > 0
++            ? await handle.read(chunk, 0, requested, offsetBytes)
++            : { bytesRead: 0 };
++        let accepted = bytesRead;
++        let content;
++        while (accepted >= 0) {
++            try {
++                content = new TextDecoder("utf-8", { fatal: true }).decode(chunk.subarray(0, accepted));
++                break;
++            }
++            catch {
++                accepted -= 1;
++                if (bytesRead - accepted > 3)
++                    throw new Error("file is not valid UTF-8 or offsetBytes is not a UTF-8 boundary");
++            }
++        }
++        const after = await handle.stat();
++        if (before.size !== after.size || before.mtimeMs !== after.mtimeMs)
++            throw new Error("file changed while reading");
++        return {
++            content,
++            offsetBytes,
++            nextOffsetBytes: offsetBytes + accepted,
++            bytesReturned: accepted,
++            totalBytes: before.size,
++            eof: offsetBytes + accepted === before.size,
++            sha256: hash.digest("hex"),
++        };
++    }
++    finally {
++        await handle.close();
++    }
++}
+ const workspaceIdDescription = "Workspace to use. Reuse the current project's workspaceId.";
+ function serverInstructions(config) {
+     const artifactInstruction = config.artifactsEnabled && isArtifactDownloadSupportedPlatform()
+@@ -124,6 +194,305 @@ function resultOutputSchema(extra = {}) {
+         ...extra,
+     };
+ }
++function deleteFailure(code, message) {
++    const error = new Error(`${code}: ${message}`);
++    error.code = code;
++    return error;
++}
++function isStrictChildPath(root, candidate) {
++    const relationship = relative(root, candidate);
++    return (relationship !== "" &&
++        !isAbsolute(relationship) &&
++        !relationship.startsWith("..") &&
++        relationship !== ".." &&
++        !relationship.includes(`..${sep}`));
++}
++export async function deleteWorkspaceFile(workspace, inputPath) {
++    if (typeof inputPath !== "string" || inputPath.trim() === "") {
++        throw deleteFailure("DELETE_INVALID_PATH", "path must be a non-empty relative file path");
++    }
++    if (isAbsolute(inputPath) || /^[A-Za-z]:/.test(inputPath) || inputPath.startsWith("\\\\")) {
++        throw deleteFailure("DELETE_ABSOLUTE_PATH_FORBIDDEN", "path must be relative to the open workspace");
++    }
++    const segments = inputPath.split(/[\\/]+/).filter(Boolean);
++    if (segments.length === 0 || segments.some((segment) => segment === "." || segment === "..")) {
++        throw deleteFailure("DELETE_TRAVERSAL_FORBIDDEN", "path traversal and redundant dot segments are not allowed");
++    }
++    if (segments.some((segment) => segment.toLocaleLowerCase() === ".git")) {
++        throw deleteFailure("DELETE_PROTECTED_TARGET", ".git internals cannot be deleted");
++    }
++    const logicalRoot = resolve(workspace.root);
++    const logicalTarget = resolve(logicalRoot, ...segments);
++    if (!isStrictChildPath(logicalRoot, logicalTarget)) {
++        throw deleteFailure("DELETE_OUTSIDE_WORKSPACE", "path is outside the open workspace");
++    }
++    const canonicalRoot = await realpath(logicalRoot);
++    const target = resolve(canonicalRoot, ...segments);
++    if (!isStrictChildPath(canonicalRoot, target)) {
++        throw deleteFailure("DELETE_OUTSIDE_WORKSPACE", "canonical path is outside the open workspace");
++    }
++    let cursor = canonicalRoot;
++    let targetStats;
++    for (let index = 0; index < segments.length; index += 1) {
++        cursor = join(cursor, segments[index]);
++        let entry;
++        try {
++            entry = await lstat(cursor);
++        }
++        catch (error) {
++            if (error && typeof error === "object" && error.code === "ENOENT") {
++                throw deleteFailure("DELETE_TARGET_NOT_FOUND", "target file does not exist");
++            }
++            throw deleteFailure("DELETE_TARGET_INSPECTION_FAILED", "target could not be inspected safely");
++        }
++        if (entry.isSymbolicLink()) {
++            throw deleteFailure("DELETE_REPARSE_FORBIDDEN", "symlink or reparse path is not deletable");
++        }
++        if (index < segments.length - 1 && !entry.isDirectory()) {
++            throw deleteFailure("DELETE_INVALID_PATH", "a parent path component is not a directory");
++        }
++        targetStats = entry;
++    }
++    if (!targetStats?.isFile()) {
++        throw deleteFailure("DELETE_TARGET_NOT_REGULAR_FILE", "only regular files can be deleted");
++    }
++    const canonicalTarget = await realpath(target);
++    if (!isStrictChildPath(canonicalRoot, canonicalTarget)) {
++        throw deleteFailure("DELETE_REPARSE_ESCAPE", "target resolves outside the open workspace");
++    }
++    try {
++        await unlink(target);
++    }
++    catch {
++        throw deleteFailure("DELETE_FILESYSTEM_FAILED", "filesystem deletion failed");
++    }
++    let existsAfter = true;
++    try {
++        await lstat(target);
++    }
++    catch (error) {
++        if (error && typeof error === "object" && error.code === "ENOENT") {
++            existsAfter = false;
++        }
++        else {
++            throw deleteFailure("DELETE_POSTCHECK_FAILED", "target absence could not be verified");
++        }
++    }
++    if (existsAfter) {
++        throw deleteFailure("DELETE_POSTCHECK_FAILED", "target still exists after deletion");
++    }
++    return {
++        requestedPath: segments.join("/"),
++        existedBefore: true,
++        deleted: true,
++        existsAfter: false,
++    };
++}
++function trashFailure(code, message) {
++    const error = new Error(`${code}: ${message}`);
++    error.code = code;
++    return error;
++}
++async function trashLstat(path) {
++    try {
++        return await lstat(path);
++    }
++    catch (error) {
++        if (error && typeof error === "object" && error.code === "ENOENT")
++            return undefined;
++        throw trashFailure("TRASH_TARGET_INSPECTION_FAILED", "filesystem path could not be inspected safely");
++    }
++}
++async function trashFileDigest(path) {
++    const hash = createHash("sha256");
++    let bytes = 0;
++    try {
++        for await (const chunk of createReadStream(path)) {
++            bytes += chunk.length;
++            hash.update(chunk);
++        }
++    }
++    catch {
++        throw trashFailure("TRASH_HASH_FAILED", "file bytes could not be hashed safely");
++    }
++    return { bytes, sha256: hash.digest("hex") };
++}
++async function assertTrashPathNotReparse(path, code) {
++    const entry = await trashLstat(path);
++    if (!entry)
++        return undefined;
++    if (entry.isSymbolicLink())
++        throw trashFailure(code, "symlink, junction, or reparse paths are not allowed");
++    let canonical;
++    try {
++        canonical = await realpath(path);
++    }
++    catch {
++        throw trashFailure("TRASH_TARGET_INSPECTION_FAILED", "filesystem path could not be resolved safely");
++    }
++    if (relative(resolve(path), resolve(canonical)) !== "")
++        throw trashFailure(code, "symlink, junction, or reparse paths are not allowed");
++    return entry;
++}
++export async function trashWorkspaceFile(workspace, inputPath, options = {}) {
++    if (typeof inputPath !== "string" || inputPath.trim() === "") {
++        throw trashFailure("TRASH_INVALID_PATH", "path must be a non-empty relative file path");
++    }
++    if (isAbsolute(inputPath) || /^[A-Za-z]:/.test(inputPath) || inputPath.startsWith("\\\\")) {
++        throw trashFailure("TRASH_ABSOLUTE_PATH_FORBIDDEN", "path must be relative to the open workspace");
++    }
++    const segments = inputPath.split(/[\\/]+/).filter(Boolean);
++    if (segments.length === 0 || segments.some((segment) => segment === "." || segment === "..")) {
++        throw trashFailure("TRASH_TRAVERSAL_FORBIDDEN", "path traversal and redundant dot segments are not allowed");
++    }
++    if (segments.some((segment) => segment.toLocaleLowerCase() === ".git")) {
++        throw trashFailure("TRASH_PROTECTED_TARGET", ".git internals cannot be moved");
++    }
++    if (segments[0].toLocaleLowerCase() === ".webjjongku-trash") {
++        throw trashFailure("TRASH_PROTECTED_TARGET", "the workspace trash area cannot be moved into itself");
++    }
++    const trashId = options.uniqueId ?? randomUUID();
++    if (typeof trashId !== "string" || !/^[A-Za-z0-9_-]{1,128}$/.test(trashId)) {
++        throw trashFailure("TRASH_INVALID_ID", "trash destination identifier is invalid");
++    }
++    const logicalRoot = resolve(workspace.root);
++    const logicalTarget = resolve(logicalRoot, ...segments);
++    if (!isStrictChildPath(logicalRoot, logicalTarget)) {
++        throw trashFailure("TRASH_OUTSIDE_WORKSPACE", "path is outside the open workspace");
++    }
++    const canonicalRoot = await realpath(logicalRoot);
++    const target = resolve(canonicalRoot, ...segments);
++    if (!isStrictChildPath(canonicalRoot, target)) {
++        throw trashFailure("TRASH_OUTSIDE_WORKSPACE", "canonical path is outside the open workspace");
++    }
++    let cursor = canonicalRoot;
++    let targetStats;
++    for (let index = 0; index < segments.length; index += 1) {
++        cursor = join(cursor, segments[index]);
++        const entry = await assertTrashPathNotReparse(cursor, "TRASH_REPARSE_FORBIDDEN");
++        if (!entry)
++            throw trashFailure("TRASH_TARGET_NOT_FOUND", "target file does not exist");
++        if (index < segments.length - 1 && !entry.isDirectory())
++            throw trashFailure("TRASH_INVALID_PATH", "a parent path component is not a directory");
++        targetStats = entry;
++    }
++    if (!targetStats?.isFile()) {
++        throw trashFailure("TRASH_TARGET_NOT_REGULAR_FILE", "only regular files can be moved to workspace trash");
++    }
++    const canonicalTarget = await realpath(target);
++    if (!isStrictChildPath(canonicalRoot, canonicalTarget)) {
++        throw trashFailure("TRASH_REPARSE_ESCAPE", "target resolves outside the open workspace");
++    }
++    const trashRoot = resolve(canonicalRoot, ".webjjongku-trash");
++    if (!isStrictChildPath(canonicalRoot, trashRoot)) {
++        throw trashFailure("TRASH_OUTSIDE_WORKSPACE", "trash destination is outside the open workspace");
++    }
++    let trashRootStats = await assertTrashPathNotReparse(trashRoot, "TRASH_REPARSE_FORBIDDEN");
++    if (!trashRootStats) {
++        try {
++            await mkdir(trashRoot, { recursive: false });
++        }
++        catch {
++            throw trashFailure("TRASH_DESTINATION_CREATE_FAILED", "workspace trash directory could not be created");
++        }
++        trashRootStats = await assertTrashPathNotReparse(trashRoot, "TRASH_REPARSE_FORBIDDEN");
++    }
++    if (!trashRootStats?.isDirectory()) {
++        throw trashFailure("TRASH_DESTINATION_INVALID", "workspace trash path is not a directory");
++    }
++    const uniqueRoot = resolve(trashRoot, trashId);
++    if (!isStrictChildPath(trashRoot, uniqueRoot)) {
++        throw trashFailure("TRASH_OUTSIDE_WORKSPACE", "trash destination is outside the workspace trash area");
++    }
++    if (await trashLstat(uniqueRoot)) {
++        throw trashFailure("TRASH_DESTINATION_COLLISION", "unique trash destination already exists");
++    }
++    try {
++        await mkdir(uniqueRoot, { recursive: false });
++    }
++    catch (error) {
++        if (error && typeof error === "object" && error.code === "EEXIST")
++            throw trashFailure("TRASH_DESTINATION_COLLISION", "unique trash destination already exists");
++        throw trashFailure("TRASH_DESTINATION_CREATE_FAILED", "unique trash destination could not be created");
++    }
++    const uniqueRootStats = await assertTrashPathNotReparse(uniqueRoot, "TRASH_REPARSE_FORBIDDEN");
++    if (!uniqueRootStats?.isDirectory()) {
++        throw trashFailure("TRASH_DESTINATION_INVALID", "unique trash destination is not a directory");
++    }
++    const destination = resolve(uniqueRoot, ...segments);
++    if (!isStrictChildPath(uniqueRoot, destination)) {
++        throw trashFailure("TRASH_OUTSIDE_WORKSPACE", "trash destination is outside the unique trash area");
++    }
++    cursor = uniqueRoot;
++    for (const segment of segments.slice(0, -1)) {
++        cursor = join(cursor, segment);
++        let entry = await assertTrashPathNotReparse(cursor, "TRASH_REPARSE_FORBIDDEN");
++        if (!entry) {
++            try {
++                await mkdir(cursor, { recursive: false });
++            }
++            catch (error) {
++                if (error && typeof error === "object" && error.code === "EEXIST")
++                    throw trashFailure("TRASH_DESTINATION_COLLISION", "trash destination parent already exists");
++                throw trashFailure("TRASH_DESTINATION_CREATE_FAILED", "trash destination parent could not be created");
++            }
++            entry = await assertTrashPathNotReparse(cursor, "TRASH_REPARSE_FORBIDDEN");
++        }
++        if (!entry?.isDirectory())
++            throw trashFailure("TRASH_DESTINATION_INVALID", "trash destination parent is not a directory");
++    }
++    if (await trashLstat(destination)) {
++        throw trashFailure("TRASH_DESTINATION_COLLISION", "trash destination already exists");
++    }
++    const before = await trashFileDigest(target);
++    const sourceBeforeMove = await assertTrashPathNotReparse(target, "TRASH_REPARSE_FORBIDDEN");
++    if (!sourceBeforeMove?.isFile() || sourceBeforeMove.size !== before.bytes) {
++        throw trashFailure("TRASH_SOURCE_CHANGED", "source changed while it was being verified");
++    }
++    cursor = uniqueRoot;
++    for (const segment of segments.slice(0, -1)) {
++        cursor = join(cursor, segment);
++        const entry = await assertTrashPathNotReparse(cursor, "TRASH_REPARSE_FORBIDDEN");
++        if (!entry?.isDirectory())
++            throw trashFailure("TRASH_DESTINATION_INVALID", "trash destination parent changed before move");
++    }
++    if (await trashLstat(destination)) {
++        throw trashFailure("TRASH_DESTINATION_COLLISION", "trash destination already exists");
++    }
++    try {
++        await rename(target, destination);
++    }
++    catch (error) {
++        if (error && typeof error === "object" && (error.code === "EEXIST" || error.code === "ENOTEMPTY"))
++            throw trashFailure("TRASH_DESTINATION_COLLISION", "trash destination already exists");
++        throw trashFailure("TRASH_MOVE_FAILED", "filesystem move failed");
++    }
++    if (await trashLstat(target)) {
++        throw trashFailure("TRASH_POSTCHECK_FAILED", "original path still exists after move");
++    }
++    const trashedStats = await assertTrashPathNotReparse(destination, "TRASH_REPARSE_FORBIDDEN");
++    if (!trashedStats?.isFile()) {
++        throw trashFailure("TRASH_POSTCHECK_FAILED", "trashed copy is not a regular file");
++    }
++    const canonicalDestination = await realpath(destination);
++    if (!isStrictChildPath(uniqueRoot, canonicalDestination)) {
++        throw trashFailure("TRASH_REPARSE_ESCAPE", "trashed copy resolves outside the unique trash area");
++    }
++    const after = await trashFileDigest(destination);
++    if (before.bytes !== after.bytes || before.sha256 !== after.sha256) {
++        throw trashFailure("TRASH_CONTENT_MISMATCH", "trashed copy does not match the original file bytes");
++    }
++    return {
++        originalRelativePath: segments.join("/"),
++        trashRelativePath: [".webjjongku-trash", trashId, ...segments].join("/"),
++        trashId,
++        moved: true,
++        originalExistsAfter: false,
++        trashExistsAfter: true,
++        bytes: after.bytes,
++        sha256: after.sha256,
++    };
++}
+ const workspaceSkillOutputSchema = z.object({
+     name: z.string(),
+     description: z.string(),
+@@ -783,6 +1152,45 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             },
+         };
+     });
++    registerAppTool(server, toolNames.readChunk, {
++        title: "Read UTF-8 file chunk",
++        description: "Read one byte-bounded UTF-8 chunk from a regular file inside an open workspace. Use this when read reports that one line exceeds its 50KB limit. Start with offsetBytes=0, then pass the exact returned nextOffsetBytes until eof=true. Each response binds the complete file SHA-256 and fails if the file changes during the call.",
++        inputSchema: {
++            workspaceId: z.string().describe(workspaceIdDescription),
++            path: z.string().describe("Regular UTF-8 file path, relative to the workspace root."),
++            offsetBytes: z.number().int().nonnegative().default(0).describe("Zero-based UTF-8 byte boundary. Reuse nextOffsetBytes from the previous response."),
++            limitBytes: z.number().int().positive().max(MAX_READ_CHUNK_BYTES).default(MAX_READ_CHUNK_BYTES).describe(`Maximum bytes to return, capped at ${MAX_READ_CHUNK_BYTES}.`),
++        },
++        outputSchema: {
++            content: z.string(),
++            offsetBytes: z.number().int().nonnegative(),
++            nextOffsetBytes: z.number().int().nonnegative(),
++            bytesReturned: z.number().int().nonnegative(),
++            totalBytes: z.number().int().nonnegative(),
++            eof: z.boolean(),
++            sha256: z.string().regex(/^[0-9a-f]{64}$/),
++        },
++        ...toolWidgetDescriptorMeta(config, "read"),
++        annotations: { readOnlyHint: true },
++    }, async ({ workspaceId, path, offsetBytes, limitBytes }) => {
++        const startedAt = performance.now();
++        const workspace = workspaces.getWorkspace(workspaceId);
++        const readPath = workspaces.resolveReadPath(workspace, path);
++        try {
++            const result = await readUtf8Chunk(readPath.absolutePath, offsetBytes, limitBytes);
++            workspaces.markReadPathLoaded(workspace, readPath);
++            logToolCall(config, { tool: toolNames.readChunk, workspaceId, path, success: true, durationMs: Math.round(performance.now() - startedAt) });
++            return {
++                content: [textBlock(result.content)], structuredContent: result,
++                _meta: { tool: toolNames.readChunk, card: { workspaceId, path, summary: { offsetBytes: result.offsetBytes, bytesReturned: result.bytesReturned, totalBytes: result.totalBytes, eof: result.eof, sha256: result.sha256 } } },
++            };
++        }
++        catch (error) {
++            const message = error instanceof Error ? error.message : String(error);
++            logFailedToolResponse(config, { tool: toolNames.readChunk, workspaceId, path }, [textBlock(message)], startedAt);
++            return { content: [textBlock(message)], isError: true };
++        }
++    });
+     if (config.toolMode !== "codex") {
+         registerAppTool(server, toolNames.write, {
+             title: "Write file",
+@@ -1287,6 +1695,127 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+                 },
+             };
+         });
++        registerAppTool(server, toolNames.delete, {
++            title: "Delete file",
++            description: "Delete exactly one existing regular file inside an open workspace. Rejects directories, .git internals, links, absolute paths, and workspace escapes. Call open_workspace first and pass workspaceId.",
++            inputSchema: {
++                workspaceId: z.string().describe("Workspace identifier returned by open_workspace."),
++                path: z.string().describe("Existing regular file path relative to the workspace root."),
++            },
++            outputSchema: resultOutputSchema({
++                requestedPath: z.string(),
++                existedBefore: z.literal(true),
++                deleted: z.literal(true),
++                existsAfter: z.literal(false),
++            }),
++            ...toolWidgetDescriptorMeta(config, "edit"),
++            annotations: DELETE_TOOL_ANNOTATIONS,
++        }, async ({ workspaceId, path }) => {
++            const startedAt = performance.now();
++            const workspace = workspaces.getWorkspace(workspaceId);
++            let deletion;
++            try {
++                deletion = await deleteWorkspaceFile(workspace, path);
++            }
++            catch (error) {
++                const message = error instanceof Error ? error.message : String(error);
++                const response = { content: [textBlock(message)], isError: true };
++                logFailedToolResponse(config, {
++                    tool: toolNames.delete,
++                    workspaceId,
++                    path,
++                }, response.content, startedAt);
++                return response;
++            }
++            const result = `Deleted ${deletion.requestedPath}.`;
++            const content = [textBlock(result)];
++            logToolCall(config, {
++                tool: toolNames.delete,
++                workspaceId,
++                path: deletion.requestedPath,
++                success: true,
++                durationMs: Math.round(performance.now() - startedAt),
++            });
++            return {
++                content,
++                _meta: {
++                    tool: toolNames.delete,
++                    card: {
++                        workspaceId,
++                        path: deletion.requestedPath,
++                        summary: { deleted: true },
++                        payload: { deletion },
++                    },
++                },
++                structuredContent: {
++                    result,
++                    ...deletion,
++                },
++            };
++        });
++        registerAppTool(server, toolNames.trash, {
++            title: "Trash file",
++            description: "Reversibly move exactly one existing regular file inside an open workspace into a unique workspace-local .webjjongku-trash path. Rejects directories, .git internals, links, absolute paths, workspace escapes, and destination collisions. Call open_workspace first and pass workspaceId.",
++            inputSchema: {
++                workspaceId: z.string().describe("Workspace identifier returned by open_workspace."),
++                path: z.string().describe("Existing regular file path relative to the workspace root."),
++            },
++            outputSchema: resultOutputSchema({
++                originalRelativePath: z.string(),
++                trashRelativePath: z.string(),
++                trashId: z.string(),
++                moved: z.literal(true),
++                originalExistsAfter: z.literal(false),
++                trashExistsAfter: z.literal(true),
++                bytes: z.number().int().nonnegative(),
++                sha256: z.string(),
++            }),
++            ...toolWidgetDescriptorMeta(config, "edit"),
++            annotations: TRASH_TOOL_ANNOTATIONS,
++        }, async ({ workspaceId, path }) => {
++            const startedAt = performance.now();
++            const workspace = workspaces.getWorkspace(workspaceId);
++            let trash;
++            try {
++                trash = await trashWorkspaceFile(workspace, path);
++            }
++            catch (error) {
++                const message = error instanceof Error ? error.message : String(error);
++                const response = { content: [textBlock(message)], isError: true };
++                logFailedToolResponse(config, {
++                    tool: toolNames.trash,
++                    workspaceId,
++                    path,
++                }, response.content, startedAt);
++                return response;
++            }
++            const result = `Moved ${trash.originalRelativePath} to ${trash.trashRelativePath}.`;
++            const content = [textBlock(result)];
++            logToolCall(config, {
++                tool: toolNames.trash,
++                workspaceId,
++                path: trash.originalRelativePath,
++                trashPath: trash.trashRelativePath,
++                success: true,
++                durationMs: Math.round(performance.now() - startedAt),
++            });
++            return {
++                content,
++                _meta: {
++                    tool: toolNames.trash,
++                    card: {
++                        workspaceId,
++                        path: trash.originalRelativePath,
++                        summary: { movedToTrash: true },
++                        payload: { trash },
++                    },
++                },
++                structuredContent: {
++                    result,
++                    ...trash,
++                },
++            };
++        });
+     }
+     if (config.toolMode === "codex") {
+         registerCodexProcessTools(server, config, workspaces, processSessions);

--- a/bin/devspace-compat/1.0.8/workspaces.patch
+++ b/bin/devspace-compat/1.0.8/workspaces.patch
@@ -1,0 +1,67 @@
+diff --git a/dist/workspaces.js b/dist/workspaces.js
+index a1b9bff..1c82729 100644
+--- a/dist/workspaces.js
++++ b/dist/workspaces.js
+@@ -352,6 +352,12 @@ const SKIPPED_CONTEXT_DIRS = new Set([
+     ".next",
+     ".turbo",
+     ".cache",
++    ".tmp",
++    ".tox",
++    ".venv",
++    "__pycache__",
++    ".mypy_cache",
++    ".ruff_cache",
+ ]);
+ export function formatAgentsPath(path, workspaceRoot) {
+     if (!workspaceRoot)
+@@ -390,22 +396,35 @@ async function tryRealpath(path) {
+     }
+ }
+ async function walkWorkspace(directory, visit) {
+-    let entries;
+-    try {
+-        entries = await opendir(directory);
+-    }
+-    catch {
+-        return;
+-    }
+-    for await (const entry of entries) {
+-        const path = join(directory, entry.name);
+-        if (entry.isDirectory()) {
+-            if (!SKIPPED_CONTEXT_DIRS.has(entry.name)) {
+-                await walkWorkspace(path, visit);
++    const pending = [directory];
++    const batchSize = 24;
++    while (pending.length > 0) {
++        const batch = pending.splice(0, batchSize);
++        const discovered = await Promise.all(batch.map(async (current) => {
++            let entries;
++            try {
++                entries = await opendir(current);
++            }
++            catch {
++                return [];
++            }
++            const childDirectories = [];
++            for await (const entry of entries) {
++                const path = join(current, entry.name);
++                if (entry.isDirectory()) {
++                    if (!SKIPPED_CONTEXT_DIRS.has(entry.name) &&
++                        !entry.name.startsWith(".pytest-")) {
++                        childDirectories.push(path);
++                    }
++                    continue;
++                }
++                await visit(path, entry);
+             }
+-            continue;
++            return childDirectories;
++        }));
++        for (const children of discovered) {
++            pending.push(...children);
+         }
+-        await visit(path, entry);
+     }
+ }
+ function isErrnoException(error) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,21 @@
 # 기술 변경 기록
 
+## 1.20.4 - Validate DevSpace 1.0.8
+
+- DevSpace `1.0.8` is the explicit current runtime for new setup and managed
+  macOS launches after archive-integrity, exact patch, and compatibility-gate
+  validation. DevSpace `1.0.7` is retained as the rollback LKG; neither path
+  resolves a moving npm `latest` tag.
+- The release portability workflow prepares only the hash-verified published
+  `1.0.8` archive before running the cross-platform contract suite.
+- DevSpace `1.0.8` adds an optional local-agent daemon and provider CLI
+  adapters. Managed ChatGPT workspace services pin `DEVSPACE_SUBAGENTS=false`;
+  enabling that separate execution surface remains an explicit user action.
+- The fast pre-submit gate now runs a named cross-section of runner launch,
+  ownership, app-read, completion, restart, and recovery contracts while the
+  full suite retains every exhaustive contradiction permutation. This restores
+  the 100-second CI budget without reducing full release coverage.
+
 ## 1.20.3 - Preserve follow-up evidence before browser launch
 
 - A live read-only Pro `followup` now creates the exact child run directory,

--- a/docs/DEVSPACE_TAILSCALE_SETUP.md
+++ b/docs/DEVSPACE_TAILSCALE_SETUP.md
@@ -45,6 +45,11 @@ the connector after the one-hour access token expires. After upgrading an
 existing setup from metadata that omitted `offline_access`, recreate or
 reconnect the app once so ChatGPT reads the corrected OAuth metadata.
 
+The managed launch also pins `DEVSPACE_SUBAGENTS=false`. DevSpace 1.0.8's
+optional local-agent daemon and provider CLI adapters remain disabled unless
+the user separately and explicitly approves that additional execution surface;
+an inherited or persisted setting must not silently enable it.
+
 ## Manual ChatGPT registration
 
 Enable Developer Mode in ChatGPT and manually create the connector:
@@ -118,7 +123,7 @@ three-artifact hash-bound `settle-recursive-self-observation` receipt; a general
 BLOCKED answer or a simple run-ID mention never qualifies.
 
 When a previously healthy long-running session fails only as its access token
-expires, the managed DevSpace 1.0.7 compatibility layer also checks a bounded
+expires, the managed DevSpace 1.0.8 compatibility layer also checks a bounded
 server-side refresh replay grace. It returns the same rotated pair only for an
 identical client, scope, and resource during a 30-second window, keeps at most
 32 entries in memory, and rejects expiry, mismatch, or revocation. This avoids

--- a/docs/DEVSPACE_TAILSCALE_SETUP.md
+++ b/docs/DEVSPACE_TAILSCALE_SETUP.md
@@ -50,6 +50,12 @@ optional local-agent daemon and provider CLI adapters remain disabled unless
 the user separately and explicitly approves that additional execution surface;
 an inherited or persisted setting must not silently enable it.
 
+Managed recovery primes the exact pinned package before native validation and
+permits a rebuild only for the hash-bound `better-sqlite3@12.11.1` dependency.
+The resulting service is supervised with redacted, bounded live logs and
+PID/start/exit evidence. It requires two consecutive loopback `/mcp` and
+`/healthz` observations before repairing Funnel routing.
+
 ## Manual ChatGPT registration
 
 Enable Developer Mode in ChatGPT and manually create the connector:

--- a/docs/FIRST_INSTALL.md
+++ b/docs/FIRST_INSTALL.md
@@ -414,6 +414,8 @@ exact folder가 `allowedRoots`에 있는지만 가볍게 확인하고, config ha
 - `DEVSPACE_NATIVE_BINDING_UNAVAILABLE`: `npm install-scripts ls`에서 정확한 DevSpace
   native dependency만 검토·승인한 뒤 `better-sqlite3`를 재빌드합니다. doctor가 실제
   메모리 DB 로드에 성공하기 전에는 서비스를 시작하지 않습니다.
+  이 경로는 정확한 1.0.8 package/lock hash와 `better-sqlite3@12.11.1`만 허용하며,
+  서비스 로그는 실행 중에도 redaction·회전됩니다.
 - 앱이 도구를 찾지 못함: 동일 URL의 MCP/OAuth 상태를 확인합니다. 자동으로 앱을
   삭제하거나 다시 만들지 않습니다. 방금 등록·재연결했다면 `post-register`를 한 번만
   실행하고 일반 Oracle 읽기 검사를 반복합니다.

--- a/docs/FIRST_INSTALL.md
+++ b/docs/FIRST_INSTALL.md
@@ -254,14 +254,15 @@ python skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py setup 
 
 1. 먼저 고정 hostname을 만들고 `http://127.0.0.1:7676`으로 전달합니다.
 2. 터널 클라이언트를 OS 로그인/서비스로 등록합니다.
-3. `npx --yes @waishnav/devspace@1.0.7 init`을 실행합니다.
+3. `npx --yes @waishnav/devspace@1.0.8 init`을 실행합니다.
 4. exact roots와 public origin을 입력합니다. public origin에는 `/mcp`를 빼고,
    ChatGPT 등록 URL에는 `/mcp`를 붙입니다.
-5. DevSpace 관리 실행 환경에 아래 두 값을 유지합니다.
+5. DevSpace 관리 실행 환경에 아래 세 값을 유지합니다.
 
 ```text
 DEVSPACE_TOOL_MODE=full
 DEVSPACE_OAUTH_SCOPES=devspace,offline_access
+DEVSPACE_SUBAGENTS=false
 ```
 
 임시 URL은 앱 등록 후 바뀌므로 설치 완료 조건을 만족하지 않습니다.

--- a/docs/FROZEN_LEGACY.md
+++ b/docs/FROZEN_LEGACY.md
@@ -67,7 +67,7 @@
 | `bin/chatgpt_oracle_profiles.py` | lane별 throwaway 프로필 |
 | `bin/chatgpt_oracle_diagnose.py` | 실패 서명 분류 |
 | `bin/chatgpt_oracle_incident.py` | 단일 수리 소유자 인계 패킷 |
-| `bin/chatgpt_devspace_compat.py` | DevSpace 1.0.7 current 호환 패치와 1.0.4 롤백 LKG |
+| `bin/chatgpt_devspace_compat.py` | DevSpace 1.0.8 current 호환 패치와 1.0.7 롤백 LKG |
 
 ## 레거시 스텁 문서
 

--- a/docs/MACOS_ULTRAWORK.md
+++ b/docs/MACOS_ULTRAWORK.md
@@ -2,7 +2,7 @@
 
 ## 경계
 
-macOS 신규 작업은 Oracle 0.18.0, DevSpace 1.0.7, Tailscale Funnel,
+macOS 신규 작업은 Oracle 0.18.0, DevSpace 1.0.8, Tailscale Funnel,
 OMO Codex Light를 사용한다. 구형 CodexPro/agbrowse 자산은 저장된 Windows
 실행 복구 전용이다. `com.ventianima.codexpro-automation.*`만 이 프로젝트가
 관리하며 기존 `com.openclaw.codexpro*`와 `~/.codexpro`는 건드리지 않는다.

--- a/docs/UPSTREAM_RUNTIME_POLICY.md
+++ b/docs/UPSTREAM_RUNTIME_POLICY.md
@@ -59,7 +59,12 @@ Current runtime contract:
 | Runtime | Current | Rollback LKG |
 | --- | --- | --- |
 | Oracle | `0.18.0` | `0.17.1` |
-| DevSpace | `1.0.7` | `1.0.4` |
+| DevSpace | `1.0.8` | `1.0.7` |
+
+DevSpace `1.0.8` includes an optional local-agent daemon and provider CLI
+adapters. The managed ChatGPT workspace service explicitly sets
+`DEVSPACE_SUBAGENTS=false`; upstream promotion does not authorize or silently
+enable that separate execution surface.
 
 This policy intentionally optimizes for fast upstream bug/UI fixes without executing an
 unreviewed moving `latest` tag on a user's machine.

--- a/doctor.ps1
+++ b/doctor.ps1
@@ -12,6 +12,8 @@ $Warnings = @()
 $Commands = @('powershell -ExecutionPolicy Bypass -File .\install.ps1 -WhatIf')
 $LocalMultiGptEnabled = $false
 $LocalMultiGptDoctor = $null
+$LegacyDependencyMode = $null
+$InstallReceiptSchema = $null
 
 function Get-Sha256([string]$Path) {
   $stream = $null
@@ -51,6 +53,7 @@ if (!$Receipt) {
     if (@('codexpro.install-receipt/v2','codexpro.install-receipt/v3') -notcontains [string]$Value.schema) {
       throw 'unsupported install receipt schema'
     }
+    $InstallReceiptSchema = [string]$Value.schema
     foreach ($Record in $Value.files) {
       $Path = Get-SafeChild $CodexRoot ([string]$Record.path)
       if (!(Test-Path -LiteralPath $Path)) {
@@ -63,6 +66,7 @@ if (!$Receipt) {
       }
     }
     $LocalMultiGptEnabled = [bool]$Value.optional_components.local_multi_gpt.enabled
+    $LegacyDependencyMode = [string]$Value.dependency.mode
   } catch {
     $Issues += @{code='RECEIPT_INVALID'; detail=$_.Exception.Message}
   }
@@ -127,9 +131,17 @@ if (Test-Path -LiteralPath $UpdateReceiptPath) {
   }
 }
 
-if (($Agbrowse -or $UpdateReceipt) -and (!$Python -or !(Test-Path -LiteralPath $Contract))) {
+$VerifyLegacyContract = (
+  [bool]$UpdateReceipt -or
+  $LegacyDependencyMode -eq 'applied' -or
+  $InstallReceiptSchema -eq 'codexpro.install-receipt/v2'
+)
+if ($Agbrowse -and !$VerifyLegacyContract) {
+  $Warnings += @{code='LEGACY_AGBROWSE_UNMANAGED'; detail='PATH agbrowse is outside this install receipt and was not contract-validated'}
+}
+if ($VerifyLegacyContract -and (!$Python -or !(Test-Path -LiteralPath $Contract))) {
   $Issues += @{code='CONTRACT_UNVERIFIED'; detail='Python or contract manifest unavailable'}
-} elseif ($Agbrowse -or $UpdateReceipt) {
+} elseif ($VerifyLegacyContract) {
   if ($UpdateReceipt -and (Get-Sha256 $Contract) -ne [string]$UpdateReceipt.contract_sha256) {
     $Issues += @{code='CONTRACT_RECEIPT_HASH_MISMATCH'; contract=$Contract}
   } else {

--- a/doctor.ps1
+++ b/doctor.ps1
@@ -170,7 +170,7 @@ if (($Agbrowse -or $UpdateReceipt) -and (!$Python -or !(Test-Path -LiteralPath $
   commands = $Commands
   agbrowse = @{selected_version=$SelectedVersion; contract=$Contract; update_receipt=$UpdateReceiptPath}
   oracle = @{package='@steipete/oracle';current_version='0.18.0';last_known_good='0.17.1';policy='newest-validated-stable';resolution='npx at explicit run time'}
-  devspace = @{package='@waishnav/devspace';current_version='1.0.7';last_known_good='1.0.4';policy='newest-validated-stable';setup='explicit setup skill only'}
+  devspace = @{package='@waishnav/devspace';current_version='1.0.8';last_known_good='1.0.7';policy='newest-validated-stable';setup='explicit setup skill only'}
   local_multi_gpt = @{enabled=$LocalMultiGptEnabled;doctor=$LocalMultiGptDoctor}
   codexpro = @{
     installation = 'external'

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.3",
+  "version": "1.20.4",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",
@@ -24,6 +24,11 @@
     "bin/devspace-compat/1.0.7/workspace-write-and-read-bridge.patch",
     "bin/devspace-compat/1.0.7/tool-read-receipts.patch",
     "bin/devspace-compat/1.0.7/workspaces.patch",
+    "bin/devspace-compat/1.0.8/oauth-refresh-replay.patch",
+    "bin/devspace-compat/1.0.8/artifact-audit-readonly.patch",
+    "bin/devspace-compat/1.0.8/workspace-write-and-read-bridge.patch",
+    "bin/devspace-compat/1.0.8/tool-read-receipts.patch",
+    "bin/devspace-compat/1.0.8/workspaces.patch",
     "bin/chatgpt_oracle_compat.py",
     "bin/oracle-compat/0.17.1/assistantResponse.terminal-marker-fallback.patch",
     "bin/oracle-compat/0.17.1/assistantResponse.terminal-marker-fallback.v1.19.6.patch",
@@ -216,14 +221,14 @@
     },
     "devspace": {
       "package": "@waishnav/devspace",
-      "tested_version": "1.0.7",
+      "tested_version": "1.0.8",
       "license": "MIT",
-      "integrity": "sha512-kP+Wk52qiMRwdqAP+nV4OZ4HU8feivZQ0k6u4ZUkvqxu8j0Rp/AU8H0K4T43G+zmu9WJKlYLTet7vIUeZHU72A==",
+      "integrity": "sha512-uyEgFUmt8UcxRy7xnH2rddYdEm6lLIPMKgS2JHwRP7qVnWFtC7j1l4//EOfEVhO4NqGMckWxixNkCWAHPvgZqg==",
       "last_known_good": {
-        "version": "1.0.4",
-        "integrity": "sha512-gYaaweaKWTK7Xb4uImpso2mbp87I7TuCmpenOR1jh1rp0nXisId10UHB9HxU5N1Qa5bDmRcIyHe85Bln2zCuzg=="
+        "version": "1.0.7",
+        "integrity": "sha512-kP+Wk52qiMRwdqAP+nV4OZ4HU8feivZQ0k6u4ZUkvqxu8j0Rp/AU8H0K4T43G+zmu9WJKlYLTet7vIUeZHU72A=="
       },
-      "installation": "resolved by the explicit setup skill at 1.0.7; exact published hashes are compatibility-patched for bounded OAuth replay, workspace writes, large reads, and context discovery; 1.0.4 remains rollback LKG only"
+      "installation": "resolved by the explicit setup skill at 1.0.8; exact published hashes are compatibility-patched for bounded OAuth replay, workspace writes, large reads, and context discovery; 1.0.7 remains rollback LKG only"
     },
     "codexpro": {
       "package": "codexpro",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.3",
+  "version": "1.20.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.3",
+      "version": "1.20.4",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.3",
+  "version": "1.20.4",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",
@@ -117,7 +117,7 @@
     "scripts/check_docs.py",
     "scripts/check_upstream_runtime_policy.py",
     "scripts/verify_upstream_runtime_maintainer.py",
-    "scripts/prepare_devspace_107_ci.py",
+    "scripts/prepare_devspace_108_ci.py",
     "upstream-runtime-policy.json",
     "upstream-runtime-maintainer-automation.json",
     "contracts/install/",

--- a/scripts/prepare_devspace_108_ci.py
+++ b/scripts/prepare_devspace_108_ci.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Prepare the exact published DevSpace 1.0.8 package for CI tests."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+
+DEVSPACE_VERSION = "1.0.8"
+DEVSPACE_INTEGRITY = "sha512-uyEgFUmt8UcxRy7xnH2rddYdEm6lLIPMKgS2JHwRP7qVnWFtC7j1l4//EOfEVhO4NqGMckWxixNkCWAHPvgZqg=="
+MAX_FILES = 10_000
+MAX_BYTES = 100 * 1024 * 1024
+WINDOWS_RESERVED_NAMES = {"CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))}
+
+
+def safe_member_parts(name: str) -> tuple[str, ...]:
+    if not name or "\\" in name or "\x00" in name or any(ord(character) < 32 for character in name):
+        raise RuntimeError("DevSpace archive contains an unsafe path")
+    raw_parts = name.split("/")
+    if any(part in {"", ".", ".."} for part in raw_parts):
+        raise RuntimeError("DevSpace archive contains an unsafe path")
+    path = PurePosixPath(name)
+    if path.is_absolute() or len(path.parts) < 2 or path.parts[0] != "package":
+        raise RuntimeError("DevSpace archive contains an unsafe path")
+    for part in path.parts[1:]:
+        if ":" in part or part.endswith((" ", ".")):
+            raise RuntimeError("DevSpace archive contains an unsafe path")
+        if part.rstrip(" .").split(".", 1)[0].upper() in WINDOWS_RESERVED_NAMES:
+            raise RuntimeError("DevSpace archive contains an unsafe path")
+    return tuple(path.parts)
+
+
+def extract_verified(archive_bytes: bytes, destination: Path) -> Path:
+    count = 0
+    total = 0
+    destination.mkdir(parents=True, exist_ok=False)
+    destination = destination.resolve(strict=True)
+    seen: set[str] = set()
+    with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as package:
+        for member in package:
+            parts = safe_member_parts(member.name)
+            collision_key = PurePosixPath(*parts).as_posix().casefold()
+            if collision_key in seen:
+                raise RuntimeError("DevSpace archive contains duplicate or case-colliding entries")
+            seen.add(collision_key)
+            target = destination.joinpath(*parts)
+            if not target.resolve(strict=False).is_relative_to(destination):
+                raise RuntimeError("DevSpace archive path escapes the extraction directory")
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            if not member.isfile() or len(parts) < 2:
+                raise RuntimeError("DevSpace archive contains a non-file entry")
+            count += 1
+            total += int(member.size)
+            if count > MAX_FILES or total > MAX_BYTES:
+                raise RuntimeError("DevSpace archive exceeds CI extraction limits")
+            source = package.extractfile(member)
+            if source is None:
+                raise RuntimeError("DevSpace archive file is unreadable")
+            content = source.read()
+            if len(content) != member.size:
+                raise RuntimeError("DevSpace archive file size is inconsistent")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("xb") as output:
+                output.write(content)
+            target.chmod(member.mode & 0o777)
+    package_root = destination / "package"
+    metadata = json.loads((package_root / "package.json").read_text(encoding="utf-8"))
+    if metadata.get("version") != DEVSPACE_VERSION:
+        raise RuntimeError("DevSpace archive version does not match the CI contract")
+    return package_root
+
+
+def main() -> int:
+    npm = shutil.which("npm") or shutil.which("npm.cmd")
+    if not npm:
+        raise RuntimeError("npm is required to prepare the DevSpace CI package")
+    runner_temp = Path(os.environ.get("RUNNER_TEMP") or tempfile.gettempdir()).resolve()
+    stage = Path(tempfile.mkdtemp(prefix="devspace-108-ci-", dir=runner_temp))
+    packed = subprocess.run(
+        [npm, "pack", "--silent", "--pack-destination", str(stage), f"@waishnav/devspace@{DEVSPACE_VERSION}"],
+        cwd=stage,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if packed.returncode != 0:
+        raise RuntimeError(f"npm pack failed: {packed.stderr.strip()[-1000:]}")
+    names = [line.strip() for line in packed.stdout.splitlines() if line.strip()]
+    if len(names) != 1 or Path(names[0]).name != names[0]:
+        raise RuntimeError("npm pack returned an unexpected archive name")
+    archive = stage / names[0]
+    if not archive.is_file() or archive.is_symlink() or archive.stat().st_size > MAX_BYTES:
+        raise RuntimeError("DevSpace npm archive is not a bounded regular file")
+    archive_bytes = archive.read_bytes()
+    actual_integrity = "sha512-" + base64.b64encode(hashlib.sha512(archive_bytes).digest()).decode("ascii")
+    if actual_integrity != DEVSPACE_INTEGRITY:
+        raise RuntimeError("DevSpace npm archive integrity does not match the CI contract")
+    package_root = extract_verified(archive_bytes, stage / "extracted")
+    github_env_value = os.environ.get("GITHUB_ENV", "")
+    if not github_env_value:
+        raise RuntimeError("GITHUB_ENV is required; this helper is CI-only")
+    github_env = Path(github_env_value)
+    for value in (package_root, archive):
+        if "\n" in str(value) or "\r" in str(value):
+            raise RuntimeError("CI package path contains a newline")
+    with github_env.open("a", encoding="utf-8", newline="\n") as output:
+        output.write(f"DEVSPACE_108_PACKAGE_ROOT={package_root}\n")
+        output.write(f"DEVSPACE_108_PACKAGE_ARCHIVE={archive}\n")
+    print(f"Prepared hash-verified DevSpace {DEVSPACE_VERSION} for CI tests.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_fast_gate.py
+++ b/scripts/run_fast_gate.py
@@ -22,7 +22,32 @@ ROOT = Path(__file__).resolve().parents[1]
 
 FAST_TARGETS = [
     "tests/test_chatgpt_oracle_state.py",
-    "tests/test_chatgpt_oracle_run.py",
+    # The full runner module now contains hundreds of exhaustive lifecycle
+    # contradiction permutations and takes about 65 seconds by itself.  Keep a
+    # bounded cross-section of the launch, ownership, read-gate, completion,
+    # restart, and recovery contracts here; the full v4/CI suite still runs
+    # every permutation.
+    "tests/test_chatgpt_oracle_run.py::test_default_oracle_command_is_pinned_to_the_hash_validated_version",
+    "tests/test_chatgpt_oracle_run.py::test_conversation_url_helpers_preserve_exact_binding_and_detect_conflicts",
+    "tests/test_chatgpt_oracle_run.py::test_new_runs_use_dynamic_cdp_port_instead_of_global_9222",
+    "tests/test_chatgpt_oracle_run.py::test_fresh_execution_binds_runtime_task_but_plain_manifest_loading_stays_unbound",
+    "tests/test_chatgpt_oracle_run.py::test_task_outcome_terminal_watchdog_is_exactly_v1_and_scrubs_inherited_state",
+    "tests/test_chatgpt_oracle_run.py::test_foreign_task_recovery_is_fail_closed_before_browser_or_oracle_access",
+    "tests/test_chatgpt_oracle_run.py::test_legacy_unbound_recovery_is_not_adopted_by_the_current_task",
+    "tests/test_chatgpt_oracle_run.py::test_dry_run_never_executes_and_has_no_file_flag",
+    "tests/test_chatgpt_oracle_run.py::test_default_signed_in_profile_is_copied_per_run_and_window_is_hidden",
+    "tests/test_chatgpt_oracle_run.py::test_regular_runs_use_provider_window_and_nonterminal_status_audit",
+    "tests/test_chatgpt_oracle_run.py::test_pro_readonly_dry_run_fails_before_layout_without_fresh_app_read_gate",
+    "tests/test_chatgpt_oracle_run.py::test_pro_readonly_dry_run_reports_bound_app_read_gate",
+    "tests/test_chatgpt_oracle_run.py::test_new_writable_pro_manifest_is_rejected_before_layout_or_browser",
+    "tests/test_chatgpt_oracle_run.py::test_d_coin_missing_exact_root_blocks_before_oracle_or_run_creation",
+    "tests/test_chatgpt_oracle_run.py::test_complete_requires_zero_exit_and_nonempty_output",
+    "tests/test_chatgpt_oracle_run.py::test_v1_task_outcome_separates_transport_success_from_execution",
+    "tests/test_chatgpt_oracle_run.py::test_devspace_patch_change_blocks_before_submission_until_restart",
+    "tests/test_chatgpt_oracle_run.py::test_post_submit_nonzero_requires_exact_recovery_and_never_restarts",
+    "tests/test_chatgpt_oracle_run.py::test_recovery_captures_output_and_updates_state",
+    "tests/test_chatgpt_oracle_run.py::test_unresolved_exact_session_blocks_different_parent_submission",
+    "tests/test_chatgpt_oracle_run.py::test_recovery_never_downgrades_durable_complete",
     "tests/test_chatgpt_oracle_diagnose.py",
     "tests/test_chatgpt_oracle_incident.py",
     "tests/test_chatgpt_oracle_compat.py",

--- a/scripts/start_devspace_bootstrap.ps1
+++ b/scripts/start_devspace_bootstrap.ps1
@@ -6,7 +6,7 @@ param(
   [ValidateSet('Once', 'Watch')]
   [string]$Mode = 'Once',
   [ValidateRange(0, 86400)]
-  [int]$WatchIntervalSeconds = 300,
+  [int]$WatchIntervalSeconds = 30,
   [ValidateRange(0, 86400)]
   [int]$FailureRetrySeconds = 60,
   [ValidateRange(0, 1000000)]
@@ -29,6 +29,16 @@ function Write-BootstrapLog([string]$Message) {
   Add-Content -LiteralPath $LogPath -Encoding UTF8 -Value ("[{0}] {1}" -f (Get-Date -Format 'yyyy-MM-dd HH:mm:ss'), $Message)
 }
 
+function Get-TextSha256([string]$Text) {
+  $Hasher = [Security.Cryptography.SHA256]::Create()
+  try {
+    $Bytes = [Text.Encoding]::UTF8.GetBytes($Text)
+    return ([BitConverter]::ToString($Hasher.ComputeHash($Bytes))).Replace('-', '').ToLowerInvariant()
+  } finally {
+    $Hasher.Dispose()
+  }
+}
+
 $Mutex = New-Object Threading.Mutex($false, ("Local\{0}" -f $MutexName))
 $Acquired = $false
 try {
@@ -39,14 +49,6 @@ try {
   $Config = Get-Content -LiteralPath $ConfigPath -Raw -Encoding UTF8 | ConvertFrom-Json
   if ([string]$Config.schema -ne 'codexpro.devspace-bootstrap/v1') { throw 'Unsupported bootstrap config schema.' }
   if (!(Test-Path -LiteralPath $DevSpaceConfigPath)) { throw "DevSpace config missing: $DevSpaceConfigPath" }
-  $DevSpaceConfig = Get-Content -LiteralPath $DevSpaceConfigPath -Raw -Encoding UTF8 | ConvertFrom-Json
-  $AllowedRoots = @($DevSpaceConfig.allowedRoots)
-  if ($AllowedRoots.Count -eq 0) { throw 'DevSpace config allowedRoots is missing or empty.' }
-  foreach ($Root in $AllowedRoots) {
-    if (![IO.Path]::IsPathRooted([string]$Root)) {
-      throw "DevSpace config allowedRoot is not absolute: $Root"
-    }
-  }
   $Python = [string]$Config.python_path
   if (!$Python) {
     $PythonCommand = Get-Command python.exe,python -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -59,32 +61,59 @@ try {
   if (Test-Path -LiteralPath 'C:\Program Files\Tailscale') {
     $env:PATH = 'C:\Program Files\Tailscale;' + $env:PATH
   }
-  $Arguments = @($Helper, 'recover')
-  foreach ($Root in $AllowedRoots) { $Arguments += @('--root', [IO.Path]::GetFullPath([string]$Root)) }
-  $Arguments += @('--hostname', [string]$Config.hostname)
-  if ($Config.local_port) { $Arguments += @('--local-port', [string]$Config.local_port) }
-  if ($Config.public_port) { $Arguments += @('--public-port', [string]$Config.public_port) }
-  Write-BootstrapLog ("Loaded {0} allowed roots from {1}." -f $AllowedRoots.Count, $DevSpaceConfigPath)
+  function Get-RecoveryInvocation {
+    $RawConfig = Get-Content -LiteralPath $DevSpaceConfigPath -Raw -Encoding UTF8
+    $LiveConfig = $RawConfig | ConvertFrom-Json
+    $LiveRoots = @($LiveConfig.allowedRoots)
+    if ($LiveRoots.Count -eq 0) { throw 'DevSpace config allowedRoots is missing or empty.' }
+    $Arguments = @($Helper, 'recover')
+    foreach ($Root in $LiveRoots) {
+      if (![IO.Path]::IsPathRooted([string]$Root)) { throw "DevSpace config allowedRoot is not absolute: $Root" }
+      $Arguments += @('--root', [IO.Path]::GetFullPath([string]$Root))
+    }
+    $Arguments += @('--hostname', [string]$Config.hostname)
+    if ($Config.local_port) { $Arguments += @('--local-port', [string]$Config.local_port) }
+    if ($Config.public_port) { $Arguments += @('--public-port', [string]$Config.public_port) }
+    return [pscustomobject]@{ Arguments = $Arguments; RootCount = $LiveRoots.Count; ConfigSha256 = Get-TextSha256 $RawConfig }
+  }
 
   $Cycle = 0
   $PreviouslyHealthy = $false
+  $PreviousConfigSha256 = ''
   while ($true) {
     $Cycle++
     $Healthy = $false
     for ($Attempt = 1; $Attempt -le 6; $Attempt++) {
       $PreviousPreference = $ErrorActionPreference
+      $RecoveryOutput = @()
       try {
+        $Invocation = Get-RecoveryInvocation
+        if ($Invocation.ConfigSha256 -ne $PreviousConfigSha256) {
+          Write-BootstrapLog ("Loaded {0} allowed roots from {1} (sha256={2})." -f $Invocation.RootCount, $DevSpaceConfigPath, $Invocation.ConfigSha256)
+          $PreviousConfigSha256 = $Invocation.ConfigSha256
+        }
         $ErrorActionPreference = 'Continue'
-        & $Python @Arguments *> $null
+        $Arguments = @($Invocation.Arguments)
+        $RecoveryOutput = @(& $Python @Arguments 2>&1)
         $ExitCode = $LASTEXITCODE
       } finally {
         $ErrorActionPreference = $PreviousPreference
       }
       if ($ExitCode -eq 0) {
+        $RecoveryText = ($RecoveryOutput -join [Environment]::NewLine).Trim()
+        try { $Recovery = $RecoveryText | ConvertFrom-Json -ErrorAction Stop } catch {
+          Write-BootstrapLog "Recovery cycle $Cycle attempt $Attempt returned invalid JSON (sha256=$(Get-TextSha256 $RecoveryText))."
+          $ExitCode = 1
+          continue
+        }
+        if ([bool]$Recovery.service_started) {
+          $Service = $Recovery.service
+          Write-BootstrapLog ("DevSpace restarted (cycle={0}, attempt={1}, supervisor_pid={2}, child_pid={3}, state={4})." -f $Cycle, $Attempt, $Service.supervisor_pid, $Service.child_pid, $Service.state_path)
+        }
         $Healthy = $true
         break
       }
-      Write-BootstrapLog "Recovery cycle $Cycle attempt $Attempt failed with exit code $ExitCode."
+      Write-BootstrapLog "Recovery cycle $Cycle attempt $Attempt failed with exit code $ExitCode (output_sha256=$(Get-TextSha256 (($RecoveryOutput -join [Environment]::NewLine).Trim()))."
       if ($Attempt -lt 6) { Start-Sleep -Seconds 15 }
     }
 

--- a/skills/chatgpt-workspace-setup/SKILL.md
+++ b/skills/chatgpt-workspace-setup/SKILL.md
@@ -85,6 +85,11 @@ active Node runtime and opens an in-memory database. A missing npm 12 native
 binding fails closed with `DEVSPACE_NATIVE_BINDING_UNAVAILABLE`; never approve
 an unbounded list of install scripts automatically.
 
+Recovery first primes the exact pinned package and may approve/rebuild only
+the hash-bound `better-sqlite3@12.11.1` dependency. It starts a redacting
+supervisor that records PID/start/exit evidence and rotates stdout/stderr while
+streaming; request, tool-call, and shell-command logs stay disabled.
+
 The only app information to enter manually in ChatGPT Developer Mode is:
 
 - Recommended app name: `codex`

--- a/skills/chatgpt-workspace-setup/SKILL.md
+++ b/skills/chatgpt-workspace-setup/SKILL.md
@@ -40,12 +40,17 @@ Afterward the helper starts `devspace serve` hidden and creates an HTTPS Funnel
 to `127.0.0.1:7676`. During `devspace init`, enter only the listed roots and
 the public origin `https://<hostname>` (without `/mcp`).
 
-Before starting or restarting DevSpace 1.0.7, run the installed
+Before starting or restarting DevSpace 1.0.8, run the installed
 `bin/chatgpt_devspace_compat.py`. It hash-validates the exact upstream
 `dist/workspaces.js`, backs it up, and applies bounded concurrent discovery
 that skips transient `.pytest-*` and cache trees. If it reports
 `service_restart_required=true`, restart DevSpace before any Oracle
 submission. Unknown versions or hashes fail closed.
+
+DevSpace 1.0.8 also ships an optional local-agent daemon and provider CLI
+adapters. The managed ChatGPT workspace service always sets
+`DEVSPACE_SUBAGENTS=false`; enabling that separate execution surface requires
+an explicit user action outside this setup skill.
 
 The same hash-gated compatibility layer exposes read-only `read_chunk` for a
 regular UTF-8 file whose single line exceeds the upstream 50KB line reader.
@@ -116,7 +121,7 @@ ChatGPT app works. A Pro submission must never be the first connectivity test.
 For a terminal `OAuth token request failed 503` that begins only when a
 previously working long run reaches access-token expiry, run the exact
 DevSpace compatibility helper before changing any credential or ChatGPT app
-setting. Its 1.0.7 contract hash-gates a short, client/scope/resource-bound
+setting. Its 1.0.8 contract hash-gates a short, client/scope/resource-bound
 refresh replay grace and exercises it against an isolated SQLite database.
 Preserve the real OAuth database, roots, Owner credential, and Funnel; restart
 only the exact managed service once, then require a regular non-Pro exact-root

--- a/skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py
+++ b/skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py
@@ -16,12 +16,15 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Sequence, TextIO
+import uuid
 
 
 DEFAULT_PORT = 7676
@@ -29,9 +32,21 @@ APP_NAME = "codex"
 DEVSPACE_PACKAGE = "@waishnav/devspace@1.0.8"
 DEVSPACE_TOOL_MODE = "full"
 DEVSPACE_OAUTH_SCOPES = "devspace,offline_access"
-SECRET_PATTERN = re.compile(r"(?i)(password|token|secret|authorization)\s*([:=])\s*[^\s,;]+")
+SERVICE_STATE_SCHEMA = "codex.chatgpt.devspace-managed-service/v1"
+SERVICE_LOG_MAX_BYTES = 5 * 1024 * 1024
+# Values can be quoted and headers/cookie chains may carry more than one secret.
+SECRET_PATTERN = re.compile(
+    r"(?i)\b([a-z0-9_-]*(?:password|token|secret|authorization|cookie|oauth_code|"
+    r"code_verifier)[a-z0-9_-]*)([\"']?\s*[:=]\s*[\"']?)([^\"'\s,;&]+)"
+)
+AUTH_SCHEME_PATTERN = re.compile(
+    r"(?i)\b((?:Bearer|Basic)\s+)(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|[^\s,;]+)"
+)
+QUERY_SECRET_PATTERN = re.compile(r"(?i)([?&](?:code|token|access_token|refresh_token)=)[^&\s]+")
+COOKIE_VALUE_PATTERN = re.compile(r"(?i)(\b[^=;\s]*(?:session|token|auth|cookie)[^=;\s]*=)[^;\s]+")
 HOSTNAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9.-]*\.ts\.net$", re.IGNORECASE)
 WINDOWS_BOOTSTRAP_RUN_NAME = "Codex Web GPT DevSpace Bootstrap"
+WINDOWS_BOOTSTRAP_WATCH_SECONDS = 30
 
 
 class SetupError(ValueError):
@@ -58,9 +73,20 @@ class SetupConfig:
     def local_mcp_url(self) -> str:
         return f"http://127.0.0.1:{self.local_port}/mcp"
 
+    @property
+    def local_health_url(self) -> str:
+        return f"http://127.0.0.1:{self.local_port}/healthz"
+
+    @property
+    def public_health_url(self) -> str:
+        return f"{self.public_origin}/healthz"
+
 
 def redact(value: str) -> str:
-    return SECRET_PATTERN.sub(lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]", value)
+    redacted = AUTH_SCHEME_PATTERN.sub(lambda match: f"{match.group(1)}[REDACTED]", value)
+    redacted = QUERY_SECRET_PATTERN.sub(lambda match: f"{match.group(1)}[REDACTED]", redacted)
+    redacted = SECRET_PATTERN.sub(lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]", redacted)
+    return COOKIE_VALUE_PATTERN.sub(lambda match: f"{match.group(1)}[REDACTED]", redacted)
 
 
 def _is_volume_root(path: Path) -> bool:
@@ -154,6 +180,17 @@ def devspace_native_argv(*, allow_package_absent: bool = False) -> list[str]:
     return argv
 
 
+def devspace_native_prepare_argv() -> list[str]:
+    argv = devspace_compat_argv()
+    argv.append("--prepare-native-runtime")
+    return argv
+
+
+def devspace_package_prepare_argv(*, platform_name: str | None = None) -> list[str]:
+    """Materialize the exact pinned npx tree before inspecting/rebuilding it."""
+    return command_argv(["npx", "--yes", DEVSPACE_PACKAGE, "--version"], platform_name=platform_name)
+
+
 def setup_plan(
     config: SetupConfig,
     *,
@@ -172,15 +209,20 @@ def setup_plan(
         "root_merge_applied": bool(preserved),
         "root_safety": "existing allowedRoots are preserved; setup must use the complete displayed list",
         "devspace_init": command_argv(["npx", "--yes", DEVSPACE_PACKAGE, "init"], platform_name=platform_name),
+        "devspace_package_prepare": devspace_package_prepare_argv(platform_name=platform_name),
+        "devspace_native_prepare": devspace_native_prepare_argv(),
         "devspace_serve": command_argv(["npx", "--yes", DEVSPACE_PACKAGE, "serve"], platform_name=platform_name),
         "managed_service_environment": {
             "DEVSPACE_TOOL_MODE": DEVSPACE_TOOL_MODE,
             "DEVSPACE_OAUTH_SCOPES": DEVSPACE_OAUTH_SCOPES,
             "DEVSPACE_SUBAGENTS": "false",
+            "DEVSPACE_LOG_REQUESTS": "false",
+            "DEVSPACE_LOG_TOOL_CALLS": "false",
+            "DEVSPACE_LOG_SHELL_COMMANDS": "false",
         },
         "startup_watchdog": {
             "windows_mode": "per-user login watchdog",
-            "health_interval_seconds": 300,
+            "health_interval_seconds": WINDOWS_BOOTSTRAP_WATCH_SECONDS,
             "runtime_root_source": str(Path.home() / ".devspace" / "config.json"),
         },
         "tailscale_funnel": [
@@ -199,7 +241,13 @@ def setup_plan(
 
 
 def run_checked(argv: Sequence[str], *, runner: Callable[..., Any] = subprocess.run) -> None:
-    runner(list(argv), check=True, text=True, **windows_subprocess_kwargs())
+    completed = runner(
+        list(argv), check=False, capture_output=True, text=True, encoding="utf-8", errors="replace",
+        **windows_subprocess_kwargs(),
+    )
+    if completed.returncode != 0:
+        summary = redact((completed.stderr or completed.stdout or "").strip())[-1200:]
+        raise SetupError(f"MANAGED_COMMAND_FAILED:{completed.returncode}:{summary}")
 
 
 def run_interactive_checked(
@@ -302,6 +350,9 @@ def devspace_service_environment(base: dict[str, str] | None = None) -> dict[str
     # to enable that separate execution surface, even when an inherited host
     # environment or a legacy config opted into subagents.
     environment["DEVSPACE_SUBAGENTS"] = "false"
+    environment["DEVSPACE_LOG_REQUESTS"] = "false"
+    environment["DEVSPACE_LOG_TOOL_CALLS"] = "false"
+    environment["DEVSPACE_LOG_SHELL_COMMANDS"] = "false"
     return environment
 
 
@@ -361,22 +412,20 @@ def apply_setup(
         ]
         if missing:
             raise SetupError("DEVSPACE_SETUP_DID_NOT_PERSIST_COMPLETE_ALLOWED_ROOTS")
+    run_checked(devspace_package_prepare_argv(platform_name=platform_name), runner=runner)
+    run_checked(devspace_native_prepare_argv(), runner=runner)
     run_checked(devspace_native_argv(), runner=runner)
     run_checked(devspace_compat_argv(), runner=runner)
     run_checked(
         devspace_compat_argv(stop_exact_service=True, local_port=config.local_port),
         runner=runner,
     )
-    launch_hidden(
-        command_argv(["npx", "--yes", DEVSPACE_PACKAGE, "serve"], platform_name=platform_name),
-        popen_factory=popen_factory,
-        environment=devspace_service_environment(),
-        platform_name=platform_name,
-    )
+    launch_managed_devspace_service(popen_factory=popen_factory, platform_name=platform_name)
     run_checked(
         devspace_compat_argv(confirm_restarted=True, local_port=config.local_port),
         runner=runner,
     )
+    wait_for_local_readiness(config, opener=opener, sleeper=sleeper)
     ensure_public_route(config, opener=opener, runner=runner, sleeper=sleeper)
 
 
@@ -392,23 +441,27 @@ def recover_service(
     local = http_probe(config.local_mcp_url, opener=opener)
     service_started = not local.get("ok")
     if service_started:
+        run_checked(devspace_package_prepare_argv(), runner=runner)
+        run_checked(devspace_native_prepare_argv(), runner=runner)
         run_checked(devspace_native_argv(), runner=runner)
         run_checked(devspace_compat_argv(), runner=runner)
         run_checked(
             devspace_compat_argv(stop_exact_service=True, local_port=config.local_port),
             runner=runner,
         )
-        launch_hidden(
-            bash_argv(["npx", "--yes", DEVSPACE_PACKAGE, "serve"]),
-            popen_factory=popen_factory,
-            environment=devspace_service_environment(),
-        )
+        launch = launch_managed_devspace_service(popen_factory=popen_factory)
         run_checked(
             devspace_compat_argv(confirm_restarted=True, local_port=config.local_port),
             runner=runner,
         )
+    readiness = wait_for_local_readiness(config, opener=opener, sleeper=sleeper)
     result = ensure_public_route(config, opener=opener, runner=runner, sleeper=sleeper)
-    return {**result, "service_started": service_started}
+    return {
+        **result,
+        "service_started": service_started,
+        "service": managed_service_evidence(locals().get("launch")),
+        "local_readiness": readiness,
+    }
 
 
 def refresh_after_app_registration(
@@ -427,25 +480,26 @@ def refresh_after_app_registration(
     the existing config, Owner credential, OAuth database, roots, and Funnel
     hostname.
     """
+    run_checked(devspace_package_prepare_argv(), runner=runner)
+    run_checked(devspace_native_prepare_argv(), runner=runner)
     run_checked(devspace_native_argv(), runner=runner)
     run_checked(devspace_compat_argv(), runner=runner)
     run_checked(
         devspace_compat_argv(stop_exact_service=True, local_port=config.local_port),
         runner=runner,
     )
-    launch_hidden(
-        bash_argv(["npx", "--yes", DEVSPACE_PACKAGE, "serve"]),
-        popen_factory=popen_factory,
-        environment=devspace_service_environment(),
-    )
+    launch = launch_managed_devspace_service(popen_factory=popen_factory)
     run_checked(
         devspace_compat_argv(confirm_restarted=True, local_port=config.local_port),
         runner=runner,
     )
+    readiness = wait_for_local_readiness(config, opener=opener, sleeper=sleeper)
     result = refresh_exact_public_route(config, opener=opener, runner=runner, sleeper=sleeper)
     return {
         **result,
         "service_restarted": True,
+        "service": managed_service_evidence(launch),
+        "local_readiness": readiness,
         "credentials_preserved": True,
         "next_action": "VERIFY_REGISTERED_CHATGPT_APP_WITH_ORACLE",
         "verification_boundary": (
@@ -505,13 +559,238 @@ def refresh_exact_public_route(
     }
 
 
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def managed_service_paths(codex_home: Path | None = None) -> dict[str, Path]:
+    root = (
+        codex_home
+        or Path(os.environ.get("CODEX_HOME") or Path(__file__).resolve().parents[3])
+    ).expanduser().resolve()
+    log_root = root / "logs" / "codexpro-devspace"
+    state_root = root / "state" / "devspace-service"
+    return {
+        "stdout": log_root / "service.stdout.log",
+        "stderr": log_root / "service.stderr.log",
+        "events": log_root / "service-events.jsonl",
+        "state": state_root / "service-state.json",
+    }
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    if path.is_symlink():
+        raise SetupError("DEVSPACE_SERVICE_STATE_SYMLINK_UNSUPPORTED")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}-{uuid.uuid4().hex}")
+    try:
+        temporary.write_text(
+            json.dumps(payload, ensure_ascii=True, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _rotate_managed_log(
+    path: Path,
+    *,
+    max_bytes: int = SERVICE_LOG_MAX_BYTES,
+    incoming_bytes: int = 0,
+) -> None:
+    if path.is_symlink():
+        raise SetupError("DEVSPACE_SERVICE_LOG_SYMLINK_UNSUPPORTED")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.is_file():
+        return
+    current_size = path.stat().st_size
+    if incoming_bytes > 0 and current_size + incoming_bytes <= max_bytes:
+        return
+    if incoming_bytes == 0 and current_size < max_bytes:
+        return
+    archive = path.with_name(path.name + ".1")
+    if archive.is_symlink():
+        raise SetupError("DEVSPACE_SERVICE_LOG_ARCHIVE_SYMLINK_UNSUPPORTED")
+    archive.unlink(missing_ok=True)
+    os.replace(path, archive)
+
+
+def _bounded_log_records(value: str, *, max_bytes: int) -> list[str]:
+    """Encode one redacted line as records that individually fit the log cap."""
+    if max_bytes < 2:
+        raise SetupError("DEVSPACE_SERVICE_LOG_LIMIT_INVALID")
+    timestamp = f"[{_utc_now()}] "
+    prefix = timestamp if len(timestamp.encode("utf-8")) + 2 < max_bytes else ""
+    payload_budget = max_bytes - len(prefix.encode("utf-8")) - 1
+    records: list[str] = []
+    chunk: list[str] = []
+    chunk_bytes = 0
+    for character in value:
+        encoded_size = len(character.encode("utf-8"))
+        if chunk and chunk_bytes + encoded_size > payload_budget:
+            records.append(f"{prefix}{''.join(chunk)}\n")
+            chunk = []
+            chunk_bytes = 0
+        if encoded_size > payload_budget:
+            continue
+        chunk.append(character)
+        chunk_bytes += encoded_size
+    if chunk or not records:
+        records.append(f"{prefix}{''.join(chunk)}\n")
+    return records
+
+
+def _append_service_event(path: Path, payload: dict[str, Any]) -> None:
+    _rotate_managed_log(path)
+    if path.is_symlink():
+        raise SetupError("DEVSPACE_SERVICE_EVENT_LOG_SYMLINK_UNSUPPORTED")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8", newline="\n") as stream:
+        stream.write(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n")
+    os.chmod(path, 0o600)
+
+
+def _copy_redacted_stream(source: TextIO, target: Path, lock: threading.Lock) -> None:
+    """Persist a live stream in bounded form; never wait until process exit to rotate."""
+    for line in iter(source.readline, ""):
+        redacted = redact(line.rstrip())
+        with lock:
+            if target.is_symlink():
+                raise SetupError("DEVSPACE_SERVICE_LOG_SYMLINK_UNSUPPORTED")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            for record in _bounded_log_records(redacted, max_bytes=SERVICE_LOG_MAX_BYTES):
+                record_bytes = len(record.encode("utf-8"))
+                _rotate_managed_log(
+                    target,
+                    max_bytes=SERVICE_LOG_MAX_BYTES,
+                    incoming_bytes=record_bytes,
+                )
+                with target.open("a", encoding="utf-8", newline="\n") as destination:
+                    os.chmod(target, 0o600)
+                    destination.write(record)
+                    destination.flush()
+
+
+def managed_service_runner_argv() -> list[str]:
+    return [sys.executable, str(Path(__file__).resolve()), "service-runner"]
+
+
+def run_managed_devspace_service(
+    *,
+    popen_factory: Callable[..., Any] = subprocess.Popen,
+    platform_name: str | None = None,
+    codex_home: Path | None = None,
+) -> int:
+    """Run DevSpace under a redacting supervisor with PID/start/exit evidence."""
+    platform = platform_name or os.name
+    paths = managed_service_paths(codex_home)
+    for key in ("stdout", "stderr", "events"):
+        _rotate_managed_log(paths[key])
+    started_at = _utc_now()
+    base_state: dict[str, Any] = {
+        "schema": SERVICE_STATE_SCHEMA,
+        "status": "starting",
+        "package": DEVSPACE_PACKAGE,
+        "supervisor_pid": os.getpid(),
+        "started_at": started_at,
+        "stdout_path": str(paths["stdout"]),
+        "stderr_path": str(paths["stderr"]),
+        "events_path": str(paths["events"]),
+        "state_path": str(paths["state"]),
+    }
+    _write_json_atomic(paths["state"], base_state)
+    try:
+        child = popen_factory(
+            command_argv(["npx", "--yes", DEVSPACE_PACKAGE, "serve"], platform_name=platform),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+            shell=False,
+            env=devspace_service_environment(),
+            start_new_session=platform != "nt",
+            **windows_subprocess_kwargs(platform),
+        )
+    except Exception as error:
+        failed = {
+            **base_state,
+            "status": "launch_failed",
+            "ended_at": _utc_now(),
+            "error_type": type(error).__name__,
+            "error": redact(str(error))[:1000],
+        }
+        _write_json_atomic(paths["state"], failed)
+        _append_service_event(paths["events"], {**failed, "event": "launch_failed"})
+        return 1
+    running = {**base_state, "status": "running", "child_pid": int(child.pid)}
+    _write_json_atomic(paths["state"], running)
+    _append_service_event(paths["events"], {**running, "event": "started"})
+    if child.stdout is None or child.stderr is None:
+        raise SetupError("DEVSPACE_SERVICE_PIPE_UNAVAILABLE")
+    stdout_lock, stderr_lock = threading.Lock(), threading.Lock()
+    pumps = (
+        threading.Thread(target=_copy_redacted_stream, args=(child.stdout, paths["stdout"], stdout_lock), daemon=True),
+        threading.Thread(target=_copy_redacted_stream, args=(child.stderr, paths["stderr"], stderr_lock), daemon=True),
+    )
+    for pump in pumps:
+        pump.start()
+    exit_code = int(child.wait())
+    for pump in pumps:
+        pump.join(timeout=5)
+    ended = {**running, "status": "exited", "ended_at": _utc_now(), "exit_code": exit_code}
+    _write_json_atomic(paths["state"], ended)
+    _append_service_event(paths["events"], {**ended, "event": "exited"})
+    return exit_code
+
+
+def launch_managed_devspace_service(
+    *,
+    popen_factory: Callable[..., Any] = subprocess.Popen,
+    platform_name: str | None = None,
+    codex_home: Path | None = None,
+) -> dict[str, Any]:
+    paths = managed_service_paths(codex_home)
+    supervisor = launch_hidden(
+        managed_service_runner_argv(), popen_factory=popen_factory,
+        environment=devspace_service_environment(), platform_name=platform_name,
+    )
+    return {
+        "supervisor_pid": int(supervisor.pid),
+        "state_path": str(paths["state"]),
+        "stdout_path": str(paths["stdout"]),
+        "stderr_path": str(paths["stderr"]),
+        "events_path": str(paths["events"]),
+    }
+
+
+def managed_service_evidence(launch: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    paths = managed_service_paths()
+    if paths["state"].is_file() and not paths["state"].is_symlink():
+        try:
+            payload = json.loads(paths["state"].read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            payload = None
+        if isinstance(payload, dict) and payload.get("schema") == SERVICE_STATE_SCHEMA:
+            allowed = (
+                "schema", "status", "package", "supervisor_pid", "child_pid", "started_at", "ended_at",
+                "exit_code", "stdout_path", "stderr_path", "events_path", "state_path",
+            )
+            return {key: payload[key] for key in allowed if key in payload}
+    return dict(launch) if launch is not None else None
+
+
 def windows_bootstrap_watchdog_command(codex_home: Path | None = None) -> str:
     root = (codex_home or Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))).resolve()
     script = root / "scripts" / "start_devspace_bootstrap.ps1"
     powershell = Path(os.environ.get("SystemRoot") or r"C:\Windows") / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe"
     return (
         f'"{powershell}" -NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass '
-        f'-File "{script}" -Mode Watch -WatchIntervalSeconds 300'
+        f'-File "{script}" -Mode Watch -WatchIntervalSeconds {WINDOWS_BOOTSTRAP_WATCH_SECONDS}'
     )
 
 
@@ -561,7 +840,7 @@ def register_windows_bootstrap_watchdog(
             "-Mode",
             "Watch",
             "-WatchIntervalSeconds",
-            "300",
+            str(WINDOWS_BOOTSTRAP_WATCH_SECONDS),
         ],
         popen_factory=popen_factory,
         platform_name=platform,
@@ -572,7 +851,7 @@ def register_windows_bootstrap_watchdog(
         "platform": platform,
         "mode": "per-user-login-watchdog",
         "run_name": WINDOWS_BOOTSTRAP_RUN_NAME,
-        "watch_interval_seconds": 300,
+        "watch_interval_seconds": WINDOWS_BOOTSTRAP_WATCH_SECONDS,
     }
 
 
@@ -584,15 +863,34 @@ def wait_for_local_service(
     attempts: int = 60,
     delay_seconds: float = 2.0,
 ) -> dict[str, Any]:
-    """Wait for the exact loopback MCP endpoint without accepting a port-only signal."""
+    """Compatibility wrapper for the stronger managed service readiness check."""
+    return wait_for_local_readiness(
+        config, opener=opener, sleeper=sleeper, attempts=attempts, delay_seconds=delay_seconds,
+    )
+
+
+def wait_for_local_readiness(
+    config: SetupConfig,
+    *,
+    opener: Callable[..., Any] = urllib.request.urlopen,
+    sleeper: Callable[[float], None] = time.sleep,
+    attempts: int = 60,
+    delay_seconds: float = 2.0,
+) -> dict[str, Any]:
+    """Require two stable, consecutive loopback MCP and health observations."""
+    consecutive = 0
     last: dict[str, Any] = {"ok": False, "error": "DEVSPACE_LOCAL_SERVICE_NOT_READY"}
     for index in range(max(1, attempts)):
-        last = http_probe(config.local_mcp_url, opener=opener)
-        if last.get("ok"):
-            return last
+        mcp = http_probe(config.local_mcp_url, opener=opener)
+        health = http_probe(config.local_health_url, opener=opener)
+        healthy = bool(mcp.get("ok")) and health.get("status") == 200
+        last = {"ok": healthy, "mcp": mcp, "health": health, "consecutive": consecutive}
+        consecutive = consecutive + 1 if healthy else 0
+        if consecutive >= 2:
+            return {**last, "ok": True, "consecutive": consecutive}
         if index + 1 < attempts:
             sleeper(delay_seconds)
-    raise SetupError("DEVSPACE_LOCAL_SERVICE_NOT_READY")
+    raise SetupError("DEVSPACE_LOCAL_SERVICE_NOT_READY:" + json.dumps(last, ensure_ascii=True, sort_keys=True))
 
 
 def wait_for_public_service(
@@ -606,8 +904,10 @@ def wait_for_public_service(
     """Wait for Funnel relay propagation while retaining the last redacted probe."""
     last: dict[str, Any] = {"ok": False, "error": "DEVSPACE_PUBLIC_ENDPOINT_NOT_READY"}
     for index in range(max(1, attempts)):
-        last = http_probe(config.registration_url, opener=opener)
-        if last.get("ok"):
+        mcp = http_probe(config.registration_url, opener=opener)
+        health = http_probe(config.public_health_url, opener=opener)
+        last = {"ok": bool(mcp.get("ok")) and health.get("status") == 200, "mcp": mcp, "health": health}
+        if last["ok"]:
             return last
         if index + 1 < attempts:
             sleeper(delay_seconds)
@@ -951,6 +1251,7 @@ def parser() -> argparse.ArgumentParser:
     sub.choices["doctor"].add_argument("--chatgpt-call-failed", action="store_true")
     owner = sub.add_parser("owner-password")
     owner.add_argument("--auth-path", type=Path)
+    sub.add_parser("service-runner", help="internal managed DevSpace supervisor")
     return value
 
 
@@ -961,6 +1262,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = review_owner_password_interactive(auth_path=args.auth_path)
             print(json.dumps(result, ensure_ascii=True, indent=2))
             return 0
+        if args.command == "service-runner":
+            return run_managed_devspace_service()
         hostname = args.hostname or discover_tailscale_hostname()
         config = validate_config(args.root, hostname, args.local_port, args.public_port)
         if args.command == "setup":

--- a/skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py
+++ b/skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py
@@ -26,7 +26,7 @@ from typing import Any, Callable, Sequence
 
 DEFAULT_PORT = 7676
 APP_NAME = "codex"
-DEVSPACE_PACKAGE = "@waishnav/devspace@1.0.7"
+DEVSPACE_PACKAGE = "@waishnav/devspace@1.0.8"
 DEVSPACE_TOOL_MODE = "full"
 DEVSPACE_OAUTH_SCOPES = "devspace,offline_access"
 SECRET_PATTERN = re.compile(r"(?i)(password|token|secret|authorization)\s*([:=])\s*[^\s,;]+")
@@ -176,6 +176,7 @@ def setup_plan(
         "managed_service_environment": {
             "DEVSPACE_TOOL_MODE": DEVSPACE_TOOL_MODE,
             "DEVSPACE_OAUTH_SCOPES": DEVSPACE_OAUTH_SCOPES,
+            "DEVSPACE_SUBAGENTS": "false",
         },
         "startup_watchdog": {
             "windows_mode": "per-user login watchdog",
@@ -296,6 +297,11 @@ def devspace_service_environment(base: dict[str, str] | None = None) -> dict[str
     environment = dict(os.environ if base is None else base)
     environment["DEVSPACE_TOOL_MODE"] = DEVSPACE_TOOL_MODE
     environment["DEVSPACE_OAUTH_SCOPES"] = DEVSPACE_OAUTH_SCOPES
+    # DevSpace 1.0.8 adds an optional local-agent daemon that can invoke local
+    # provider CLIs.  The managed ChatGPT workspace service is not an authority
+    # to enable that separate execution surface, even when an inherited host
+    # environment or a legacy config opted into subagents.
+    environment["DEVSPACE_SUBAGENTS"] = "false"
     return environment
 
 
@@ -415,7 +421,7 @@ def refresh_after_app_registration(
 ) -> dict[str, Any]:
     """Recycle the managed server after manual ChatGPT OAuth registration.
 
-    DevSpace 1.0.7 can leave a newly approved ChatGPT connector unable to
+    DevSpace 1.0.8 can leave a newly approved ChatGPT connector unable to
     create its first tool session until the server is recycled.  This command
     is deliberately explicit: it never opens ChatGPT settings and it preserves
     the existing config, Owner credential, OAuth database, roots, and Funnel

--- a/tests/test_chatgpt_devspace_compat.py
+++ b/tests/test_chatgpt_devspace_compat.py
@@ -68,6 +68,60 @@ def test_native_runtime_probe_loads_exact_binding_and_fails_actionably(tmp_path:
     assert "install-scripts" in failure.value.evidence["next_action"]
 
 
+def test_native_prepare_is_exact_and_does_not_widen_script_approval(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compat = load_compat()
+    workspace = tmp_path / "npx"
+    package = workspace / "node_modules" / "@waishnav" / "devspace"
+    dependency = workspace / "node_modules" / "better-sqlite3"
+    dependency.mkdir(parents=True)
+    package.mkdir(parents=True)
+    package.joinpath("package.json").write_text(json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8")
+    dependency.joinpath("package.json").write_text(json.dumps({
+        "name": compat.NATIVE_DEPENDENCY_NAME, "version": compat.NATIVE_DEPENDENCY_VERSION,
+        "scripts": {"install": compat.NATIVE_DEPENDENCY_INSTALL_SCRIPT},
+    }), encoding="utf-8")
+    workspace.joinpath("package-lock.json").write_text(json.dumps({
+        "lockfileVersion": 3,
+        "packages": {f"node_modules/{compat.NATIVE_DEPENDENCY_NAME}": {
+            "version": compat.NATIVE_DEPENDENCY_VERSION, "integrity": compat.NATIVE_DEPENDENCY_INTEGRITY,
+            "resolved": compat.NATIVE_DEPENDENCY_RESOLVED, "hasInstallScript": True,
+        }},
+    }), encoding="utf-8")
+    policy_path = workspace / "package.json"
+    policy_path.write_text(json.dumps({"allowScripts": {"preserved@1.0.0": False}}), encoding="utf-8")
+    monkeypatch.setattr(compat.shutil, "which", lambda name: "node.exe" if name == "node" else "npm.cmd" if name in {"npm", "npm.cmd"} else None)
+    rebuilt = False
+    calls: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        nonlocal rebuilt
+        calls.append(list(argv))
+        if argv[0] == "node.exe":
+            return SimpleNamespace(returncode=0 if rebuilt else 1, stdout="", stderr="missing binding")
+        if argv[1:] == ["--version"]:
+            return SimpleNamespace(returncode=0, stdout="12.0.0\n", stderr="")
+        if "install-scripts" in argv:
+            payload = json.loads(policy_path.read_text(encoding="utf-8"))
+            payload["allowScripts"][f"{compat.NATIVE_DEPENDENCY_NAME}@{compat.NATIVE_DEPENDENCY_VERSION}"] = True
+            policy_path.write_text(json.dumps(payload), encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rebuild" in argv:
+            rebuilt = True
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(argv)
+
+    report = compat.prepare_native_runtime(package_root=package, runner=runner)
+    assert report["checks"][0]["status"] == "rebuilt-and-loadable"
+    assert json.loads(policy_path.read_text(encoding="utf-8"))["allowScripts"] == {
+        "preserved@1.0.0": False,
+        f"{compat.NATIVE_DEPENDENCY_NAME}@{compat.NATIVE_DEPENDENCY_VERSION}": True,
+    }
+    assert any("install-scripts" in call for call in calls)
+    assert any("rebuild" in call for call in calls)
+
+
 def test_oauth_refresh_replay_probe_is_isolated_and_fail_closed(tmp_path: Path) -> None:
     compat = load_compat()
     package = tmp_path / "devspace"
@@ -312,26 +366,30 @@ def test_stop_service_requires_exact_devspace_identity() -> None:
     compat = load_compat()
     stopped: list[int] = []
     package = Path("C:/tested/node_modules/@waishnav/devspace")
+    first_identity = {
+                "pid": 44,
+                "command_line": f"node {package / 'dist' / 'cli.js'} serve",
+                "started_at_unix_ns": 1,
+    }
+    first_probes = iter([first_identity, None])
     result = compat.stop_exact_devspace_service(
-        service_probe=lambda port: {
-            "pid": 44,
-            "command_line": f"node {package / 'dist' / 'cli.js'} serve",
-            "started_at_unix_ns": 1,
-        },
+        service_probe=lambda port: next(first_probes),
         stopper=stopped.append,
         package_roots=[package],
     )
     assert result["stopped"] is True
     assert stopped == [44]
 
-    npx_result = compat.stop_exact_devspace_service(
-        service_probe=lambda port: {
-            "pid": 45,
+    npx_identity = {
+                "pid": 45,
             "command_line": (
                 r'"node" "C:\tested\node_modules\.bin\\..\@waishnav\devspace\dist\cli.js" serve'
             ),
-            "started_at_unix_ns": 1,
-        },
+                "started_at_unix_ns": 1,
+    }
+    npx_probes = iter([npx_identity, None])
+    npx_result = compat.stop_exact_devspace_service(
+        service_probe=lambda port: next(npx_probes),
         stopper=stopped.append,
         package_roots=[package],
     )
@@ -364,16 +422,53 @@ def test_service_stop_resolves_current_and_lkg_roots(tmp_path: Path, monkeypatch
     assert compat.resolve_service_stop_roots() == [current.resolve(), lkg.resolve()]
 
     stopped: list[int] = []
-    result = compat.stop_exact_devspace_service(
-        service_probe=lambda port: {
-            "pid": 46,
+    identity = {
+                "pid": 46,
             "command_line": f"node {lkg / 'dist' / 'cli.js'} serve",
-            "started_at_unix_ns": 1,
-        },
+                "started_at_unix_ns": 1,
+    }
+    probes = iter([identity, None])
+    result = compat.stop_exact_devspace_service(
+        service_probe=lambda port: next(probes),
         stopper=stopped.append,
     )
     assert result["stopped"] is True
     assert stopped == [46]
+
+
+def test_windows_stop_requires_pid_start_binding_and_listener_release() -> None:
+    compat = load_compat()
+    package = Path("C:/tested/node_modules/@waishnav/devspace")
+    identity = {
+        "pid": 60008,
+        "command_line": f"node {package / 'dist' / 'cli.js'} serve",
+        "started_at_unix_ns": 123_000_000,
+    }
+    probes = iter([identity, None])
+    calls: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        calls.append(list(argv))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({
+                "ok": True, "pid": 60008, "stale_pid": False, "forced": False,
+                "process_exited": True, "listener_released": True, "listener_pid": None,
+            }),
+            stderr="",
+        )
+
+    result = compat.stop_exact_devspace_service(
+        service_probe=lambda port: next(probes), package_roots=[package], platform_name="nt",
+        windows_runner=runner, sleeper=lambda _: None,
+    )
+
+    script = calls[0][-1]
+    assert "Stop-Process -Id $targetPid -ErrorAction SilentlyContinue" in script
+    assert "Stop-Process -Id $targetPid -Force -ErrorAction SilentlyContinue" in script
+    assert "listener_released=$released" in script
+    assert result["stop"]["process_exited"] is True
+    assert result["stop"]["listener_released"] is True
 
 
 def test_stop_service_cli_forwards_validated_package_root(

--- a/tests/test_chatgpt_devspace_compat.py
+++ b/tests/test_chatgpt_devspace_compat.py
@@ -47,7 +47,7 @@ def test_native_runtime_probe_loads_exact_binding_and_fails_actionably(tmp_path:
     compat = load_compat()
     package = tmp_path / "devspace"
     package.mkdir()
-    (package / "package.json").write_text(json.dumps({"version": "1.0.7"}), encoding="utf-8")
+    (package / "package.json").write_text(json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8")
     calls: list[tuple[list[str], dict]] = []
 
     def passing(argv, **kwargs):
@@ -163,7 +163,7 @@ def test_exact_devspace_patch_is_hash_gated_idempotent_and_backed_up(
     compat = load_compat()
     package = tmp_path / "package"
     package.mkdir()
-    (package / "package.json").write_text(json.dumps({"version": "1.0.7"}), encoding="utf-8")
+    (package / "package.json").write_text(json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8")
     target = package / "sample.txt"
     target.write_bytes(b"before\n")
     patches = tmp_path / "patches"
@@ -218,7 +218,7 @@ def test_exact_devspace_patch_accepts_only_hash_bound_upgrade_chain(
     compat = load_compat()
     package = tmp_path / "package"
     package.mkdir()
-    (package / "package.json").write_text(json.dumps({"version": "1.0.7"}), encoding="utf-8")
+    (package / "package.json").write_text(json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8")
     target = package / "sample.txt"
     target.write_bytes(b"middle-one\n")
     patches = tmp_path / "patches"
@@ -267,7 +267,7 @@ def test_restart_confirmation_rejects_old_or_foreign_listener(
     compat = load_compat()
     package = tmp_path / "package"
     package.mkdir()
-    (package / "package.json").write_text(json.dumps({"version": "1.0.7"}), encoding="utf-8")
+    (package / "package.json").write_text(json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8")
     (package / "sample.txt").write_bytes(b"after\n")
     compat.PATCHES = {
         "sample.txt": {
@@ -356,7 +356,7 @@ def test_service_stop_resolves_current_and_lkg_roots(tmp_path: Path, monkeypatch
     current = tmp_path / "current"
     lkg = tmp_path / "lkg"
     foreign = tmp_path / "foreign"
-    for root, version in ((current, "1.0.7"), (lkg, "1.0.4"), (foreign, "9.9.9")):
+    for root, version in ((current, compat.SUPPORTED_VERSION), (lkg, compat.LEGACY_LKG_VERSION), (foreign, "9.9.9")):
         root.mkdir()
         (root / "package.json").write_text(json.dumps({"version": version}), encoding="utf-8")
     monkeypatch.setattr(compat, "_candidate_roots", lambda: [foreign, lkg, current])
@@ -384,7 +384,7 @@ def test_stop_service_cli_forwards_validated_package_root(
     compat = load_compat()
     lkg = tmp_path / "lkg"
     lkg.mkdir()
-    (lkg / "package.json").write_text(json.dumps({"version": "1.0.4"}), encoding="utf-8")
+    (lkg / "package.json").write_text(json.dumps({"version": compat.LEGACY_LKG_VERSION}), encoding="utf-8")
     calls: list[dict] = []
     monkeypatch.setattr(
         compat,
@@ -460,7 +460,7 @@ def test_service_identity_rejects_posix_npm_shim_for_foreign_package(
 
 def test_unknown_devspace_version_or_file_hash_fails_closed(tmp_path: Path) -> None:
     compat = load_compat()
-    assert compat.LEGACY_LKG_VERSION == "1.0.4"
+    assert compat.LEGACY_LKG_VERSION == "1.0.7"
     package = tmp_path / "package"
     package.mkdir()
     (package / "package.json").write_text(json.dumps({"version": "2.0.0"}), encoding="utf-8")
@@ -473,7 +473,7 @@ def test_unknown_devspace_version_or_file_hash_fails_closed(tmp_path: Path) -> N
         compat.ensure_devspace_compatibility(package_root=package)
     assert legacy.value.code == "DEVSPACE_VERSION_UNVALIDATED"
 
-    (package / "package.json").write_text(json.dumps({"version": "1.0.7"}), encoding="utf-8")
+    (package / "package.json").write_text(json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8")
     (package / "sample.txt").write_bytes(b"unknown\n")
     compat.PATCHES = {
         "sample.txt": {
@@ -526,7 +526,7 @@ def test_oauth_refresh_patch_is_hash_gated_bounded_and_revocation_aware() -> Non
     assert "this.refreshReplays.clear();" in patch
 
 
-def test_107_workspace_bridge_patch_preserves_write_tools_and_adds_bounded_read_chunk() -> None:
+def test_108_workspace_bridge_patch_preserves_write_tools_and_adds_bounded_read_chunk() -> None:
     compat = load_compat()
     patch = (
         MODULE_PATH.parent
@@ -537,10 +537,10 @@ def test_107_workspace_bridge_patch_preserves_write_tools_and_adds_bounded_read_
 
     assert compat.PATCHES["dist/server.js"] == {
         "patch": "workspace-write-and-read-bridge.patch",
-        "pristine": "42d340924421182eea7f2580f96c8d1d5aae459061a6a90804e6900905ef2d72",
-        "patched": "3b258463fcd5a31b754727545ac2b6ecbc0dd922bee568573a8e5a0643842bfc",
+        "pristine": "bf3db902241b631d7c6fbaf12385243b46b4f2d4bb776b6ea7ca6c9d429a3263",
+        "patched": "1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c",
         "upgrades": {
-            "259b5810206bc87e1e16e7963d084f4c90adc19ea9f54b4655d90ad51e49a967": "tool-read-receipts.patch",
+            "659cb1011cd7ab7fb75debb21a44f030001797c2160a42beac527354be93e497": "tool-read-receipts.patch",
         },
     }
     assert 'delete: "delete_file"' in patch
@@ -592,7 +592,7 @@ def test_107_workspace_bridge_patch_preserves_write_tools_and_adds_bounded_read_
     assert "await writeToolReadReceipt" in receipt_patch
 
 
-def test_107_artifact_write_is_bound_to_audit_readonly_scope() -> None:
+def test_108_artifact_write_is_bound_to_audit_readonly_scope() -> None:
     compat = load_compat()
     artifact_patch = (
         MODULE_PATH.parent
@@ -618,14 +618,14 @@ def test_107_artifact_write_is_bound_to_audit_readonly_scope() -> None:
     assert server_patch.index('assertAuditReadonly(_meta, "download_artifact")') < server_patch.index("return server;")
 
 
-def test_107_tool_read_receipt_upgrade_is_immutable_and_records_only_successes(
+def test_108_tool_read_receipt_upgrade_is_immutable_and_records_only_successes(
     tmp_path: Path,
 ) -> None:
     compat = load_compat()
     try:
         source_root = compat.resolve_package_roots()[0]
     except compat.DevSpaceCompatError as exc:
-        pytest.skip(f"DevSpace 1.0.7 package unavailable: {exc.code}")
+        pytest.skip(f"DevSpace {compat.SUPPORTED_VERSION} package unavailable: {exc.code}")
     source = source_root / "dist" / "server.js"
     if compat.sha256_file(source) != next(iter(compat.PATCHES["dist/server.js"]["upgrades"])):
         pytest.skip("installed DevSpace server is not the prior hash-gated bridge payload")
@@ -689,7 +689,7 @@ def test_107_tool_read_receipt_upgrade_is_immutable_and_records_only_successes(
     assert json.loads(completed.stdout) == {"ok": True}
 
 
-def test_delete_file_contract_is_part_of_the_107_hash_gated_bridge() -> None:
+def test_delete_file_contract_is_part_of_the_108_hash_gated_bridge() -> None:
     compat = load_compat()
     patch_path = MODULE_PATH.parent / "devspace-compat" / compat.SUPPORTED_VERSION / "workspace-write-and-read-bridge.patch"
     patch = patch_path.read_text(encoding="utf-8")
@@ -702,7 +702,7 @@ def test_delete_file_contract_is_part_of_the_107_hash_gated_bridge() -> None:
     assert "readOnlyHint: false" in patch
 
 
-def test_trash_file_contract_is_part_of_the_107_hash_gated_bridge() -> None:
+def test_trash_file_contract_is_part_of_the_108_hash_gated_bridge() -> None:
     compat = load_compat()
     patch = (
         MODULE_PATH.parent
@@ -724,14 +724,14 @@ def test_trash_file_contract_is_part_of_the_107_hash_gated_bridge() -> None:
     assert "readOnlyHint: false" in patch
 
 
-def test_published_107_default_contract_applies_every_current_patch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_published_108_default_contract_applies_every_current_patch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     compat = load_compat()
-    configured = os.environ.get("DEVSPACE_107_PACKAGE_ROOT", "").strip()
-    source = Path(configured) if configured else Path("__devspace_107_cache_unset__")
+    configured = os.environ.get("DEVSPACE_108_PACKAGE_ROOT", "").strip()
+    source = Path(configured) if configured else Path("__devspace_108_cache_unset__")
     if not source.is_dir():
         if os.environ.get("CI"):
-            pytest.fail("CI must prepare the exact published DevSpace 1.0.7 package")
-        pytest.skip("published DevSpace 1.0.7 package root is unavailable")
+            pytest.fail("CI must prepare the exact published DevSpace 1.0.8 package")
+        pytest.skip("published DevSpace 1.0.8 package root is unavailable")
     package = tmp_path / "devspace-published"
     shutil.copytree(source, package)
     monkeypatch.setenv("CODEX_DEVSPACE_COMPAT_STATE_ROOT", str(tmp_path / "state"))
@@ -768,11 +768,11 @@ def test_delete_file_patch_safety_contract_on_temporary_workspace(
     try:
         source_root = compat.resolve_package_roots()[0]
     except compat.DevSpaceCompatError as exc:
-        pytest.skip(f"DevSpace 1.0.7 package unavailable: {exc.code}")
+        pytest.skip(f"DevSpace {compat.SUPPORTED_VERSION} package unavailable: {exc.code}")
     package = tmp_path / "devspace"
     (package / "dist").mkdir(parents=True)
     shutil.copy2(source_root / "dist" / "server.js", package / "dist" / "server.js")
-    (package / "package.json").write_text(json.dumps({"version": "1.0.7"}), encoding="utf-8")
+    (package / "package.json").write_text(json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8")
     monkeypatch.setenv("CODEX_DEVSPACE_COMPAT_STATE_ROOT", str(tmp_path / "state"))
     compat.PATCHES = {"dist/server.js": compat.PATCHES["dist/server.js"]}
     compat.ensure_devspace_compatibility(package_root=package, backup_root=tmp_path / "backup")
@@ -834,11 +834,11 @@ def test_trash_file_patch_safety_and_byte_identity_on_temporary_workspace(
     try:
         source_root = compat.resolve_package_roots()[0]
     except compat.DevSpaceCompatError as exc:
-        pytest.skip(f"DevSpace 1.0.7 package unavailable: {exc.code}")
+        pytest.skip(f"DevSpace {compat.SUPPORTED_VERSION} package unavailable: {exc.code}")
     package = tmp_path / "devspace"
     (package / "dist").mkdir(parents=True)
     shutil.copy2(source_root / "dist" / "server.js", package / "dist" / "server.js")
-    (package / "package.json").write_text(json.dumps({"version": "1.0.7"}), encoding="utf-8")
+    (package / "package.json").write_text(json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8")
     monkeypatch.setenv("CODEX_DEVSPACE_COMPAT_STATE_ROOT", str(tmp_path / "state"))
     compat.PATCHES = {"dist/server.js": compat.PATCHES["dist/server.js"]}
 
@@ -903,7 +903,7 @@ def test_directory_read_patch_unknown_upstream_hash_fails_closed(tmp_path: Path)
     compat = load_compat()
     package = tmp_path / "package"
     package.mkdir()
-    (package / "package.json").write_text(json.dumps({"version": "1.0.7"}), encoding="utf-8")
+    (package / "package.json").write_text(json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8")
     server = package / "dist" / "server.js"
     server.parent.mkdir()
     server.write_text("unknown upstream bytes\\n", encoding="utf-8")

--- a/tests/test_chatgpt_oracle_comprehensive.py
+++ b/tests/test_chatgpt_oracle_comprehensive.py
@@ -794,6 +794,126 @@ def test_running_oracle_stage_recovers_exact_run_without_resubmission(tmp_path: 
     assert second["recovery"]["status"] == "recovered"
 
 
+def test_exact_root_preflight_exception_settles_before_layout_without_resubmission(
+    tmp_path: Path,
+) -> None:
+    module = load()
+    attempts = 0
+
+    def exact_root_blocked(oracle_manifest: Path, *, dry_run: bool):
+        nonlocal attempts
+        attempts += 1
+        raise module.RUNNER.OracleRunError(
+            "DEVSPACE_EXACT_ROOT_UNAVAILABLE",
+            "the exact project root is not registered in DevSpace allowedRoots",
+            {"missing_root": str(tmp_path)},
+        )
+
+    workflow_manifest = manifest(tmp_path)
+    result = module.run_workflow(workflow_manifest, oracle_execute=exact_root_blocked)
+    config = module.load_manifest(workflow_manifest)
+    state = json.loads(module._state_path(config, "a" * 32).read_text(encoding="utf-8"))
+    record = state["records"][-1]
+
+    assert attempts == 1
+    assert result["status"] == "attention_required"
+    assert result["safe_for_fresh_run"] is False
+    assert result["settlement"] == "oracle-layout-not-created-pre-submit"
+    assert state["status"] == "attention_required"
+    assert state["pre_submit_retries"] == 0
+    assert record["failure_code"] == "DEVSPACE_EXACT_ROOT_UNAVAILABLE"
+    assert record["settlement_proof"]["kind"] == "oracle-layout-not-created"
+    assert not Path(record["run_dir"]).exists()
+
+
+def test_legacy_missing_layout_state_remains_attention_required_without_submission(
+    tmp_path: Path,
+) -> None:
+    module = load()
+    planned_run_dirs: list[Path] = []
+
+    def legacy_preflight_crash(oracle_manifest: Path, *, dry_run: bool):
+        oracle_config = module.RUNNER.STATE.load_manifest(oracle_manifest)
+        layout = module.RUNNER.STATE.create_layout(
+            oracle_config, run_id=oracle_config.requested_run_id
+        )
+        planned_run_dirs.append(layout.run_dir)
+        raise RuntimeError("legacy exact-root preflight escaped before layout creation")
+
+    workflow_manifest = manifest(tmp_path)
+    with pytest.raises(RuntimeError, match="before layout creation"):
+        module.run_workflow(workflow_manifest, oracle_execute=legacy_preflight_crash)
+
+    config = module.load_manifest(workflow_manifest)
+    config["_review_policy"] = module._review_policy_from_history(config)
+    state_path = module._state_path(config, "a" * 32)
+    legacy_state = json.loads(state_path.read_text(encoding="utf-8"))
+    legacy_state["status"] = "attention_required"
+    legacy_state["records"] = [{
+        "stage": "plan",
+        "run_id": legacy_state["current_attempt_id"],
+        "run_dir": legacy_state["oracle_run_dir"],
+        "recovered": True,
+        "recovery_status": None,
+    }]
+    module._write_workflow_state(state_path, config, legacy_state)
+
+    def forbidden_execute(*args, **kwargs):
+        raise AssertionError("settlement must not submit a replacement")
+
+    def forbidden_recover(*args, **kwargs):
+        raise AssertionError("an absent layout has no exact session to recover")
+
+    settled = module.run_workflow(
+        workflow_manifest,
+        oracle_execute=forbidden_execute,
+        oracle_recover=forbidden_recover,
+    )
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+
+    assert len(planned_run_dirs) == 1
+    assert not planned_run_dirs[0].exists()
+    assert settled["status"] == "attention_required"
+    assert settled["safe_for_fresh_run"] is False
+    assert settled["settlement"] == "oracle-layout-not-created-pre-submit"
+    assert persisted["status"] == "attention_required"
+    assert persisted["pre_submit_retries"] == 0
+    assert persisted["records"][-1]["failure_code"] == "ORACLE_LAYOUT_NOT_CREATED_PRE_SUBMIT"
+
+
+def test_missing_layout_with_execution_result_record_remains_fail_closed(tmp_path: Path) -> None:
+    module = load()
+
+    def legacy_crash(oracle_manifest: Path, *, dry_run: bool):
+        raise RuntimeError("legacy crash")
+
+    workflow_manifest = manifest(tmp_path)
+    with pytest.raises(RuntimeError, match="legacy crash"):
+        module.run_workflow(workflow_manifest, oracle_execute=legacy_crash)
+
+    config = module.load_manifest(workflow_manifest)
+    config["_review_policy"] = module._review_policy_from_history(config)
+    state_path = module._state_path(config, "a" * 32)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["records"] = [{
+        "stage": "plan",
+        "run_dir": state["oracle_run_dir"],
+        "ok": False,
+    }]
+    module._write_workflow_state(state_path, config, state)
+
+    result = module.run_workflow(
+        workflow_manifest,
+        oracle_execute=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("missing-layout recovery must not submit")
+        ),
+    )
+
+    assert result["status"] == "attention_required"
+    assert result["recovery"]["error"] == "ORACLE_RECOVERY_RUN_UNAVAILABLE"
+    assert result.get("safe_for_fresh_run") is not True
+
+
 def test_post_submit_watchdog_persists_same_attempt_and_only_exact_recovers(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_chatgpt_oracle_diagnose.py
+++ b/tests/test_chatgpt_oracle_diagnose.py
@@ -92,6 +92,42 @@ def test_report_buckets_pre_submit_ui_and_host_causes_separately(tmp_path: Path)
     ]
 
 
+@pytest.mark.parametrize(
+    ("stderr", "signature"),
+    [
+        (
+            "Oracle launch/run failed: project submit mutex could not be acquired",
+            "project-submit-mutex-held",
+        ),
+        (
+            "PROJECT_SESSION_STILL_LIVE: an exact Oracle session still owns this project",
+            "same-task-project-session-still-live",
+        ),
+    ],
+)
+def test_pre_submit_ownership_conflicts_are_classified_but_never_retry_safe(
+    tmp_path: Path,
+    stderr: str,
+    signature: str,
+) -> None:
+    module = load()
+    state_root = tmp_path / "oracle-state"
+    run_dir = write_run(
+        state_root,
+        "o" * 8,
+        status="failed",
+        session_authority="pre_submit",
+    )
+    (run_dir / "stderr.log").write_text(stderr, encoding="utf-8")
+
+    report = module.diagnose(state_root)
+    run = report["unresolved_runs"][0]
+
+    assert run["bucket"] == "submission-ownership-conflict"
+    assert run["signature"] == signature
+    assert "submission-ownership-conflict" not in report["safe_for_fresh_run_buckets"]
+
+
 def test_pre_submit_signature_outranks_post_submit_interpretation(tmp_path: Path) -> None:
     module = load()
     state_root = tmp_path / "oracle-state"
@@ -848,6 +884,126 @@ def test_oauth_503_outranks_foreign_connector_search_evidence(tmp_path: Path) ->
     verdict = module.diagnose(state_root)["unresolved_runs"][0]
 
     assert verdict["signature"] == "registered-app-oauth-token-request-503"
+
+
+def test_terminal_devspace_checkout_502_nonexecution_has_a_bounded_signature(
+    tmp_path: Path,
+) -> None:
+    module = load()
+    state_root = tmp_path / "oracle-state"
+    project_root = state_root / "project"
+    run_dir = write_run(
+        state_root,
+        "x" * 12,
+        status="attention_required",
+        output=(
+            f"I opened the exact project root {project_root} in checkout mode.\n"
+            "The checkout failed with 502 Upstream or external service errors and no workspace ID.\n"
+            "I did not read the mission, did not run commands, and did not change files.\n"
+            "TASK_OUTCOME: BLOCKED\n"
+        ),
+        session_authority="terminal",
+        terminal_harvested=True,
+        task_outcome="blocked",
+    )
+    state_path = run_dir / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["transport"] = "pro-devspace"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    verdict = module.diagnose(state_root)["unresolved_runs"][0]
+
+    assert verdict["bucket"] == "terminal-task-not-executed"
+    assert verdict["signature"] == "terminal-devspace-checkout-502-no-execution"
+
+
+def test_terminal_devspace_app_tools_unavailable_has_its_own_bounded_signature(
+    tmp_path: Path,
+) -> None:
+    module = load()
+    state_root = tmp_path / "oracle-state"
+    project_root = state_root / "project"
+    run_dir = write_run(
+        state_root,
+        "y" * 12,
+        status="attention_required",
+        output=(
+            "이 세션에는 dev 앱이 제공하는 workspace 도구가 노출되어 있지 않아 "
+            f"지정한 {project_root}를 dev checkout 모드로 열 수 없습니다. "
+            "사용자가 금지한 다른 workspace 커넥터·셸·웹·Oracle 우회는 시도하지 않았으며, "
+            "따라서 미션 파일이나 AGENTS.md도 읽거나 수정하지 않았습니다.\n"
+            "TASK_OUTCOME: BLOCKED\n"
+        ),
+        session_authority="terminal",
+        terminal_harvested=True,
+        task_outcome="blocked",
+    )
+    state_path = run_dir / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.update({"transport": "devspace", "app_name": "dev"})
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    verdict = module.diagnose(state_root)["unresolved_runs"][0]
+
+    assert verdict["bucket"] == "terminal-task-not-executed"
+    assert verdict["signature"] == (
+        "terminal-devspace-app-tools-unavailable-no-execution"
+    )
+
+
+def test_terminal_devspace_read_chunk_exposure_failure_has_bounded_signature(
+    tmp_path: Path,
+) -> None:
+    module = load()
+    state_root = tmp_path / "oracle-state"
+    project_root = state_root / "project"
+    escaped_root = str(project_root).replace("\\", "\\\\")
+    output = (
+        "* 앱: `dev`\n"
+        "* Workspace ID: `ws_a0770e8338`\n"
+        f"* 정확한 루트: `{escaped_root}`\n"
+        "* 모드: `checkout`\n"
+        "* 적용 `AGENTS.md`: 전체 확인 완료\n"
+        "* 미션 파일: 전체 확인 완료\n"
+        "* 보고서 첫 Markdown heading: `# Example`\n"
+        "* 저장소 쓰기 작업: 없음\n"
+        "* 금지된 Oracle controller/run 관련 파일·상태·프로세스: 검사하거나 호출하지 않음\n"
+        "현재 `dev` 앱이 이 workspace에서 노출한 도구에 `read_chunk`가 없으며, "
+        "`chunk` 관련 도구가 반환되지 않았습니다.\n"
+        "따라서 다음 단계인 정확히 한 번의 `git status --short --branch` 명령도 실행하지 않았습니다.\n"
+        "* 명령 실행: **안 함**\n"
+        "* exit code: **미확인**\n"
+        "* command output: **없음**\n"
+        "TASK_OUTCOME: BLOCKED\n"
+    )
+    run_dir = write_run(
+        state_root,
+        "r" * 12,
+        status="attention_required",
+        output=output,
+        session_authority="terminal",
+        terminal_harvested=True,
+        task_outcome="blocked",
+    )
+    state_path = run_dir / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.update({
+        "transport": "devspace",
+        "app_name": "dev",
+        "profile": {
+            "model": "gpt-5.6",
+            "model_strategy": "select",
+            "thinking_time": "extra-high",
+        },
+    })
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    verdict = module.diagnose(state_root)["unresolved_runs"][0]
+
+    assert verdict["bucket"] == "terminal-task-not-executed"
+    assert verdict["signature"] == (
+        "terminal-devspace-read-chunk-unavailable-after-read-only-probe"
+    )
 
 
 def test_recursive_self_observation_outranks_foreign_connector_search_evidence(

--- a/tests/test_chatgpt_oracle_incident.py
+++ b/tests/test_chatgpt_oracle_incident.py
@@ -93,7 +93,10 @@ def test_packet_carries_exact_run_bucket_and_evidence(tmp_path: Path) -> None:
     assert packet["conversation_url"] == "https://chatgpt.com/c/exact"
     assert packet["evaluated_from_thread"] == DEFAULT_EVALUATOR
     assert packet["target_source_thread_id"] == DEFAULT_EVALUATOR
-    assert packet["safe_for_fresh_run"] is True
+    # A classifier label alone cannot authorize a replacement: this fixture
+    # deliberately has no durable exact pre-submit state proof.
+    assert packet["safe_for_fresh_run"] is False
+    assert packet["fresh_run_authority"] is None
     assert str(run_dir / "state.json") in packet["evidence_paths"]
 
 
@@ -128,6 +131,26 @@ def test_bound_packet_routes_only_to_exact_owner_task(tmp_path: Path, monkeypatc
         "executable_by_evaluated_thread": False,
         "fresh_state_check_required": False,
     }
+
+
+def test_ambiguous_submitted_unknown_pre_submit_bucket_never_authorizes_replacement(
+    tmp_path: Path,
+) -> None:
+    module = load()
+    run_dir = write_run(
+        tmp_path,
+        "ambiguous-run",
+        status="attention_required",
+        session_authority="submitted_unknown",
+        stdout="ERROR: ChatGPT app mention was not confirmed in the composer.\n",
+        source_thread_id=DEFAULT_EVALUATOR,
+    )
+
+    packet = module.validate_packet(module.build_packet(run_dir))
+
+    assert packet["bucket"] == module.DIAGNOSE.PRE_SUBMIT_UI
+    assert packet["safe_for_fresh_run"] is False
+    assert packet["fresh_run_authority"] is None
 
 
 def test_v2_build_requires_exact_evaluating_task(
@@ -309,7 +332,7 @@ def test_v2_validation_rejects_impossible_owner_scope_pairs(
     assert exc.value.code == "INCIDENT_OWNERSHIP_SCOPE_INVALID"
 
 
-def test_version_resolution_prelaunch_incident_is_safe_to_retry(tmp_path: Path) -> None:
+def test_version_resolution_label_without_durable_pre_submit_proof_is_not_safe_to_retry(tmp_path: Path) -> None:
     module = load()
     run_dir = write_run(
         tmp_path,
@@ -330,10 +353,11 @@ def test_version_resolution_prelaunch_incident_is_safe_to_retry(tmp_path: Path) 
 
     assert packet["bucket"] == "pre-submit-host-environment"
     assert packet["signature"] == "oracle-version-resolution-prelaunch-timeout"
-    assert packet["safe_for_fresh_run"] is True
+    assert packet["safe_for_fresh_run"] is False
+    assert packet["fresh_run_authority"] is None
 
 
-def test_model_switcher_pre_submit_incident_is_safe_to_retry(tmp_path: Path) -> None:
+def test_model_switcher_label_without_durable_pre_submit_proof_is_not_safe_to_retry(tmp_path: Path) -> None:
     module = load()
     run_dir = write_run(
         tmp_path,
@@ -355,7 +379,8 @@ def test_model_switcher_pre_submit_incident_is_safe_to_retry(tmp_path: Path) -> 
 
     assert packet["bucket"] == "pre-submit-ui-contract"
     assert packet["signature"] == "model-option-label-missing"
-    assert packet["safe_for_fresh_run"] is True
+    assert packet["safe_for_fresh_run"] is False
+    assert packet["fresh_run_authority"] is None
 
 
 def test_version_compatibility_drift_incident_is_safe_to_retry(tmp_path: Path) -> None:
@@ -515,6 +540,200 @@ def test_recursive_self_observation_needs_append_only_user_authority(tmp_path: P
     assert after["fresh_run_authority"]["sha256"] == module.STATE.sha256_file(receipt_path)
 
 
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_signature"),
+    [
+        ("checkout-502", "terminal-devspace-checkout-502-no-execution"),
+        (
+            "app-tools-unavailable",
+            "terminal-devspace-app-tools-unavailable-no-execution",
+        ),
+    ],
+)
+def test_terminal_devspace_nonexecution_authority_releases_only_the_authorized_task(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+    expected_signature: str,
+) -> None:
+    module = load()
+    task_id = DEFAULT_EVALUATOR
+    project_root = tmp_path / "project"
+    if failure_kind == "checkout-502":
+        output = (
+            f"I opened the exact project root {project_root} in checkout mode.\n"
+            "The checkout failed with 502 Upstream or external service errors and no workspace ID.\n"
+            "I did not read the mission, did not run commands, and did not change files.\n"
+            "TASK_OUTCOME: BLOCKED\n"
+        )
+    else:
+        output = (
+            "이 세션에는 dev 앱이 제공하는 workspace 도구가 노출되어 있지 않아 "
+            f"지정한 {project_root}를 dev checkout 모드로 열 수 없습니다. "
+            "사용자가 금지한 다른 workspace 커넥터·셸·웹·Oracle 우회는 시도하지 않았으며, "
+            "따라서 미션 파일이나 AGENTS.md도 읽거나 수정하지 않았습니다.\n"
+            "TASK_OUTCOME: BLOCKED\n"
+        )
+    run_dir = write_run(
+        tmp_path,
+        "devspace502run",
+        status="attention_required",
+        output=output,
+        session_authority="terminal",
+        terminal_harvested=True,
+    )
+    mission = run_dir / "mission.md"
+    mission.write_text("review exact project", encoding="utf-8")
+    state_path = run_dir / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.update({
+        "transport": "pro-devspace",
+        "task_outcome_contract": "v1",
+        "mission": {"sha256": module.STATE.sha256_file(mission)},
+    })
+    if failure_kind == "app-tools-unavailable":
+        state["app_name"] = "dev"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    before = module.validate_packet(module.build_packet(run_dir))
+    assert before["signature"] == expected_signature
+    assert before["ownership_scope"] == "legacy-unbound"
+    assert before["safe_for_fresh_run"] is False
+
+    receipt_path = run_dir / "settlements" / "terminal-devspace-nonexecution-fresh-run.json"
+    receipt_path.parent.mkdir()
+    receipt_path.write_text(json.dumps({
+        "schema": module.STATE.TERMINAL_DEVSPACE_NONEXECUTION_SETTLEMENT_SCHEMA,
+        "confirmation": module.STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,
+        "reason": "user authorized a new review after repairing the bounded outage",
+        "authorized_source_thread_id": task_id,
+        "historical_owner_scope": "legacy-unbound",
+        "run_id": state["run_id"],
+        "project_root": state["project_root"],
+        "slug": state["oracle"]["slug"],
+        "transport": state["transport"],
+        "task_outcome": state["task_outcome"],
+        "signature": expected_signature,
+        "state_sha256": module.STATE.sha256_file(state_path),
+        "output_sha256": module.STATE.sha256_file(run_dir / "output.md"),
+        "transcript_sha256": module.STATE.sha256_file(run_dir / "transcript.md"),
+        "stdout_sha256": module.STATE.sha256_file(run_dir / "stdout.log"),
+        "stderr_sha256": module.STATE.sha256_file(run_dir / "stderr.log"),
+        "mission_sha256": module.STATE.sha256_file(mission),
+        "auto_retry": False,
+        "submission_action": "none",
+        "authorized_at": "2026-08-25T00:00:00Z",
+    }), encoding="utf-8")
+
+    after = module.validate_packet(module.build_packet(run_dir))
+
+    assert after["safe_for_fresh_run"] is True
+    assert after["fresh_run_authority"]["authorized_source_thread_id"] == task_id
+    foreign = "22222222-2222-4222-8222-222222222222"
+    monkeypatch.setenv("CODEX_THREAD_ID", foreign)
+    foreign_packet = module.build_packet(run_dir)
+    assert foreign_packet["safe_for_fresh_run"] is False
+
+
+def test_terminal_devspace_read_route_refresh_authority_releases_one_probe(
+    tmp_path: Path,
+) -> None:
+    module = load()
+    task_id = DEFAULT_EVALUATOR
+    project_root = tmp_path / "project"
+    escaped_root = str(project_root).replace("\\", "\\\\")
+    output = (
+        "* 앱: `dev`\n"
+        "* Workspace ID: `ws_a0770e8338`\n"
+        f"* 정확한 루트: `{escaped_root}`\n"
+        "* 모드: `checkout`\n"
+        "* 적용 `AGENTS.md`: 전체 확인 완료\n"
+        "* 미션 파일: 전체 확인 완료\n"
+        "* 보고서 첫 Markdown heading: `# Example`\n"
+        "* 저장소 쓰기 작업: 없음\n"
+        "* 금지된 Oracle controller/run 관련 파일·상태·프로세스: 검사하거나 호출하지 않음\n"
+        "현재 `dev` 앱이 이 workspace에서 노출한 도구에 `read_chunk`가 없으며, "
+        "`chunk` 관련 도구가 반환되지 않았습니다.\n"
+        "따라서 다음 단계인 정확히 한 번의 `git status --short --branch` 명령도 실행하지 않았습니다.\n"
+        "* 명령 실행: **안 함**\n"
+        "* exit code: **미확인**\n"
+        "* command output: **없음**\n"
+        "TASK_OUTCOME: BLOCKED\n"
+    )
+    run_dir = write_run(
+        tmp_path,
+        "readrouteblocked",
+        status="attention_required",
+        output=output,
+        session_authority="terminal",
+        terminal_harvested=True,
+        source_thread_id=task_id,
+    )
+    mission = run_dir / "mission.md"
+    mission.write_text(
+        "Call `read_chunk` from `offsetBytes=0` through `eof=true`.\n"
+        "Run exactly one command: `git status --short --branch`.\n"
+        "Run no other command. Do not create, edit, delete, rename, stage, commit, switch, build, or test.\n"
+        "If any required operation fails, report the concrete blocker and stop.\n",
+        encoding="utf-8",
+    )
+    state_path = run_dir / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.update({
+        "transport": "devspace",
+        "app_name": "dev",
+        "profile": {
+            "model": "gpt-5.6",
+            "model_strategy": "select",
+            "thinking_time": "extra-high",
+        },
+        "task_outcome_contract": "v1",
+        "mission": {"sha256": module.STATE.sha256_file(mission)},
+    })
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+    before = module.validate_packet(module.build_packet(run_dir))
+    assert before["signature"] == (
+        module.STATE.TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SIGNATURE
+    )
+    assert before["safe_for_fresh_run"] is False
+
+    receipt_path = (
+        run_dir / "settlements" / "terminal-devspace-read-route-refresh-fresh-run.json"
+    )
+    receipt_path.parent.mkdir()
+    receipt_path.write_text(json.dumps({
+        "schema": module.STATE.TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SETTLEMENT_SCHEMA,
+        "confirmation": module.STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH,
+        "reason": "user refreshed the configured app tools and completed post-register",
+        "authorized_source_thread_id": task_id,
+        "run_id": state["run_id"],
+        "project_root": state["project_root"],
+        "slug": state["oracle"]["slug"],
+        "transport": state["transport"],
+        "task_outcome": state["task_outcome"],
+        "app_name": state["app_name"],
+        "workspace_id": "ws_a0770e8338",
+        "signature": module.STATE.TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SIGNATURE,
+        "retry_ordinal": 1,
+        "state_sha256": module.STATE.sha256_file(state_path),
+        "output_sha256": module.STATE.sha256_file(run_dir / "output.md"),
+        "transcript_sha256": module.STATE.sha256_file(run_dir / "transcript.md"),
+        "stdout_sha256": module.STATE.sha256_file(run_dir / "stdout.log"),
+        "stderr_sha256": module.STATE.sha256_file(run_dir / "stderr.log"),
+        "mission_sha256": module.STATE.sha256_file(mission),
+        "auto_retry": False,
+        "submission_action": "none",
+        "authorized_at": "2026-08-25T00:00:00Z",
+    }), encoding="utf-8")
+
+    after = module.validate_packet(module.build_packet(run_dir))
+
+    assert after["safe_for_fresh_run"] is True
+    assert after["fresh_run_authority"]["authorized_source_thread_id"] == task_id
+    assert after["fresh_run_authority"]["retry_ordinal"] == 1
+
+
 def test_packet_build_requires_the_exact_persisted_run(tmp_path: Path) -> None:
     module = load()
     empty = tmp_path / "no-run"
@@ -523,6 +742,53 @@ def test_packet_build_requires_the_exact_persisted_run(tmp_path: Path) -> None:
     with pytest.raises(module.IncidentError) as exc:
         module.build_packet(empty)
     assert exc.value.code == "INCIDENT_RUN_STATE_MISSING"
+
+
+def test_missing_layout_packet_is_diagnostic_only_without_durable_run_state(
+    tmp_path: Path,
+) -> None:
+    module = load()
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    run_dir = tmp_path / "state" / "projects" / "projectkey" / "runs" / ("a" * 32)
+    manifest_path = tmp_path / "oracle.json"
+    manifest_path.write_text(json.dumps({
+        "schema": "codex.chatgpt.oracle-run/v1",
+        "project_root": str(project_root),
+        "run_id": "a" * 32,
+    }), encoding="utf-8")
+    workflow_state = tmp_path / "workflow-state.json"
+    workflow_state.write_text(json.dumps({
+        "schema": "codex.chatgpt.oracle-comprehensive-state/v1",
+        "status": "attention_required",
+        "workflow_id": "b" * 32,
+        "source_thread_id": DEFAULT_EVALUATOR,
+        "records": [{
+            "stage": "plan",
+            "run_id": "a" * 32,
+            "run_dir": str(run_dir),
+            "pre_submit_failure": True,
+            "pre_submit_retry_consumed": False,
+            "settlement": "oracle-layout-not-created-pre-submit",
+            "settlement_proof": {
+                "schema": module.MISSING_LAYOUT_PRE_SUBMIT_SCHEMA,
+                "kind": "oracle-layout-not-created",
+                "safe_for_fresh_run": False,
+                "workflow_id": "b" * 32,
+                "attempt_id": "a" * 32,
+                "run_dir": str(run_dir),
+                "oracle_manifest_path": str(manifest_path),
+            },
+        }],
+    }), encoding="utf-8")
+
+    packet = module.validate_packet(module.build_missing_layout_packet(workflow_state))
+
+    assert packet["lifecycle"] == "attention_required"
+    assert packet["authority_source"] == "workflow-missing-layout-unproven"
+    assert packet["safe_for_fresh_run"] is False
+    assert packet["fresh_run_authority"] is None
+    assert packet["operational_instruction"]["action"] == "inspect-owned-exact-run"
 
 
 def test_build_is_read_only_for_the_reported_run(tmp_path: Path) -> None:

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -4931,6 +4931,397 @@ def test_exact_recovery_bypasses_live_submit_mutex_and_harvests_same_slug(tmp_pa
     )
 
 
+def terminal_devspace_nonexecution_run(runner, tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True)
+    run_id = "devspace502run"
+    slug = "oracle-project-devspace502"
+    run_dir = tmp_path / "state" / "projects" / "key" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mission = run_dir / "mission.md"
+    output = run_dir / "output.md"
+    transcript = run_dir / "transcript.md"
+    stdout = run_dir / "stdout.log"
+    stderr = run_dir / "stderr.log"
+    mission.write_text("review the exact project", encoding="utf-8")
+    exact = (
+        f"I opened the exact project root {project_root} in checkout mode.\n"
+        "The checkout failed with 502 Upstream or external service errors and no workspace ID.\n"
+        "I did not read the mission, did not run commands, and did not change files.\n"
+        "TASK_OUTCOME: BLOCKED\n"
+    )
+    output.write_text(exact, encoding="utf-8")
+    transcript.write_text(exact, encoding="utf-8")
+    stdout.write_text("terminal assistant answer captured", encoding="utf-8")
+    stderr.write_text("", encoding="utf-8")
+    state_path = run_dir / "state.json"
+    runner.STATE.write_json_atomic(state_path, {
+        "schema": "codex.chatgpt.oracle-run-state/v1",
+        "status": "attention_required",
+        "run_id": run_id,
+        "project_root": str(project_root),
+        "transport": "pro-devspace",
+        "session_authority": "terminal",
+        "terminal_harvested": True,
+        "transport_status": "complete",
+        "task_outcome_contract": "v1",
+        "task_outcome": "blocked",
+        "mission": {"sha256": runner.STATE.sha256_file(mission)},
+        "oracle": {"slug": slug},
+        "artifacts": {
+            "output": str(output), "transcript": str(transcript),
+            "stdout": str(stdout), "stderr": str(stderr),
+        },
+    })
+    hashes = {
+        "expected_state_sha256": runner.STATE.sha256_file(state_path),
+        "expected_output_sha256": runner.STATE.sha256_file(output),
+        "expected_transcript_sha256": runner.STATE.sha256_file(transcript),
+        "expected_stdout_sha256": runner.STATE.sha256_file(stdout),
+        "expected_stderr_sha256": runner.STATE.sha256_file(stderr),
+        "expected_mission_sha256": runner.STATE.sha256_file(mission),
+    }
+    return run_dir, hashes
+
+
+def test_terminal_devspace_nonexecution_settlement_is_append_only_and_task_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = load_runner()
+    task_id = "11111111-1111-4111-8111-111111111111"
+    monkeypatch.setenv("CODEX_THREAD_ID", task_id)
+    run_dir, hashes = terminal_devspace_nonexecution_run(runner, tmp_path)
+    state_path = run_dir / "state.json"
+    before_state = state_path.read_bytes()
+
+    dry = runner.settle_terminal_devspace_nonexecution_fresh_run(
+        run_dir,
+        confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,
+        reason="user authorized a new review after repairing the bounded DevSpace outage",
+        dry_run=True,
+        **hashes,
+    )
+    assert dry["status"] == "dry-run"
+    assert dry["settlement_payload"]["authorized_source_thread_id"] == task_id
+    assert not Path(dry["settlement_path"]).exists()
+
+    settled = runner.settle_terminal_devspace_nonexecution_fresh_run(
+        run_dir,
+        confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,
+        reason="user authorized a new review after repairing the bounded DevSpace outage",
+        **hashes,
+    )
+    proof = runner.STATE.proven_terminal_devspace_nonexecution_fresh_run_authority(state_path)
+
+    assert settled["safe_for_fresh_run"] is True
+    assert settled["auto_retry"] is False
+    assert settled["submission_action"] == "none"
+    assert proof is not None
+    assert proof["authorized_source_thread_id"] == task_id
+    assert proof["historical_owner_scope"] == "legacy-unbound"
+    assert state_path.read_bytes() == before_state
+    repeated = runner.settle_terminal_devspace_nonexecution_fresh_run(
+        run_dir,
+        confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,
+        reason="user authorized a new review after repairing the bounded DevSpace outage",
+        **hashes,
+    )
+    assert repeated["settlement"]["sha256"] == proof["sha256"]
+    (run_dir / "output.md").write_text(
+        "changed after settlement\nTASK_OUTCOME: BLOCKED\n", encoding="utf-8"
+    )
+    assert runner.STATE.proven_terminal_devspace_nonexecution_fresh_run_authority(
+        state_path
+    ) is None
+
+
+def test_terminal_devspace_nonexecution_settlement_accepts_exact_app_tools_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = load_runner()
+    task_id = "11111111-1111-4111-8111-111111111111"
+    monkeypatch.setenv("CODEX_THREAD_ID", task_id)
+    run_dir, hashes = terminal_devspace_nonexecution_run(runner, tmp_path)
+    state_path = run_dir / "state.json"
+    output = run_dir / "output.md"
+    transcript = run_dir / "transcript.md"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["app_name"] = "dev"
+    exact = (
+        "이 세션에는 dev 앱이 제공하는 workspace 도구가 노출되어 있지 않아 "
+        f"지정한 {state['project_root']}를 dev checkout 모드로 열 수 없습니다. "
+        "사용자가 금지한 다른 workspace 커넥터·셸·웹·Oracle 우회는 시도하지 않았으며, "
+        "따라서 미션 파일이나 AGENTS.md도 읽거나 수정하지 않았습니다.\n"
+        "TASK_OUTCOME: BLOCKED\n"
+    )
+    output.write_text(exact, encoding="utf-8")
+    transcript.write_text(exact, encoding="utf-8")
+    runner.STATE.write_json_atomic(state_path, state)
+    hashes.update({
+        "expected_state_sha256": runner.STATE.sha256_file(state_path),
+        "expected_output_sha256": runner.STATE.sha256_file(output),
+        "expected_transcript_sha256": runner.STATE.sha256_file(transcript),
+    })
+
+    dry = runner.settle_terminal_devspace_nonexecution_fresh_run(
+        run_dir,
+        confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,
+        reason="user authorized a configured-app canary after exact no-tool evidence",
+        dry_run=True,
+        **hashes,
+    )
+    assert dry["settlement_payload"]["signature"] == (
+        "terminal-devspace-app-tools-unavailable-no-execution"
+    )
+    settled = runner.settle_terminal_devspace_nonexecution_fresh_run(
+        run_dir,
+        confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,
+        reason="user authorized a configured-app canary after exact no-tool evidence",
+        **hashes,
+    )
+    proof = runner.STATE.proven_terminal_devspace_nonexecution_fresh_run_authority(state_path)
+
+    assert settled["safe_for_fresh_run"] is True
+    assert proof is not None
+    assert proof["signature"] == "terminal-devspace-app-tools-unavailable-no-execution"
+
+
+def test_terminal_devspace_nonexecution_settlement_rejects_generic_blocker_and_foreign_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = load_runner()
+    caller = "11111111-1111-4111-8111-111111111111"
+    foreign = "22222222-2222-4222-8222-222222222222"
+    monkeypatch.setenv("CODEX_THREAD_ID", caller)
+    run_dir, hashes = terminal_devspace_nonexecution_run(runner, tmp_path)
+    output = run_dir / "output.md"
+    output.write_text("ordinary blocker\nTASK_OUTCOME: BLOCKED\n", encoding="utf-8")
+    hashes["expected_output_sha256"] = runner.STATE.sha256_file(output)
+    with pytest.raises(runner.OracleRunError) as generic:
+        runner.settle_terminal_devspace_nonexecution_fresh_run(
+            run_dir,
+            confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,
+            reason="continue",
+            **hashes,
+        )
+    assert generic.value.code == "TERMINAL_DEVSPACE_NONEXECUTION_EVIDENCE_REQUIRED"
+
+    run_dir, hashes = terminal_devspace_nonexecution_run(runner, tmp_path / "foreign")
+    state_path = run_dir / "state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["originating_task"] = {
+        "schema": "codex.chatgpt.oracle-task-owner/v1",
+        "source_thread_id": foreign,
+    }
+    runner.STATE.write_json_atomic(state_path, state)
+    hashes["expected_state_sha256"] = runner.STATE.sha256_file(state_path)
+    with pytest.raises(runner.OracleRunError) as foreign_error:
+        runner.settle_terminal_devspace_nonexecution_fresh_run(
+            run_dir,
+            confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_TERMINAL_DEVSPACE_NONEXECUTION,
+            reason="continue",
+            **hashes,
+        )
+    assert foreign_error.value.code == "FOREIGN_TASK_SESSION"
+
+
+def terminal_devspace_read_route_refresh_run(
+    runner,
+    tmp_path: Path,
+    *,
+    task_id: str,
+    run_id: str = "readrouteblocked",
+) -> tuple[Path, dict[str, str]]:
+    project_root = tmp_path / "project"
+    project_root.mkdir(parents=True, exist_ok=True)
+    slug = f"oracle-project-{run_id[:10]}"
+    run_dir = tmp_path / "state" / "projects" / "key" / "runs" / run_id
+    run_dir.mkdir(parents=True)
+    mission = run_dir / "mission.md"
+    output = run_dir / "output.md"
+    transcript = run_dir / "transcript.md"
+    stdout = run_dir / "stdout.log"
+    stderr = run_dir / "stderr.log"
+    mission.write_text(
+        "# Regular read route canary\n"
+        "Call `read_chunk` from `offsetBytes=0` through `eof=true`.\n"
+        "Run exactly one command: `git status --short --branch`.\n"
+        "Run no other command. Do not create, edit, delete, rename, stage, commit, switch, build, or test.\n"
+        "If any required operation fails, report the concrete blocker and stop.\n",
+        encoding="utf-8",
+    )
+    escaped_root = str(project_root).replace("\\", "\\\\")
+    exact = (
+        "**관찰된 사실**\n\n"
+        "* 앱: `dev`\n"
+        "* Workspace ID: `ws_a0770e8338`\n"
+        f"* 정확한 루트: `{escaped_root}`\n"
+        "* 모드: `checkout`\n"
+        "* 적용 `AGENTS.md`: 전체 확인 완료\n"
+        "* 미션 파일: 전체 확인 완료\n"
+        "* 보고서 첫 Markdown heading: `# Example`\n"
+        "* 저장소 쓰기 작업: 없음\n"
+        "* 금지된 Oracle controller/run 관련 파일·상태·프로세스: 검사하거나 호출하지 않음\n\n"
+        "**구체적 차단 사유**\n"
+        "현재 `dev` 앱이 이 workspace에서 노출한 도구에 `read_chunk`가 없으며, "
+        "`dev` 도구 검색에서도 `chunk` 관련 도구가 반환되지 않았습니다.\n"
+        "따라서 다음 단계인 정확히 한 번의 `git status --short --branch` 명령도 실행하지 않았습니다.\n\n"
+        "* complete report SHA-256: **미확인**\n"
+        "* 명령 실행: **안 함**\n"
+        "* exit code: **미확인**\n"
+        "* command output: **없음**\n\n"
+        "TASK_OUTCOME: BLOCKED\n"
+    )
+    output.write_text(exact, encoding="utf-8")
+    transcript.write_text(exact, encoding="utf-8")
+    stdout.write_text("terminal assistant answer captured", encoding="utf-8")
+    stderr.write_text("", encoding="utf-8")
+    state_path = run_dir / "state.json"
+    task_owner = {
+        "schema": "codex.chatgpt.oracle-task-owner/v1",
+        "source_thread_id": task_id,
+        "binding": "bound",
+    }
+    runner.STATE.write_json_atomic(state_path, {
+        "schema": "codex.chatgpt.oracle-run-state/v1",
+        "status": "attention_required",
+        "run_id": run_id,
+        "project_root": str(project_root),
+        "transport": "devspace",
+        "app_name": "dev",
+        "profile": {
+            "model": "gpt-5.6",
+            "model_strategy": "select",
+            "thinking_time": "extra-high",
+        },
+        "originating_task": task_owner,
+        "ownership": task_owner,
+        "session_authority": "terminal",
+        "terminal_harvested": True,
+        "transport_status": "complete",
+        "task_outcome_contract": "v1",
+        "task_outcome": "blocked",
+        "mission": {"sha256": runner.STATE.sha256_file(mission)},
+        "oracle": {"slug": slug},
+        "artifacts": {
+            "output": str(output), "transcript": str(transcript),
+            "stdout": str(stdout), "stderr": str(stderr),
+        },
+    })
+    hashes = {
+        "expected_state_sha256": runner.STATE.sha256_file(state_path),
+        "expected_output_sha256": runner.STATE.sha256_file(output),
+        "expected_transcript_sha256": runner.STATE.sha256_file(transcript),
+        "expected_stdout_sha256": runner.STATE.sha256_file(stdout),
+        "expected_stderr_sha256": runner.STATE.sha256_file(stderr),
+        "expected_mission_sha256": runner.STATE.sha256_file(mission),
+    }
+    return run_dir, hashes
+
+
+def test_terminal_devspace_read_route_refresh_settlement_is_one_use_and_hash_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = load_runner()
+    task_id = "11111111-1111-4111-8111-111111111111"
+    monkeypatch.setenv("CODEX_THREAD_ID", task_id)
+    run_dir, hashes = terminal_devspace_read_route_refresh_run(
+        runner, tmp_path, task_id=task_id
+    )
+    state_path = run_dir / "state.json"
+
+    dry = runner.settle_terminal_devspace_read_route_refresh_fresh_run(
+        run_dir,
+        confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH,
+        reason="user refreshed the configured app tools and completed post-register",
+        dry_run=True,
+        **hashes,
+    )
+    assert dry["status"] == "dry-run"
+    assert dry["settlement_payload"]["signature"] == (
+        runner.STATE.TERMINAL_DEVSPACE_READ_ROUTE_REFRESH_SIGNATURE
+    )
+    assert dry["settlement_payload"]["retry_ordinal"] == 1
+    assert not Path(dry["settlement_path"]).exists()
+
+    settled = runner.settle_terminal_devspace_read_route_refresh_fresh_run(
+        run_dir,
+        confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH,
+        reason="user refreshed the configured app tools and completed post-register",
+        **hashes,
+    )
+    proof = runner.STATE.proven_terminal_devspace_read_route_refresh_fresh_run_authority(
+        state_path
+    )
+    assert settled["safe_for_fresh_run"] is True
+    assert settled["auto_retry"] is False
+    assert proof is not None
+    assert proof["workspace_id"] == "ws_a0770e8338"
+
+    repeated = runner.settle_terminal_devspace_read_route_refresh_fresh_run(
+        run_dir,
+        confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH,
+        reason="user refreshed the configured app tools and completed post-register",
+        **hashes,
+    )
+    assert repeated["settlement"]["sha256"] == proof["sha256"]
+
+    second_dir, second_hashes = terminal_devspace_read_route_refresh_run(
+        runner, tmp_path, task_id=task_id, run_id="readrouteagain"
+    )
+    with pytest.raises(runner.OracleRunError) as used:
+        runner.settle_terminal_devspace_read_route_refresh_fresh_run(
+            second_dir,
+            confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH,
+            reason="another refresh",
+            **second_hashes,
+        )
+    assert used.value.code == "DEVSPACE_READ_ROUTE_REFRESH_RETRY_ALREADY_USED"
+
+
+def test_terminal_devspace_read_route_refresh_settlement_rejects_ambiguity_and_foreign_task(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = load_runner()
+    caller = "11111111-1111-4111-8111-111111111111"
+    foreign = "22222222-2222-4222-8222-222222222222"
+    monkeypatch.setenv("CODEX_THREAD_ID", caller)
+    run_dir, hashes = terminal_devspace_read_route_refresh_run(
+        runner, tmp_path / "ambiguous", task_id=caller
+    )
+    output = run_dir / "output.md"
+    transcript = run_dir / "transcript.md"
+    ambiguous = output.read_text(encoding="utf-8").replace(
+        "* 명령 실행: **안 함**", "* 명령 실행: **미확인**"
+    )
+    output.write_text(ambiguous, encoding="utf-8")
+    transcript.write_text(ambiguous, encoding="utf-8")
+    hashes.update({
+        "expected_output_sha256": runner.STATE.sha256_file(output),
+        "expected_transcript_sha256": runner.STATE.sha256_file(transcript),
+    })
+    with pytest.raises(runner.OracleRunError) as ambiguity:
+        runner.settle_terminal_devspace_read_route_refresh_fresh_run(
+            run_dir,
+            confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH,
+            reason="continue",
+            **hashes,
+        )
+    assert ambiguity.value.code == "DEVSPACE_READ_ROUTE_REFRESH_EVIDENCE_REQUIRED"
+
+    foreign_dir, foreign_hashes = terminal_devspace_read_route_refresh_run(
+        runner, tmp_path / "foreign", task_id=foreign
+    )
+    with pytest.raises(runner.OracleRunError) as foreign_error:
+        runner.settle_terminal_devspace_read_route_refresh_fresh_run(
+            foreign_dir,
+            confirmation=runner.STATE.USER_AUTHORIZED_FRESH_AFTER_DEVSPACE_READ_ROUTE_REFRESH,
+            reason="continue",
+            **foreign_hashes,
+        )
+    assert foreign_error.value.code == "FOREIGN_TASK_SESSION"
+
+
 def test_recursive_self_observation_settlement_is_append_only_and_hash_bound(tmp_path: Path) -> None:
     runner = load_runner()
     project_root = tmp_path / "project"

--- a/tests/test_codex_web_gpt_onboarding.py
+++ b/tests/test_codex_web_gpt_onboarding.py
@@ -45,6 +45,7 @@ def test_plan_orders_the_complete_first_install_without_secrets(tmp_path: Path) 
     assert "owner_token" not in dumped.casefold()
     assert "--browser-manual-login" in dumped
     assert "DEVSPACE_OAUTH_SCOPES" in dumped
+    assert plan["stages"][3]["environment"]["DEVSPACE_SUBAGENTS"] == "false"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_codexpro_macos_launchd.py
+++ b/tests/test_codexpro_macos_launchd.py
@@ -30,7 +30,11 @@ def test_launchd_services_use_unique_labels_and_exact_allowed_root(tmp_path: Pat
     assert {value["Label"] for value in values.values()} == set(module.LABELS.values())
     assert all(value["CodexProManaged"] is True for value in values.values())
     assert values["supervisor"]["StartInterval"] == 60
+    assert values["devspace"]["ProgramArguments"] == [
+        "/opt/homebrew/bin/npx", "--yes", "@waishnav/devspace@1.0.8", "serve"
+    ]
     assert values["devspace"]["EnvironmentVariables"]["DEVSPACE_TOOL_MODE"] == "full"
+    assert values["devspace"]["EnvironmentVariables"]["DEVSPACE_SUBAGENTS"] == "false"
     for value in values.values():
         assert plistlib.loads(plistlib.dumps(value))["Label"] == value["Label"]
 

--- a/tests/test_devspace_bootstrap_script.py
+++ b/tests/test_devspace_bootstrap_script.py
@@ -18,13 +18,15 @@ def test_bootstrap_script_uses_live_devspace_allowed_roots_contract() -> None:
     text = SCRIPT.read_text(encoding="utf-8")
 
     assert "$DevSpaceConfigPath" in text
-    assert "$DevSpaceConfig.allowedRoots" in text
-    assert "foreach ($Root in $AllowedRoots)" in text
+    assert "$LiveConfig.allowedRoots" in text
+    assert "foreach ($Root in $LiveRoots)" in text
     assert "foreach ($Root in @($Config.roots))" not in text
     assert "[ValidateSet('Once', 'Watch')]" in text
     assert "$Mode = 'Once'" in text
     assert "while ($true)" in text
     assert "watchdog remains active" in text
+    assert "WatchIntervalSeconds = 30" in text
+    assert "ConfigSha256" in text
 
 
 @pytest.mark.skipif(shutil.which("powershell.exe") is None, reason="PowerShell is unavailable")
@@ -168,3 +170,41 @@ def test_watch_mode_rechecks_health_without_losing_live_roots(tmp_path: Path) ->
     calls = [json.loads(line) for line in capture.read_text(encoding="utf-8").splitlines()]
     assert len(calls) == 2
     assert all(str(root.resolve()) in call for call in calls)
+
+
+@pytest.mark.skipif(shutil.which("powershell.exe") is None, reason="PowerShell is unavailable")
+def test_watch_mode_reloads_allowed_roots_each_cycle(tmp_path: Path) -> None:
+    codex_home = tmp_path / "codex-home"
+    helper = codex_home / "skills" / "chatgpt-workspace-setup" / "scripts" / "devspace_tailscale_setup.py"
+    helper.parent.mkdir(parents=True)
+    capture = tmp_path / "reload-calls.jsonl"
+    first, second = tmp_path / "first", tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    devspace = tmp_path / "devspace.json"
+    devspace.write_text(json.dumps({"allowedRoots": [str(first.resolve())]}), encoding="utf-8")
+    helper.write_text(
+        "import json, pathlib, sys\n"
+        f"capture = pathlib.Path({str(capture)!r})\n"
+        "with capture.open('a', encoding='utf-8') as stream:\n"
+        "    stream.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+        f"config = pathlib.Path({str(devspace)!r})\n"
+        "if len(capture.read_text(encoding='utf-8').splitlines()) == 1:\n"
+        f"    config.write_text(json.dumps({{'allowedRoots': [{str(first.resolve())!r}, {str(second.resolve())!r}]}}), encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+    bootstrap = tmp_path / "bootstrap.json"
+    bootstrap.write_text(json.dumps({
+        "schema": "codexpro.devspace-bootstrap/v1", "python_path": sys.executable,
+        "hostname": "device.example.ts.net", "local_port": 7676, "public_port": 443,
+    }), encoding="utf-8")
+    completed = subprocess.run([
+        "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(SCRIPT),
+        "-CodexHome", str(codex_home), "-ConfigPath", str(bootstrap), "-DevSpaceConfigPath", str(devspace),
+        "-Mode", "Watch", "-WatchIntervalSeconds", "0", "-MaxCycles", "2",
+        "-MutexName", f"CodexProDevSpaceBootstrapTest-{uuid.uuid4().hex}",
+    ], capture_output=True, text=True, timeout=30, check=False)
+    assert completed.returncode == 0, completed.stderr
+    calls = [json.loads(line) for line in capture.read_text(encoding="utf-8").splitlines()]
+    assert str(first.resolve()) in calls[0] and str(second.resolve()) not in calls[0]
+    assert str(first.resolve()) in calls[1] and str(second.resolve()) in calls[1]

--- a/tests/test_devspace_tailscale_setup.py
+++ b/tests/test_devspace_tailscale_setup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import shutil
 import subprocess
@@ -39,6 +40,80 @@ def test_roots_are_narrow_and_registration_url_is_exact(tmp_path: Path) -> None:
         module.validate_config([str(Path(tmp_path.anchor))], "device.tailnet.ts.net")
 
 
+def test_redaction_covers_basic_quoted_values_and_cookie_chains() -> None:
+    module = load_module()
+    value = (
+        'Authorization: Basic dXNlcjpwYXNz token="quoted-secret" '
+        'Cookie: sessionid=first; next_token=second Bearer abc.def'
+    )
+    redacted = module.redact(value)
+    for secret in ("dXNlcjpwYXNz", "quoted-secret", "first", "second", "abc.def"):
+        assert secret not in redacted
+    assert redacted.count("[REDACTED]") >= 4
+
+
+@pytest.mark.parametrize(
+    "value, secret",
+    (
+        ('Authorization: Bearer "quoted-bearer"', "quoted-bearer"),
+        ("Authorization: Bearer 'single-bearer'", "single-bearer"),
+        ('Authorization: Basic "quoted-basic"', "quoted-basic"),
+        ("Authorization: Basic 'single-basic'", "single-basic"),
+    ),
+)
+def test_redaction_covers_quoted_authorization_tokens(value: str, secret: str) -> None:
+    module = load_module()
+    redacted = module.redact(value)
+    assert secret not in redacted
+    assert redacted.endswith("[REDACTED]")
+
+
+def test_streaming_supervisor_rotates_and_redacts_before_exit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_module()
+    monkeypatch.setattr(module, "SERVICE_LOG_MAX_BYTES", 32)
+
+    class Child:
+        pid = 5050
+        stdout = io.StringIO("token=one\nAuthorization: Basic dXNlcjpwYXNz\n")
+        stderr = io.StringIO("Cookie: sessionid=first; next_token=second\n")
+        def wait(self):
+            return 0
+
+    result = module.run_managed_devspace_service(
+        popen_factory=lambda *args, **kwargs: Child(), platform_name="posix", codex_home=tmp_path,
+    )
+    paths = module.managed_service_paths(tmp_path)
+    persisted = "\n".join(path.read_text(encoding="utf-8") for path in (
+        paths["stdout"], paths["stderr"], paths["stdout"].with_name(paths["stdout"].name + ".1"), paths["stderr"].with_name(paths["stderr"].name + ".1"),
+    ) if path.exists())
+    assert result == 0
+    for secret in ("one", "dXNlcjpwYXNz", "first", "second"):
+        assert secret not in persisted
+    assert "[REDACTED]" in persisted
+
+
+def test_streaming_supervisor_bounds_a_single_long_line(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_module()
+    monkeypatch.setattr(module, "SERVICE_LOG_MAX_BYTES", 32)
+
+    class Child:
+        pid = 6060
+        stdout = io.StringIO("x" * 128 + "\n")
+        stderr = io.StringIO("")
+        def wait(self):
+            return 0
+
+    assert module.run_managed_devspace_service(
+        popen_factory=lambda *args, **kwargs: Child(),
+        platform_name="posix",
+        codex_home=tmp_path,
+    ) == 0
+    paths = module.managed_service_paths(tmp_path)
+    for path in (paths["stdout"], paths["stdout"].with_name(paths["stdout"].name + ".1")):
+        if path.exists():
+            assert path.stat().st_size <= 32
+
+
 def test_setup_plan_has_no_secrets_and_is_explicit_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module, current = config(tmp_path)
     bash = tmp_path / "bash.exe"
@@ -54,10 +129,13 @@ def test_setup_plan_has_no_secrets_and_is_explicit_only(tmp_path: Path, monkeypa
         "DEVSPACE_TOOL_MODE": "full",
         "DEVSPACE_OAUTH_SCOPES": "devspace,offline_access",
         "DEVSPACE_SUBAGENTS": "false",
+        "DEVSPACE_LOG_REQUESTS": "false",
+        "DEVSPACE_LOG_TOOL_CALLS": "false",
+        "DEVSPACE_LOG_SHELL_COMMANDS": "false",
     }
     assert plan["startup_watchdog"] == {
         "windows_mode": "per-user login watchdog",
-        "health_interval_seconds": 300,
+        "health_interval_seconds": 30,
         "runtime_root_source": str(Path.home() / ".devspace" / "config.json"),
     }
     assert plan["devspace_init"][1:3] == [
@@ -189,7 +267,9 @@ def test_doctor_orders_local_funnel_public_and_manual_failure_branch(tmp_path: P
 
     def opener(request, timeout):
         seen.append(request.full_url)
-        return Response()
+        response = Response()
+        response.status = 200 if request.full_url.endswith("/healthz") else 401
+        return response
 
     def runner(argv, **kwargs):
         assert argv == ["tailscale", "funnel", "status", "--json"]
@@ -228,7 +308,7 @@ def test_doctor_reports_persisted_allowed_root_mismatch(tmp_path: Path) -> None:
     config_path.write_text(json.dumps({"allowedRoots": [str(other.resolve())]}), encoding="utf-8")
 
     class Response:
-        status = 401
+        status = 200
         def __enter__(self):
             return self
         def __exit__(self, *args):
@@ -345,7 +425,9 @@ def test_recover_starts_missing_service_then_restores_exact_funnel(
         probes += 1
         if probes == 1:
             raise OSError("service is down")
-        return Response()
+        response = Response()
+        response.status = 200 if request.full_url.endswith("/healthz") else 401
+        return response
 
     def runner(argv, **kwargs):
         calls.append(list(argv))
@@ -361,13 +443,15 @@ def test_recover_starts_missing_service_then_restores_exact_funnel(
         current,
         opener=opener,
         runner=runner,
-        popen_factory=lambda argv, **kwargs: launches.append(list(argv)),
+        popen_factory=lambda argv, **kwargs: (launches.append(list(argv)) or SimpleNamespace(pid=1234)),
         sleeper=lambda _: None,
     )
 
     assert report["ok"] is True
     assert report["service_started"] is True
     assert len(launches) == 1
+    assert calls.index(module.devspace_package_prepare_argv()) < calls.index(module.devspace_native_prepare_argv()) < calls.index(module.devspace_native_argv())
+    assert launches[0] == module.managed_service_runner_argv()
     assert any("--stop-exact-service" in call for call in calls)
     assert any("--confirm-service-restarted" in call for call in calls)
 
@@ -405,11 +489,16 @@ def test_post_register_always_recycles_service_and_preserves_oauth_state(
             )
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
+    def opener(request, timeout):
+        response = Response()
+        response.status = 200 if request.full_url.endswith("/healthz") else 401
+        return response
+
     report = module.refresh_after_app_registration(
         current,
-        opener=lambda *args, **kwargs: Response(),
+        opener=opener,
         runner=runner,
-        popen_factory=lambda argv, **kwargs: launches.append((list(argv), kwargs.get("env"))),
+        popen_factory=lambda argv, **kwargs: (launches.append((list(argv), kwargs.get("env"))) or SimpleNamespace(pid=2234)),
         sleeper=lambda _: None,
     )
 
@@ -420,10 +509,12 @@ def test_post_register_always_recycles_service_and_preserves_oauth_state(
     assert report["funnel_recycle_scope"] == "https:443"
     assert report["next_action"] == "VERIFY_REGISTERED_CHATGPT_APP_WITH_ORACLE"
     assert "different connector" in report["verification_boundary"]
-    assert calls[0] == module.devspace_native_argv()
-    assert calls[1] == module.devspace_compat_argv()
-    assert calls[2] == module.devspace_compat_argv(stop_exact_service=True)
-    assert calls[3] == module.devspace_compat_argv(confirm_restarted=True)
+    assert calls[0] == module.devspace_package_prepare_argv()
+    assert calls[1] == module.devspace_native_prepare_argv()
+    assert calls[2] == module.devspace_native_argv()
+    assert calls[3] == module.devspace_compat_argv()
+    assert calls[4] == module.devspace_compat_argv(stop_exact_service=True)
+    assert calls[5] == module.devspace_compat_argv(confirm_restarted=True)
     assert ["tailscale", "funnel", "--bg", "--https=443", "off"] in calls
     assert [
         "tailscale", "funnel", "--bg", "--https=443", f"http://127.0.0.1:{current.local_port}"
@@ -431,6 +522,8 @@ def test_post_register_always_recycles_service_and_preserves_oauth_state(
     assert launches[0][1]["DEVSPACE_TOOL_MODE"] == "full"
     assert launches[0][1]["DEVSPACE_OAUTH_SCOPES"] == "devspace,offline_access"
     assert launches[0][1]["DEVSPACE_SUBAGENTS"] == "false"
+    assert launches[0][0] == module.managed_service_runner_argv()
+    assert launches[0][1]["DEVSPACE_LOG_REQUESTS"] == "false"
 
 
 def test_post_register_preserves_shared_funnel_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -441,7 +534,8 @@ def test_post_register_preserves_shared_funnel_port(tmp_path: Path, monkeypatch:
     calls: list[list[str]] = []
 
     class Response:
-        status = 401
+        def __init__(self, status: int):
+            self.status = status
         def __enter__(self):
             return self
         def __exit__(self, *args):
@@ -462,9 +556,9 @@ def test_post_register_preserves_shared_funnel_port(tmp_path: Path, monkeypatch:
 
     report = module.refresh_after_app_registration(
         current,
-        opener=lambda *args, **kwargs: Response(),
+        opener=lambda request, timeout: Response(200 if request.full_url.endswith("/healthz") else 401),
         runner=runner,
-        popen_factory=lambda *args, **kwargs: SimpleNamespace(),
+        popen_factory=lambda *args, **kwargs: SimpleNamespace(pid=3234),
         sleeper=lambda _: None,
     )
 
@@ -517,11 +611,16 @@ def test_setup_applies_hash_validated_devspace_compat_before_service_start(
             return SimpleNamespace(returncode=0, stdout=json.dumps({"Web": web}), stderr="")
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
+    def opener(request, timeout):
+        response = Response()
+        response.status = 200 if request.full_url.endswith("/healthz") else 401
+        return response
+
     module.apply_setup(
         current,
-        opener=lambda *args, **kwargs: Response(),
+        opener=opener,
         runner=runner,
-        popen_factory=lambda argv, **kwargs: launched.append((list(argv), kwargs.get("env"))),
+        popen_factory=lambda argv, **kwargs: (launched.append((list(argv), kwargs.get("env"))) or SimpleNamespace(pid=4234)),
         sleeper=lambda _: None,
         platform_name="nt",
         owner_password_reviewer=lambda: {"ok": True},
@@ -534,14 +633,13 @@ def test_setup_applies_hash_validated_devspace_compat_before_service_start(
     ]
     assert "creationflags" not in call_kwargs[1]
     assert "startupinfo" not in call_kwargs[1]
-    assert calls[2] == module.devspace_native_argv()
-    assert calls[3] == module.devspace_compat_argv()
-    assert calls[4] == module.devspace_compat_argv(stop_exact_service=True)
-    assert calls[5] == module.devspace_compat_argv(confirm_restarted=True)
-    assert launched and launched[0][0][1:3] == [
-        "-lc",
-        "exec npx --yes @waishnav/devspace@1.0.8 serve",
-    ]
+    assert calls[2] == module.devspace_package_prepare_argv(platform_name="nt")
+    assert calls[3] == module.devspace_native_prepare_argv()
+    assert calls[4] == module.devspace_native_argv()
+    assert calls[5] == module.devspace_compat_argv()
+    assert calls[6] == module.devspace_compat_argv(stop_exact_service=True)
+    assert calls[7] == module.devspace_compat_argv(confirm_restarted=True)
+    assert launched and launched[0][0] == module.managed_service_runner_argv()
     assert launched[0][1]["DEVSPACE_TOOL_MODE"] == "full"
     assert launched[0][1]["DEVSPACE_OAUTH_SCOPES"] == "devspace,offline_access"
     assert launched[0][1]["DEVSPACE_SUBAGENTS"] == "false"
@@ -571,7 +669,7 @@ def test_windows_startup_watchdog_registration_is_hidden_and_deterministic(tmp_p
     )
 
     assert result["mode"] == "per-user-login-watchdog"
-    assert result["watch_interval_seconds"] == 300
+    assert result["watch_interval_seconds"] == 30
     assert runs[0][0][:3] == [
         "reg.exe",
         "ADD",
@@ -579,9 +677,9 @@ def test_windows_startup_watchdog_registration_is_hidden_and_deterministic(tmp_p
     ]
     assert module.WINDOWS_BOOTSTRAP_RUN_NAME in runs[0][0]
     command = runs[0][0][runs[0][0].index("/d") + 1]
-    assert "-Mode Watch -WatchIntervalSeconds 300" in command
+    assert "-Mode Watch -WatchIntervalSeconds 30" in command
     assert str(script.resolve()) in command
-    assert launches[0][0][-4:] == ["-Mode", "Watch", "-WatchIntervalSeconds", "300"]
+    assert launches[0][0][-4:] == ["-Mode", "Watch", "-WatchIntervalSeconds", "30"]
     assert launches[0][1]["stdin"] is subprocess.DEVNULL
     assert launches[0][1]["stdout"] is subprocess.DEVNULL
     assert launches[0][1]["stderr"] is subprocess.DEVNULL
@@ -610,7 +708,8 @@ def test_public_route_retries_bounded_funnel_propagation(tmp_path: Path) -> None
     sleeps: list[float] = []
 
     class Response:
-        status = 401
+        def __init__(self, status: int = 401):
+            self.status = status
         def __enter__(self):
             return self
         def __exit__(self, *args):
@@ -623,7 +722,7 @@ def test_public_route_retries_bounded_funnel_propagation(tmp_path: Path) -> None
         public_calls += 1
         if public_calls == 1:
             raise OSError("relay still propagating")
-        return Response()
+        return Response(200 if request.full_url.endswith("/healthz") else 401)
 
     status = json.dumps({"Web": {current.hostname + ":443": {
         "Proxy": f"http://127.0.0.1:{current.local_port}"
@@ -636,8 +735,8 @@ def test_public_route_retries_bounded_funnel_propagation(tmp_path: Path) -> None
     )
 
     assert report["ok"] is True
-    assert public_calls == 2
-    assert sleeps == [2.0]
+    assert public_calls == 5
+    assert sleeps == [2.0, 2.0]
 
 
 def test_owner_password_review_keeps_or_atomically_replaces_secret(tmp_path: Path) -> None:
@@ -720,7 +819,9 @@ def test_ensure_public_route_restores_missing_mapping_after_exact_local_health(t
     ))
 
     class Response:
-        status = 401
+        def __init__(self, status: int) -> None:
+            self.status = status
+
         def __enter__(self):
             return self
         def __exit__(self, *args):
@@ -736,7 +837,13 @@ def test_ensure_public_route_restores_missing_mapping_after_exact_local_health(t
         ]
         return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    report = module.ensure_public_route(current, opener=lambda *args, **kwargs: Response(), runner=runner)
+    report = module.ensure_public_route(
+        current,
+        opener=lambda request, **kwargs: Response(
+            200 if request.full_url.endswith("/healthz") else 401
+        ),
+        runner=runner,
+    )
     assert report["ok"] is True
     assert report["changed"] is True
     assert calls.count(["tailscale", "funnel", "status", "--json"]) == 2
@@ -819,7 +926,9 @@ def test_doctor_reports_persisted_full_mode_without_guessing_process_environment
     )
 
     class Response:
-        status = 200
+        def __init__(self, status: int) -> None:
+            self.status = status
+
         def __enter__(self):
             return self
         def __exit__(self, *args):
@@ -827,7 +936,7 @@ def test_doctor_reports_persisted_full_mode_without_guessing_process_environment
 
     report = module.doctor(
         current,
-        opener=lambda *args, **kwargs: Response(),
+        opener=lambda request, timeout: Response(200 if request.full_url.endswith("/healthz") else 401),
         config_path=config_path,
         runner=lambda *args, **kwargs: SimpleNamespace(
             returncode=0,

--- a/tests/test_devspace_tailscale_setup.py
+++ b/tests/test_devspace_tailscale_setup.py
@@ -53,6 +53,7 @@ def test_setup_plan_has_no_secrets_and_is_explicit_only(tmp_path: Path, monkeypa
     assert plan["managed_service_environment"] == {
         "DEVSPACE_TOOL_MODE": "full",
         "DEVSPACE_OAUTH_SCOPES": "devspace,offline_access",
+        "DEVSPACE_SUBAGENTS": "false",
     }
     assert plan["startup_watchdog"] == {
         "windows_mode": "per-user login watchdog",
@@ -61,7 +62,7 @@ def test_setup_plan_has_no_secrets_and_is_explicit_only(tmp_path: Path, monkeypa
     }
     assert plan["devspace_init"][1:3] == [
         "-lc",
-        "exec npx --yes @waishnav/devspace@1.0.7 init",
+        "exec npx --yes @waishnav/devspace@1.0.8 init",
     ]
 
 
@@ -429,6 +430,7 @@ def test_post_register_always_recycles_service_and_preserves_oauth_state(
     ] in calls
     assert launches[0][1]["DEVSPACE_TOOL_MODE"] == "full"
     assert launches[0][1]["DEVSPACE_OAUTH_SCOPES"] == "devspace,offline_access"
+    assert launches[0][1]["DEVSPACE_SUBAGENTS"] == "false"
 
 
 def test_post_register_preserves_shared_funnel_port(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -528,7 +530,7 @@ def test_setup_applies_hash_validated_devspace_compat_before_service_start(
 
     assert calls[1][1:3] == [
         "-lc",
-        "exec npx --yes @waishnav/devspace@1.0.7 init",
+        "exec npx --yes @waishnav/devspace@1.0.8 init",
     ]
     assert "creationflags" not in call_kwargs[1]
     assert "startupinfo" not in call_kwargs[1]
@@ -538,10 +540,11 @@ def test_setup_applies_hash_validated_devspace_compat_before_service_start(
     assert calls[5] == module.devspace_compat_argv(confirm_restarted=True)
     assert launched and launched[0][0][1:3] == [
         "-lc",
-        "exec npx --yes @waishnav/devspace@1.0.7 serve",
+        "exec npx --yes @waishnav/devspace@1.0.8 serve",
     ]
     assert launched[0][1]["DEVSPACE_TOOL_MODE"] == "full"
     assert launched[0][1]["DEVSPACE_OAUTH_SCOPES"] == "devspace,offline_access"
+    assert launched[0][1]["DEVSPACE_SUBAGENTS"] == "false"
 
 
 def test_windows_startup_watchdog_registration_is_hidden_and_deterministic(tmp_path: Path) -> None:
@@ -687,8 +690,8 @@ def test_owner_password_review_requires_tty_and_rejects_numeric_only(tmp_path: P
 def test_posix_setup_invokes_pinned_devspace_directly(tmp_path: Path) -> None:
     module, current = config(tmp_path)
     plan = module.setup_plan(current, platform_name="posix")
-    assert plan["devspace_init"] == ["npx", "--yes", "@waishnav/devspace@1.0.7", "init"]
-    assert plan["devspace_serve"] == ["npx", "--yes", "@waishnav/devspace@1.0.7", "serve"]
+    assert plan["devspace_init"] == ["npx", "--yes", "@waishnav/devspace@1.0.8", "init"]
+    assert plan["devspace_serve"] == ["npx", "--yes", "@waishnav/devspace@1.0.8", "serve"]
 
 
 def test_tailscale_hostname_is_discovered_from_status_json() -> None:

--- a/tests/test_global_gpt_browser_policy.py
+++ b/tests/test_global_gpt_browser_policy.py
@@ -143,9 +143,12 @@ def test_install_inventory_contains_new_active_runtime_and_keeps_legacy_recovery
         "bin/chatgpt_oracle_dispatch.py",
         "bin/chatgpt_oracle_multi.py",
         "bin/chatgpt_oracle_comprehensive.py",
-        "bin/devspace-compat/1.0.7/oauth-refresh-replay.patch",
-        "bin/devspace-compat/1.0.7/workspace-write-and-read-bridge.patch",
-        "bin/devspace-compat/1.0.7/workspaces.patch",
+        "bin/devspace-compat/1.0.8/oauth-refresh-replay.patch",
+        "bin/devspace-compat/1.0.8/artifact-audit-readonly.patch",
+        "bin/devspace-compat/1.0.8/workspace-write-and-read-bridge.patch",
+        "bin/devspace-compat/1.0.8/tool-read-receipts.patch",
+        "bin/devspace-compat/1.0.8/workspaces.patch",
+        "bin/devspace-compat/1.0.7/tool-read-receipts.patch",
         "bin/devspace-compat/1.0.4/directory-read.patch",
         "bin/devspace-compat/1.0.4/delete-file.patch",
         "bin/devspace-compat/1.0.4/trash-file.patch",
@@ -173,8 +176,8 @@ def test_install_inventory_contains_new_active_runtime_and_keeps_legacy_recovery
     assert manifest["external"]["oracle"]["tested_version"] == "0.18.0"
     assert manifest["external"]["oracle"]["last_known_good"]["version"] == "0.17.1"
     assert manifest["external"]["devspace"]["license"] == "MIT"
-    assert manifest["external"]["devspace"]["tested_version"] == "1.0.7"
-    assert manifest["external"]["devspace"]["last_known_good"]["version"] == "1.0.4"
+    assert manifest["external"]["devspace"]["tested_version"] == "1.0.8"
+    assert manifest["external"]["devspace"]["last_known_good"]["version"] == "1.0.7"
     assert manifest["external"]["agbrowse"]["role"] == "persisted-run-recovery-only"
     assert manifest["external"]["agbrowse"]["default_install"] is False
     assert manifest["external"]["codexpro"]["frozen"] is True

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -1,5 +1,10 @@
 import json
+import importlib.util
+import io
+import tarfile
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).parents[1]
 
@@ -159,6 +164,7 @@ def test_package_is_publishable_and_lockfile_matches() -> None:
         'LICENSE',
         'scripts/run_v4_contract_tests.py',
         'scripts/check_docs.py',
+        'scripts/prepare_devspace_108_ci.py',
         'contracts/install/',
     } <= set(package['files'])
 
@@ -177,6 +183,65 @@ def test_release_workflow_runs_focused_and_full_contract_checks() -> None:
     assert 'scripts/run_v4_contract_tests.py --full' in workflow
     assert 'windows-latest' in workflow
     assert 'macos-14' in workflow
+    assert 'scripts/prepare_devspace_108_ci.py' in workflow
+
+
+def test_devspace_ci_preparer_pins_the_policy_archive_integrity() -> None:
+    policy = json.loads((ROOT / "upstream-runtime-policy.json").read_text(encoding="utf-8"))
+    helper = (ROOT / "scripts" / "prepare_devspace_108_ci.py").read_text(encoding="utf-8")
+    expected = policy["runtimes"]["devspace"]["current"]["integrity"]
+    assert f'DEVSPACE_INTEGRITY = "{expected}"' in helper
+
+
+def test_manual_devspace_launch_docs_disable_optional_subagents_by_default() -> None:
+    guide = (ROOT / "docs" / "FIRST_INSTALL.md").read_text(encoding="utf-8")
+    managed_environment = guide[
+        guide.index("DEVSPACE_TOOL_MODE=full") : guide.index(
+            "임시 URL은 앱 등록 후 바뀌므로", guide.index("DEVSPACE_TOOL_MODE=full")
+        )
+    ]
+    assert "아래 세 값을 유지합니다" in guide
+    assert "DEVSPACE_OAUTH_SCOPES=devspace,offline_access" in managed_environment
+    assert "DEVSPACE_SUBAGENTS=false" in managed_environment
+    tailscale = (ROOT / "docs" / "DEVSPACE_TAILSCALE_SETUP.md").read_text(
+        encoding="utf-8"
+    )
+    assert "`DEVSPACE_SUBAGENTS=false`" in tailscale
+    assert "separately and explicitly approves" in tailscale
+
+
+def test_bug_report_template_tracks_current_devspace_version() -> None:
+    policy = json.loads((ROOT / "upstream-runtime-policy.json").read_text(encoding="utf-8"))
+    current = policy["runtimes"]["devspace"]["current"]["version"]
+    template = (ROOT / ".github" / "ISSUE_TEMPLATE" / "bug-report.yml").read_text(
+        encoding="utf-8"
+    )
+    assert f"DevSpace {current}" in template
+
+
+def test_devspace_ci_preparer_rejects_archive_escape_and_links(tmp_path: Path) -> None:
+    path = ROOT / "scripts" / "prepare_devspace_108_ci.py"
+    spec = importlib.util.spec_from_file_location("prepare_devspace_108_ci_test", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    def archive(member: tarfile.TarInfo, content: bytes = b"") -> bytes:
+        stream = io.BytesIO()
+        with tarfile.open(fileobj=stream, mode="w:gz") as package:
+            member.size = len(content)
+            package.addfile(member, io.BytesIO(content) if content else None)
+        return stream.getvalue()
+
+    traversal = tarfile.TarInfo("package/../escape.txt")
+    with pytest.raises(RuntimeError, match="unsafe path"):
+        module.extract_verified(archive(traversal, b"escape"), tmp_path / "traversal")
+
+    link = tarfile.TarInfo("package/link")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "package.json"
+    with pytest.raises(RuntimeError, match="non-file entry"):
+        module.extract_verified(archive(link), tmp_path / "link")
 
 
 def test_tag_push_workflow_publishes_only_validated_annotated_release() -> None:

--- a/tests/test_upstream_runtime_policy.py
+++ b/tests/test_upstream_runtime_policy.py
@@ -65,7 +65,8 @@ def test_checked_in_policy_separates_reporter_from_gated_maintainer_mutation() -
     assert policy["promotion"]["promotion_automation_schedule"] == "every-6-hours"
     assert "devspace-open-workspace-same-id-read" in policy["promotion"]["required_gates"]
     assert policy["runtimes"]["oracle"]["current"]["version"] == "0.18.0"
-    assert policy["runtimes"]["devspace"]["current"]["version"] == "1.0.7"
+    assert policy["runtimes"]["devspace"]["current"]["version"] == "1.0.8"
+    assert policy["runtimes"]["devspace"]["last_known_good"]["version"] == "1.0.7"
 
 
 def test_offline_fixture_reports_sync_and_hash_bound_archives() -> None:
@@ -135,7 +136,7 @@ def test_main_allows_drift_for_workflow_issue_handling(tmp_path: Path, capsys) -
     module = load_module()
     policy = json.loads(POLICY_PATH.read_text(encoding="utf-8"))
     fixture_path = tmp_path / "fixture.json"
-    fixture_path.write_text(json.dumps(fixture(policy, devspace_latest="1.0.8")), encoding="utf-8")
+    fixture_path.write_text(json.dumps(fixture(policy, devspace_latest="1.0.9")), encoding="utf-8")
     output = tmp_path / "report.json"
     assert module.main(["--fixture", str(fixture_path), "--output", str(output), "--allow-drift"]) == 0
     assert json.loads(output.read_text(encoding="utf-8"))["drifted"] == ["devspace"]

--- a/tests/test_verification_gates.py
+++ b/tests/test_verification_gates.py
@@ -22,15 +22,24 @@ def test_fast_gate_targets_exist_and_cover_the_pre_submit_contracts() -> None:
     gate = load("fast_gate_test", SCRIPTS / "run_fast_gate.py")
 
     for target in gate.FAST_TARGETS:
-        assert (ROOT / target).is_file(), target
+        assert (ROOT / target.split("::", 1)[0]).is_file(), target
 
-    covered = set(gate.FAST_TARGETS)
+    covered = {target.split("::", 1)[0] for target in gate.FAST_TARGETS}
     # The buckets that actually blocked runs before submission must be gated.
     assert "tests/test_chatgpt_oracle_state.py" in covered
     assert "tests/test_chatgpt_oracle_run.py" in covered
     assert "tests/test_chatgpt_oracle_compat.py" in covered
     assert "tests/test_chatgpt_oracle_incident.py" in covered
     assert "tests/test_chatgpt_oracle_diagnose.py" in covered
+    selected_runner_contracts = {
+        target for target in gate.FAST_TARGETS
+        if target.startswith("tests/test_chatgpt_oracle_run.py::")
+    }
+    assert len(selected_runner_contracts) >= 20
+    assert any("fresh_app_read_gate" in target for target in selected_runner_contracts)
+    assert any("dynamic_cdp_port" in target for target in selected_runner_contracts)
+    assert any("foreign_task_recovery" in target for target in selected_runner_contracts)
+    assert "tests/test_chatgpt_oracle_run.py" not in gate.FAST_TARGETS
     assert gate.FAST_DESELECTS == [
         "tests/test_chatgpt_oracle_compat.py::test_archived_parent_direct_restore_requires_exact_control_and_composer_transition"
     ]
@@ -48,7 +57,8 @@ def test_fast_gate_is_a_strict_subset_of_the_full_suite() -> None:
         f"tests/{path.name}" for path in (ROOT / "tests").glob("test_*.py")
     }
 
-    assert set(gate.FAST_TARGETS) < all_tests
+    covered = {target.split("::", 1)[0] for target in gate.FAST_TARGETS}
+    assert covered < all_tests
 
 
 def test_fast_gate_hides_windows_console_windows() -> None:

--- a/upstream-runtime-policy.json
+++ b/upstream-runtime-policy.json
@@ -54,13 +54,13 @@
       "package": "@waishnav/devspace",
       "registry": "https://registry.npmjs.org/%40waishnav%2Fdevspace",
       "current": {
-        "version": "1.0.7",
-        "integrity": "sha512-kP+Wk52qiMRwdqAP+nV4OZ4HU8feivZQ0k6u4ZUkvqxu8j0Rp/AU8H0K4T43G+zmu9WJKlYLTet7vIUeZHU72A==",
-        "source": "https://www.npmjs.com/package/%40waishnav/devspace/v/1.0.7"
+        "version": "1.0.8",
+        "integrity": "sha512-uyEgFUmt8UcxRy7xnH2rddYdEm6lLIPMKgS2JHwRP7qVnWFtC7j1l4//EOfEVhO4NqGMckWxixNkCWAHPvgZqg==",
+        "source": "https://www.npmjs.com/package/%40waishnav/devspace/v/1.0.8"
       },
       "last_known_good": {
-        "version": "1.0.4",
-        "integrity": "sha512-gYaaweaKWTK7Xb4uImpso2mbp87I7TuCmpenOR1jh1rp0nXisId10UHB9HxU5N1Qa5bDmRcIyHe85Bln2zCuzg=="
+        "version": "1.0.7",
+        "integrity": "sha512-kP+Wk52qiMRwdqAP+nV4OZ4HU8feivZQ0k6u4ZUkvqxu8j0Rp/AU8H0K4T43G+zmu9WJKlYLTet7vIUeZHU72A=="
       }
     }
   }


### PR DESCRIPTION
Closes #25
Supersedes #22

## Outcome

Promotes the reviewed official `@waishnav/devspace@1.0.8` archive while keeping `1.0.7` as LKG and `1.0.4` historical-only. The compatibility patch stack remains hash-gated and fail-closed.

Selectively integrates the still-needed managed DevSpace recovery chain from #22 on current main, while excluding stale SkillOpt/research/persistent-Pro history. It fixes the outstanding #22 review findings: durable pre-submit evidence is mandatory, complete Basic/Bearer/cookie redaction is enforced, and streaming logs remain bounded including one oversized line.

The upstream release adds an optional local-agent surface. Managed Windows/macOS/onboarding launch paths explicitly set `DEVSPACE_SUBAGENTS=false`; this PR does not enable that surface or change user permissions/accounts.

## Exact upstream identity

- npm integrity: `sha512-uyEgFUmt8UcxRy7xnH2rddYdEm6lLIPMKgS2JHwRP7qVnWFtC7j1l4//EOfEVhO4NqGMckWxixNkCWAHPvgZqg==`
- tar SHA-256: `59578F71855C160826682FA0409CA885287FEE79F549B57128D8962348FF6488`

## Validation completed on final candidate bytes

- affected suite: 437 passed, 10 skipped after contract-fixture update
- DevSpace setup: 38 passed
- focused v4: 61 passed
- v3 contracts: 6 groups PASS
- full v4: 1321 passed, 24 skipped
- fast gate: PASS in 62.33s (100-second budget)
- portability, docs, upstream policy, Python compile, patch idempotency: PASS
- Oracle source canary: `submitted_question=false`
- isolated patched 1.0.8 MCP canary: same workspace for `open_workspace`, `read`, `read_chunk`; local and reconstructed SHA-256 matched; `DEVSPACE_SUBAGENTS=false`
- independent final-head review: PASS

## Post-merge gates still required

- exact-head Windows/macOS/Linux CI
- exact-main push CI
- annotated `v1.20.4` tag and non-draft release
- maintainer-host lifecycle install and source/install parity
- one safe-window managed DevSpace restart
- registered-app non-Pro same-workspace `open_workspace`/`read`/`read_chunk` SHA and receipt canary
- doctor/local-public/Funnel/tool-mode health

No Coin project files, accounts, ChatGPT settings, or Pro submissions are touched by this PR.