### PR TITLE
fix: decode Tailscale status as UTF-8

### DIFF
--- a/bin/codex_web_gpt_onboarding.py
+++ b/bin/codex_web_gpt_onboarding.py
@@ -621,11 +621,10 @@ def _discover_tailscale_hostname() -> str:
             [executable, "status", "--json"],
             check=True,
             capture_output=True,
-            text=True,
             timeout=30,
         )
-        value = json.loads(completed.stdout)
-    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        value = json.loads(completed.stdout.decode("utf-8-sig", errors="strict"))
+    except (OSError, subprocess.SubprocessError, UnicodeError, json.JSONDecodeError) as exc:
         raise OnboardingError("TAILSCALE_HOSTNAME_UNAVAILABLE") from exc
     hostname = str((value.get("Self") or {}).get("DNSName") or "").strip().casefold().rstrip(".")
     if not hostname.endswith(".ts.net"):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 기술 변경 기록
 
+## 1.20.8 - Decode Tailscale status as UTF-8 during onboarding
+
+- Windows 한국어 로케일에서도 `onboard.py start`가 `tailscale status --json`의
+  비 ASCII 장치 정보를 CP949로 오해하지 않도록 stdout bytes를 UTF-8 strict로
+  직접 디코딩합니다.
+- 잘못된 인코딩은 기존 `TAILSCALE_HOSTNAME_UNAVAILABLE` fail-closed 오류로 유지하고,
+  실제 UTF-8 비 ASCII 상태 응답과 손상된 응답을 모두 회귀 테스트합니다.
+
 ## 1.20.7 - Bind registered-app final gates to server receipts
 
 - 새 일반 비-Pro final canary만 `registered_app_final_gate`로 명시해 실제 생성된

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.7",
+  "version": "1.20.8",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.7",
+  "version": "1.20.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.7",
+      "version": "1.20.8",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.7",
+  "version": "1.20.8",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/tests/test_codex_web_gpt_onboarding.py
+++ b/tests/test_codex_web_gpt_onboarding.py
@@ -4,6 +4,7 @@ import importlib.util
 import hashlib
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -58,6 +59,74 @@ def test_plan_orders_the_complete_first_install_without_secrets(tmp_path: Path) 
     assert "--browser-manual-login" in dumped
     assert "DEVSPACE_OAUTH_SCOPES" in dumped
     assert plan["stages"][3]["environment"]["DEVSPACE_SUBAGENTS"] == "false"
+
+
+def test_tailscale_hostname_discovery_decodes_utf8_bytes_on_windows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(module.shutil, "which", lambda _name: "tailscale.exe")
+    payload = json.dumps(
+        {
+            "Self": {
+                "DNSName": "lasal-pc.tail46ec90.ts.net.",
+                "HostName": "라살-PC",
+            }
+        },
+        ensure_ascii=False,
+    ).encode("utf-8")
+    observed: dict[str, object] = {}
+
+    def run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+        observed["argv"] = argv
+        observed["kwargs"] = kwargs
+        return subprocess.CompletedProcess(argv, 0, stdout=payload, stderr=b"")
+
+    monkeypatch.setattr(module.subprocess, "run", run)
+    assert module._discover_tailscale_hostname() == "lasal-pc.tail46ec90.ts.net"
+    assert observed["argv"] == ["tailscale.exe", "status", "--json"]
+    assert observed["kwargs"] == {"check": True, "capture_output": True, "timeout": 30}
+
+
+def test_tailscale_hostname_discovery_rejects_non_utf8_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(module.shutil, "which", lambda _name: "tailscale.exe")
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(
+            argv, 0, stdout=b'{"Self":{"DNSName":"host.ts.net","HostName":"\x80"}}', stderr=b""
+        ),
+    )
+    with pytest.raises(module.OnboardingError, match="TAILSCALE_HOSTNAME_UNAVAILABLE"):
+        module._discover_tailscale_hostname()
+
+
+def test_start_uses_utf8_tailscale_auto_discovery_without_injected_hostname(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = tmp_path / "프로젝트"
+    project.mkdir()
+    monkeypatch.setattr(module.shutil, "which", lambda _name: "tailscale.exe")
+    payload = json.dumps(
+        {"Self": {"DNSName": "lasal-pc.tail46ec90.ts.net.", "HostName": "라살-PC"}},
+        ensure_ascii=False,
+    ).encode("utf-8")
+    monkeypatch.setattr(
+        module.subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout=payload, stderr=b""),
+    )
+
+    state = module.start_onboarding(
+        provider="tailscale",
+        roots=[str(project)],
+        codex_home=tmp_path / ".codex",
+        devspace_home=tmp_path / ".devspace",
+    )
+    assert state["registration_url"] == "https://lasal-pc.tail46ec90.ts.net/mcp"
+    assert state["allowed_roots"] == [str(project.resolve())]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- capture 	ailscale status --json as bytes and decode explicit UTF-8 with BOM tolerance
- fail closed on invalid UTF-8 instead of inheriting the Windows console code page
- add helper and full start-path regressions with Korean host/project text
- bump package/install manifest to 1.20.8

## Verification
- focused onboarding: 108 passed, 1 skipped
- v3 contract: PASS
- v4 full: 1347 passed, 22 skipped
- docs contract: PASS
- portability: PASS
- fast gate: PASS (60.75s / 100s)
- independent read-only review: no must-fix