### PR TITLE
fix: tolerate managed DevSpace cold starts

### DIFF
--- a/bin/chatgpt_devspace_compat.py
+++ b/bin/chatgpt_devspace_compat.py
@@ -954,7 +954,10 @@ def confirm_service_restarted(
     *,
     package_root: Path | None = None,
     local_port: int = 7676,
-    wait_timeout_seconds: float = 20,
+    # A first hash-verified npx materialization can take longer than the HTTP
+    # readiness window on Windows.  Keep waiting on the stronger exact process
+    # identity instead of weakening confirmation to a port or health probe.
+    wait_timeout_seconds: float = 120,
     service_probe=current_devspace_service_identity,
     sleep: Any = time.sleep,
 ) -> dict[str, Any]:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # 기술 변경 기록
 
+## 1.20.5 - Harden managed DevSpace cold-start confirmation
+
+- Windows의 첫 `npx` DevSpace 1.0.8 기동이 20초를 넘는 경우에도 관리형
+  재시작 증명이 조기 실패하지 않도록, 정확한 post-patch listener 신원 확인의
+  bounded 대기를 120초로 늘렸습니다.
+- 단순 포트나 `/healthz` 응답으로 완화하지 않고, 기존의 패치 해시, 정확한
+  `dist/cli.js serve` 명령, 패치 이후 시작 시각 검증을 모두 유지합니다.
+- 60초 지연 listener와 old/foreign listener를 함께 재현하는 회귀 테스트를
+  추가해 marker가 정확한 새 서비스에서만 제거되는 것을 검증합니다.
+
 ## 1.20.4 - Validate DevSpace 1.0.8
 
 - DevSpace `1.0.8` is the explicit current runtime for new setup and managed

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.4",
+      "version": "1.20.5",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/tests/test_chatgpt_devspace_compat.py
+++ b/tests/test_chatgpt_devspace_compat.py
@@ -362,6 +362,84 @@ def test_restart_confirmation_rejects_old_or_foreign_listener(
     assert marker.is_file()
 
 
+def test_restart_confirmation_waits_through_managed_npx_cold_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compat = load_compat()
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "package.json").write_text(
+        json.dumps({"version": compat.SUPPORTED_VERSION}), encoding="utf-8"
+    )
+    (package / "sample.txt").write_bytes(b"after\n")
+    compat.PATCHES = {
+        "sample.txt": {
+            "patch": "unused.patch",
+            "pristine": digest(b"before\n"),
+            "patched": digest(b"after\n"),
+        }
+    }
+    monkeypatch.setenv("CODEX_DEVSPACE_COMPAT_STATE_ROOT", str(tmp_path / "state"))
+    marker = compat._write_restart_marker([package])
+    marker_payload = json.loads(marker.read_text(encoding="utf-8"))
+    patched_at = int(marker_payload["created_at_unix_ns"])
+    probes = 0
+    sleeps: list[float] = []
+    clock = [0.0]
+
+    def advance_clock(seconds: float) -> None:
+        sleeps.append(seconds)
+        clock[0] += seconds
+
+    monkeypatch.setattr(compat.time, "monotonic", lambda: clock[0])
+
+    def delayed_service_probe(port: int) -> dict[str, object] | None:
+        nonlocal probes
+        probes += 1
+        if probes < 121:
+            return None
+        if probes < 241:
+            return {
+                "pid": 11,
+                "command_line": f"node {package / 'dist' / 'cli.js'} serve",
+                "started_at_unix_ns": patched_at - 1,
+                "local_port": port,
+            }
+        return {
+            "pid": 22,
+            "command_line": f"node {package / 'dist' / 'cli.js'} serve",
+            "started_at_unix_ns": patched_at + 1,
+            "local_port": port,
+        }
+
+    with pytest.raises(compat.DevSpaceCompatError) as legacy_bound:
+        compat.confirm_service_restarted(
+            package_root=package,
+            wait_timeout_seconds=20,
+            service_probe=delayed_service_probe,
+            sleep=advance_clock,
+        )
+    assert legacy_bound.value.code == "DEVSPACE_RESTART_NOT_PROVEN"
+    assert marker.exists()
+
+    probes = 0
+    sleeps.clear()
+    clock[0] = 0.0
+    confirmed = compat.confirm_service_restarted(
+        package_root=package,
+        service_probe=delayed_service_probe,
+        sleep=advance_clock,
+    )
+
+    assert probes == 241
+    assert sum(sleeps) == pytest.approx(60.0)
+    assert confirmed["restart_confirmed"] is True
+    assert confirmed["restart_marker_cleared"] is True
+    assert confirmed["service_identity"]["pid"] == 22
+    assert not marker.exists()
+
+
 def test_stop_service_requires_exact_devspace_identity() -> None:
     compat = load_compat()
     stopped: list[int] = []


### PR DESCRIPTION
## Summary
- extend exact post-patch DevSpace listener confirmation from 20s to a bounded 120s
- preserve hash, command-line identity, post-marker timestamp, and marker fail-closed checks
- add a fake-clock regression proving the legacy 20s bound fails while a 60s managed cold start succeeds
- prepare patch release v1.20.5

## Incident evidence
The v1.20.4 lifecycle install passed 197/197 parity, but the first managed Windows post-register recycle returned DEVSPACE_RESTART_NOT_PROVEN before npx finished. The exact patched 1.0.8 listener appeared later as PID 20544 and was then proven by the official confirmation command. This PR fixes that reproducible cold-start race without using a weaker port or health-only signal.

## Validation
- python -m pytest tests/test_chatgpt_devspace_compat.py tests/test_devspace_tailscale_setup.py -q (63 passed, 4 skipped)
- python scripts/run_fast_gate.py (PASS, 53.27s / 100s)
- python scripts/check_portability.py --root . (PASS)
- python scripts/check_docs.py (PASS)
- python scripts/check_upstream_runtime_policy.py (in sync)
- python scripts/run_v3_contract_tests.py (PASS)
- v4 full suite is running locally; exact-head three-OS CI is required before merge

Related: #22, #25