### PR TITLE
fix: preserve registered DevSpace apps across updates

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -110,6 +110,16 @@ for exact commands and provider-specific branches.
 When adding a project, preserve the complete existing root set and add only the
 new exact folder. Do not inspect or automate ChatGPT app settings per task.
 
+Keep an existing `codex` app's exact name and `/mcp` URL. When Actions are
+stale, use the visible **Refresh**/**New refresh** control in the app detail;
+if OAuth or tool calls remain stale, open `https://chatgpt.com/#settings/Plugins/`,
+select the existing app, and use **Reconnect**. Business UI or an unavailable
+Refresh control is not grounds to recreate the app: do so only when its record
+is actually absent or corrupt. Run `post-register` exactly once only when
+required, then use a fresh regular non-Pro auditNonce canary to prove
+`open_workspace → read → read_chunk`. A widget-domain warning alone does not
+establish whether `read_chunk` is present.
+
 ## Choose a mode
 
 | Desired result | Mode | Route |

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ python3 doctor.py
 ChatGPT 앱 `codex` 등록은 준비가 끝난 뒤 **최초 한 번 수동 등록**하는
 절차입니다. ChatGPT 설정·앱 목록·권한·삭제·선택 UI를 자동화하지 않습니다.
 
+기존 `codex` 앱은 같은 이름과 정확한 `/mcp` URL로 보존합니다. Action이 오래되면
+앱 상세의 보이는 `Refresh`/`새로 고침`으로 갱신하고, OAuth 또는 도구 호출이 계속
+오래되면 `https://chatgpt.com/#settings/Plugins/`에서 기존 앱을 선택해
+`Reconnect`/`다시 연결`합니다. Business UI나 Refresh 부재만으로 앱을 다시 만들지
+않으며, 실제 앱 레코드가 없거나 손상된 경우에만 예외적으로 재생성합니다. 필요할 때만
+`post-register`를 정확히 한 번 실행한 후, 새 일반 비-Pro auditNonce canary로
+`open_workspace → read → read_chunk`를 확인합니다. 위젯 도메인 경고만으로
+`read_chunk`의 존재·부재를 판단하지 않습니다.
+
 새 프로젝트를 추가할 때는 기존 root를 보존한 전체 목록에 exact folder만
 추가합니다. 앱 설정은 매 작업마다 재검사하거나 자동 조작하지 않습니다.
 

--- a/bin/chatgpt_chrome_local_network.py
+++ b/bin/chatgpt_chrome_local_network.py
@@ -14,10 +14,21 @@ import sys
 import tempfile
 from pathlib import Path
 from typing import Any, Mapping
+from urllib.parse import urlsplit
 
 
 CHATGPT_ORIGIN = "https://chatgpt.com"
 POLICY_SUBKEY = r"Software\Policies\Google\Chrome\LocalNetworkAccessAllowedForUrls"
+POLICY_SUBKEYS = {
+    "legacy_allow": POLICY_SUBKEY,
+    "legacy_block": r"Software\Policies\Google\Chrome\LocalNetworkAccessBlockedForUrls",
+    "local_allow": r"Software\Policies\Google\Chrome\LocalNetworkAllowedForUrls",
+    "local_block": r"Software\Policies\Google\Chrome\LocalNetworkBlockedForUrls",
+    "loopback_allow": r"Software\Policies\Google\Chrome\LoopbackNetworkAllowedForUrls",
+    "loopback_block": r"Software\Policies\Google\Chrome\LoopbackNetworkBlockedForUrls",
+}
+_PROFILE_LEGACY_KEY = "local_network_access"
+_PROFILE_SPLIT_KEYS = ("local_network", "loopback_network")
 
 
 def _normalized(value: object) -> str:
@@ -29,6 +40,76 @@ def policy_contains_origin(values: Mapping[str, object], origin: str = CHATGPT_O
     return any(_normalized(value) == expected for value in values.values())
 
 
+def _policy_pattern_matches_origin(value: object, origin: str = CHATGPT_ORIGIN) -> bool:
+    """Match the bounded Chrome URL-pattern forms relevant to this exact origin."""
+    # Profile exceptions use a primary,secondary content-setting pattern such
+    # as ``https://chatgpt.com:443,*``; policy lists contain just the primary.
+    pattern = _normalized(value).split(",", 1)[0]
+    expected = _normalized(origin)
+    if pattern in {"*", expected}:
+        return True
+    parsed = urlsplit(expected)
+    host = parsed.hostname or ""
+    if pattern in {f"[*.]{host}", f"*.{host}"}:
+        return True
+    candidate = urlsplit(pattern)
+    if not candidate.scheme or candidate.hostname != host or candidate.scheme != parsed.scheme:
+        return False
+    authority = pattern.split("://", 1)[1].split("/", 1)[0]
+    expected_port = "443" if parsed.scheme == "https" else "80" if parsed.scheme == "http" else ""
+    return authority in {host, f"{host}:{expected_port}", f"{host}:*"}
+
+
+def _matching_policy_value_names(
+    values: Mapping[str, object], origin: str = CHATGPT_ORIGIN
+) -> list[str]:
+    return [name for name, value in values.items() if _policy_pattern_matches_origin(value, origin)]
+
+
+def _profile_setting(entries: object, origin: str = CHATGPT_ORIGIN) -> int | None:
+    if not isinstance(entries, dict):
+        return None
+    matches: list[int] = []
+    for pattern, entry in entries.items():
+        if not _policy_pattern_matches_origin(pattern, origin) or not isinstance(entry, dict):
+            continue
+        setting = entry.get("setting")
+        if isinstance(setting, int):
+            matches.append(setting)
+    if 2 in matches:  # ContentSetting::CONTENT_SETTING_BLOCK
+        return 2
+    if 1 in matches:  # ContentSetting::CONTENT_SETTING_ALLOW
+        return 1
+    return None
+
+
+def browser_profile_loopback_allowed(profile_dir: Path) -> bool:
+    """Return whether the profile effectively allows chatgpt.com loopback access.
+
+    Chrome 151 splits the legacy local-network-access grant into local_network
+    and loopback_network. DevSpace connects to 127.0.0.1, so local_network on
+    its own is not sufficient. A legacy grant is accepted only before either
+    split preference has been created; this avoids treating a partially migrated
+    profile as ready.
+    """
+    try:
+        preferences = json.loads((profile_dir / "Default" / "Preferences").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if not isinstance(preferences, dict):
+        return False
+    exceptions = preferences.get("profile", {}).get("content_settings", {}).get("exceptions", {})
+    if not isinstance(exceptions, dict):
+        return False
+    split_present = any(key in exceptions for key in _PROFILE_SPLIT_KEYS)
+    loopback_setting = _profile_setting(exceptions.get("loopback_network"))
+    if loopback_setting is not None:
+        return loopback_setting == 1
+    if split_present:
+        return False
+    return _profile_setting(exceptions.get(_PROFILE_LEGACY_KEY)) == 1
+
+
 def next_policy_value_name(values: Mapping[str, object]) -> str:
     used = {int(name) for name in values if str(name).isdigit() and int(name) > 0}
     candidate = 1
@@ -37,11 +118,11 @@ def next_policy_value_name(values: Mapping[str, object]) -> str:
     return str(candidate)
 
 
-def _read_windows_policy() -> dict[str, str]:
+def _read_windows_policy(subkey: str = POLICY_SUBKEY) -> dict[str, str]:
     import winreg
 
     try:
-        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, POLICY_SUBKEY, 0, winreg.KEY_READ)
+        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, subkey, 0, winreg.KEY_READ)
     except FileNotFoundError:
         return {}
     values: dict[str, str] = {}
@@ -66,17 +147,33 @@ def policy_status() -> dict[str, Any]:
             "origin": CHATGPT_ORIGIN,
             "reason": "WINDOWS_CHROME_POLICY_ONLY",
         }
-    values = _read_windows_policy()
+    policies = {name: _read_windows_policy(subkey) for name, subkey in POLICY_SUBKEYS.items()}
+    matches = {name: _matching_policy_value_names(values) for name, values in policies.items()}
+    # Chrome's split-policy precedence for a loopback request is specific
+    # loopback block/allow, then legacy block/allow. Local-network entries are
+    # intentionally reported but cannot make a 127.0.0.1 DevSpace ready.
+    if matches["loopback_block"]:
+        effective = "blocked"
+    elif matches["loopback_allow"]:
+        effective = "allowed"
+    elif matches["legacy_block"]:
+        effective = "blocked"
+    elif matches["legacy_allow"]:
+        effective = "allowed"
+    else:
+        effective = "unset"
     return {
         "schema": "codex-web-gpt.chrome-local-network/v1",
         "supported": True,
-        "enabled": policy_contains_origin(values),
+        "enabled": effective == "allowed",
         "origin": CHATGPT_ORIGIN,
         "policy_subkey": POLICY_SUBKEY,
-        "matching_value_names": [
-            name for name, value in values.items() if _normalized(value) == _normalized(CHATGPT_ORIGIN)
-        ],
-        "entry_count": len(values),
+        "matching_value_names": matches["legacy_allow"],
+        "entry_count": len(policies["legacy_allow"]),
+        "effective_permission": "loopback_network",
+        "effective_policy": effective,
+        "policy_matches": matches,
+        "policy_entry_counts": {name: len(values) for name, values in policies.items()},
     }
 
 

--- a/bin/chatgpt_devspace_compat.py
+++ b/bin/chatgpt_devspace_compat.py
@@ -41,9 +41,10 @@ PATCHES = {
     "dist/server.js": {
         "patch": "workspace-write-and-read-bridge.patch",
         "pristine": "bf3db902241b631d7c6fbaf12385243b46b4f2d4bb776b6ea7ca6c9d429a3263",
-        "patched": "1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c",
+        "patched": "efd7a769601aae31b1f4d8a2e22767bba6c587b56488100dea85ad2c17f02985",
         "upgrades": {
             "659cb1011cd7ab7fb75debb21a44f030001797c2160a42beac527354be93e497": "tool-read-receipts.patch",
+            "1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c": "widget-domain.patch",
         },
     },
     "dist/workspaces.js": {
@@ -405,17 +406,24 @@ try {
   fs.rmSync(state, { recursive: true, force: true });
 }
 """
-    completed = runner(
-        [node, "--input-type=module", "-e", source],
-        cwd=str(root),
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-        check=False,
-        timeout=30,
-        **_git_kwargs(),
-    )
+    try:
+        completed = runner(
+            [node, "--input-type=module", "-e", source],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=30,
+            **_git_kwargs(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise DevSpaceCompatError(
+            "DEVSPACE_OAUTH_REFRESH_REPLAY_CHECK_TIMEOUT",
+            "DevSpace OAuth refresh replay check timed out",
+            {"root": str(root), "timeout_seconds": 30},
+        ) from exc
     if completed.returncode != 0:
         raise DevSpaceCompatError(
             "DEVSPACE_OAUTH_REFRESH_REPLAY_CHECK_FAILED",

--- a/bin/chatgpt_devspace_preflight.py
+++ b/bin/chatgpt_devspace_preflight.py
@@ -28,15 +28,17 @@ REGISTERED_APP_ACTION_SNAPSHOT_GATE_ERRORS = frozenset(
 REGISTERED_APP_ACTION_SNAPSHOT_GUIDANCE = {
     "ko": [
         "새 일반 비-Pro canary에서 read_chunk 또는 서버 생성 Audit receipt ID가 보이지 않으면, 서버가 아니라 ChatGPT의 등록 앱 Action 스냅샷이 오래된 상태로 취급합니다.",
-        "Enterprise/Edu 관리자는 ChatGPT의 Workspace settings > Apps에서 정확한 codex 앱의 더보기 메뉴를 열고 Action control > Refresh를 직접 실행한 뒤 새 Action을 검토·활성화합니다. 이 과정은 자동화하지 않습니다.",
-        "Business 또는 Refresh가 없는 UI에서는 같은 정확한 /mcp URL로 앱을 다시 만들고 게시한 뒤, 현재 서버가 노출한 Action을 검토·활성화하고 Owner 승인을 직접 완료합니다.",
-        "그 뒤 post-register를 한 번 실행하고, 새 일반 비-Pro auditNonce canary에서 open_workspace, read, read_chunk 및 세 서버 생성 receipt ID를 다시 증명합니다. open_workspace/read만으로는 통과하지 않습니다.",
+        "정확한 기존 codex 앱의 이름과 /mcp URL은 보존합니다. 앱 상세에서 보이는 Refresh 또는 새로 고침을 직접 눌러 Action을 갱신한 뒤 새 Action을 검토·활성화합니다. 이 ChatGPT 설정은 자동화하지 않습니다.",
+        "OAuth 또는 도구 호출이 계속 오래되면 https://chatgpt.com/#settings/Plugins/ 에서 기존 codex 앱을 선택하고 Reconnect(다시 연결)를 직접 실행합니다. Business라는 이유나 Refresh가 보이지 않는다는 이유만으로 앱을 삭제·재등록하지 않습니다.",
+        "post-register는 방금 등록했거나 다시 연결한 뒤 단계/진단이 요구할 때만 정확히 한 번 실행합니다. 이어서 새 일반 비-Pro auditNonce canary에서 open_workspace, read, read_chunk 및 세 서버 생성 receipt ID를 다시 증명합니다. open_workspace/read만으로는 통과하지 않습니다.",
+        "앱 레코드가 실제로 없거나 손상되어 기존 앱을 선택·갱신·재연결할 수 없을 때만 예외적으로 같은 정확한 이름과 /mcp URL로 다시 만듭니다.",
     ],
     "en": [
         "If a fresh regular non-Pro canary exposes no read_chunk or server-generated Audit receipt IDs, treat the registered ChatGPT app Action snapshot as stale rather than accepting the partial tool surface.",
-        "On Enterprise/Edu, an admin must open the exact codex app's overflow menu under Workspace settings > Apps, use Action control > Refresh, and review and enable the new Actions. Do not automate this ChatGPT setting.",
-        "On Business, or when Refresh is unavailable, recreate and publish the app with the same exact /mcp URL, review and enable the Actions currently exposed by the server, and complete Owner approval manually.",
-        "Then run post-register once and run a fresh regular non-Pro auditNonce canary proving open_workspace, read, read_chunk, and all three server-generated receipt IDs. open_workspace/read alone never passes.",
+        "Keep the exact existing codex app name and /mcp URL. In the app detail, manually use the visible Refresh or New refresh control to update Actions, then review and enable the new Actions. Do not automate this ChatGPT setting.",
+        "If OAuth or tool calls remain stale, manually open https://chatgpt.com/#settings/Plugins/, select the existing codex app, and use Reconnect. Do not delete or re-register the app merely because the workspace is Business or Refresh is unavailable.",
+        "Run post-register exactly once only when the stage or diagnosis requires it after registration or reconnection. Then run a fresh regular non-Pro auditNonce canary proving open_workspace, read, read_chunk, and all three server-generated receipt IDs. open_workspace/read alone never passes.",
+        "Recreate with the same exact name and /mcp URL only as an exception when the app record is actually absent or corrupt and the existing app cannot be selected, refreshed, or reconnected.",
     ],
 }
 

--- a/bin/codex_web_gpt_onboarding.py
+++ b/bin/codex_web_gpt_onboarding.py
@@ -22,7 +22,7 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-from chatgpt_chrome_local_network import policy_status
+from chatgpt_chrome_local_network import browser_profile_loopback_allowed, policy_status
 import codex_local_multi_gpt_setup as LOCAL_MULTI_GPT_SETUP
 
 
@@ -44,6 +44,10 @@ STAGE_IDS = (
     "07_chatgpt_app",
     "08_final_gate",
 )
+# These stages existed before the additive local-network stage.  Keep this
+# baseline fixed: later stage additions are migrated as pending rather than
+# making an otherwise valid, resumable v1 state require a reset.
+REQUIRED_LEGACY_STAGE_IDS = tuple(stage_id for stage_id in STAGE_IDS if stage_id != "06b_local_network_access")
 USER_OWNED_STAGES = (
     "02_stable_endpoint",
     "03_devspace_init",
@@ -364,22 +368,7 @@ def _persisted_allowed_roots(devspace_home: Path) -> tuple[str, ...]:
 
 
 def browser_profile_local_network_allowed(profile_dir: Path) -> bool:
-    preferences = _load_json(profile_dir / "Default" / "Preferences") or {}
-    exceptions = (
-        preferences.get("profile", {})
-        .get("content_settings", {})
-        .get("exceptions", {})
-        .get("local_network", {})
-    )
-    if not isinstance(exceptions, dict):
-        return False
-    expected = "https://chatgpt.com:443,*"
-    return any(
-        str(pattern).casefold() == expected
-        and isinstance(entry, dict)
-        and entry.get("setting") == 1
-        for pattern, entry in exceptions.items()
-    )
+    return browser_profile_loopback_allowed(profile_dir)
 
 
 def _root_identities(values: Sequence[Any]) -> list[str]:
@@ -464,7 +453,20 @@ def configure_app_name(*, codex_home: Path | None = None, app_name: str = APP_NA
     root = (codex_home or Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))).resolve()
     root.mkdir(parents=True, exist_ok=True)
     target = root / "chatgpt-workspace.json"
-    payload = json.dumps({"app_name": app_name}, ensure_ascii=True, indent=2) + "\n"
+    existing: dict[str, Any] = {}
+    if target.exists():
+        loaded = _load_json(target)
+        if loaded is None:
+            raise OnboardingError("CHATGPT_WORKSPACE_STATE_CORRUPT")
+        _secret_free(loaded)
+        if "app_name" in loaded and (
+            not isinstance(loaded["app_name"], str) or not loaded["app_name"].strip()
+        ):
+            raise OnboardingError("CHATGPT_WORKSPACE_STATE_CORRUPT")
+        existing = loaded
+    existing["app_name"] = app_name
+    _secret_free(existing)
+    payload = json.dumps(existing, ensure_ascii=True, indent=2) + "\n"
     fd, temporary_name = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=str(root))
     try:
         with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
@@ -529,8 +531,9 @@ def load_state(*, codex_home: Path | None = None) -> dict[str, Any]:
         raise OnboardingError("ONBOARDING_NOT_STARTED")
     if value.get("schema") != STATE_SCHEMA:
         raise OnboardingError("ONBOARDING_STATE_CORRUPT")
+    _secret_free(value)
     stages = value.get("stages")
-    if not isinstance(stages, dict) or set(stages) != set(STAGE_IDS):
+    if not isinstance(stages, dict) or not set(REQUIRED_LEGACY_STAGE_IDS).issubset(stages):
         raise OnboardingError("ONBOARDING_STATE_CORRUPT")
     for name in ("provider", "registration_url", "app_name"):
         if not isinstance(value.get(name), str) or not value[name].strip():
@@ -538,12 +541,31 @@ def load_state(*, codex_home: Path | None = None) -> dict[str, Any]:
     roots = value.get("allowed_roots")
     if not isinstance(roots, list) or not roots or not all(isinstance(item, str) and item.strip() for item in roots):
         raise OnboardingError("ONBOARDING_STATE_CORRUPT")
+    for stage_id in STAGE_IDS:
+        stages.setdefault(stage_id, {})
     for stage_id, stage in stages.items():
         if not isinstance(stage, dict):
+            raise OnboardingError("ONBOARDING_STATE_CORRUPT")
+        if not isinstance(stage_id, str) or not stage_id.strip():
+            raise OnboardingError("ONBOARDING_STATE_CORRUPT")
+        if "status" in stage and stage["status"] not in {"pending", "complete"}:
+            raise OnboardingError("ONBOARDING_STATE_CORRUPT")
+        if "verified_at" in stage and stage["verified_at"] is not None and (
+            not isinstance(stage["verified_at"], str) or not stage["verified_at"].strip()
+        ):
+            raise OnboardingError("ONBOARDING_STATE_CORRUPT")
+        if "evidence" in stage and stage["evidence"] is not None and not isinstance(stage["evidence"], dict):
             raise OnboardingError("ONBOARDING_STATE_CORRUPT")
         stage.setdefault("status", "pending")
         stage.setdefault("verified_at", None)
         stage.setdefault("evidence", None)
+    if "requested_roots" in value and (
+        not isinstance(value["requested_roots"], list)
+        or not all(isinstance(item, str) and item.strip() for item in value["requested_roots"])
+    ):
+        raise OnboardingError("ONBOARDING_STATE_CORRUPT")
+    if "enable_local_multi_gpt" in value and not isinstance(value["enable_local_multi_gpt"], bool):
+        raise OnboardingError("ONBOARDING_STATE_CORRUPT")
     value.setdefault("requested_roots", list(roots))
     value.setdefault("enable_local_multi_gpt", False)
     return value
@@ -1393,8 +1415,8 @@ def stage_instructions(stage_id: str, state: dict[str, Any], language: str = "ko
             f"새 일반 비-Pro Oracle 실행에서 @{state['app_name']} 로 exact root 를 열고 반환된 workspaceId를 보존합니다.",
             "Oracle run_id를 세 호출의 auditNonce로 쓰고 open_workspace를 그 대화의 첫 workspace/process/mutation 호출로 실행합니다. 같은 workspaceId로 미션 파일을 별도 read 호출한 뒤 같은 파일 전체를 offset 0의 read_chunk로 읽습니다.",
             "각 도구 결과가 돌려준 서버 생성 Audit receipt ID 3개를 최종 답변에 정확히 다시 적습니다. 이 challenge-response와 ~/.devspace/state/tool-read-receipts의 open_workspace → read → read_chunk 영수증을 함께 검증하며, 임의 ID/SHA 자기진술만으로는 통과하지 않습니다.",
-            f"새 canary에 read_chunk 또는 서버 생성 Audit receipt ID가 없으면 ChatGPT의 정확한 @{state['app_name']} 앱 Action 스냅샷이 오래된 것입니다. Enterprise/Edu 관리자는 워크스페이스 설정 → 앱에서 {state['app_name']} 앱의 더보기 메뉴를 열고 Action control → Refresh를 직접 실행한 뒤 새 Action을 검토·활성화합니다. 자동화가 이 설정을 조작하지 않습니다.",
-            "Business 또는 Refresh가 보이지 않는 UI에서는 같은 exact /mcp URL로 앱을 다시 만들고 게시한 뒤 현재 서버 Action을 검토·활성화하고 Owner 승인을 직접 완료합니다. 그 뒤 위 post-register를 한 번 실행하고 새 regular non-Pro auditNonce canary를 실행합니다. open_workspace/read만으로는 절대 통과하지 않습니다.",
+            f"새 canary에 read_chunk 또는 서버 생성 Audit receipt ID가 없으면 ChatGPT의 정확한 기존 @{state['app_name']} 앱 Action 스냅샷이 오래된 것입니다. 앱 상세에서 보이는 Refresh/새로 고침으로 Action을 갱신하고 새 Action을 검토·활성화합니다. 자동화가 이 설정을 조작하지 않습니다.",
+            "OAuth 또는 도구 호출이 계속 오래되면 https://chatgpt.com/#settings/Plugins/ 에서 기존 앱을 선택하고 Reconnect/다시 연결합니다. Business 또는 Refresh 부재만으로 앱을 삭제·재등록하지 않습니다. 앱 레코드가 실제로 없거나 손상된 경우에만 예외적으로 같은 exact 이름과 /mcp URL로 다시 만듭니다. 진단이 요구할 때만 위 post-register를 정확히 한 번 실행한 뒤 새 regular non-Pro auditNonce canary를 실행합니다. open_workspace/read만으로는 절대 통과하지 않습니다.",
             "Codex Desktop 내장 DevSpace 플러그인 결과는 증거로 쓰지 않습니다.",
             "성공하면 onboard.py record-final-gate --run-dir <Oracle run 디렉터리> --root <루트> --evidence <요약> --listing <항목> 을 실행합니다.",
         ],
@@ -1471,8 +1493,8 @@ def stage_instructions(stage_id: str, state: dict[str, Any], language: str = "ko
             f"In a fresh regular non-Pro Oracle run, open the exact root with @{state['app_name']} and preserve the returned workspaceId.",
             "Use the Oracle run_id as auditNonce for all three calls and make open_workspace the conversation's first workspace/process/mutation call. With that same workspaceId, separately read the mission and then read_chunk the complete same file from offset zero.",
             "Echo the three server-generated Audit receipt IDs returned by the tool calls exactly in the final answer. The gate verifies that challenge-response together with DevSpace's ~/.devspace/state/tool-read-receipts open_workspace → read → read_chunk chain; arbitrary output ID/SHA claims alone never pass.",
-            f"If the fresh canary exposes no read_chunk or server-generated Audit receipt ID, the exact @{state['app_name']} ChatGPT app Action snapshot is stale. On Enterprise/Edu, an admin must open that app's overflow menu under Workspace settings > Apps, use Action control > Refresh, and review and enable the new Actions; automation must not change this ChatGPT setting.",
-            "On Business, or when Refresh is unavailable, recreate and publish the app with the same exact /mcp URL, review and enable the current server Actions, and complete Owner approval manually. Then run the post-register command above once and run a fresh regular non-Pro auditNonce canary. open_workspace/read alone never passes.",
+            f"If the fresh canary exposes no read_chunk or server-generated Audit receipt ID, the exact existing @{state['app_name']} ChatGPT app Action snapshot is stale. Use the visible Refresh/New refresh control in that app's detail, then review and enable the new Actions; automation must not change this ChatGPT setting.",
+            "If OAuth or tool calls remain stale, open https://chatgpt.com/#settings/Plugins/, select the existing app, and use Reconnect. Do not delete or re-register it merely because the workspace is Business or Refresh is unavailable. Recreate with the same exact name and /mcp URL only when the app record is actually absent or corrupt. Run the post-register command above exactly once only when diagnosis requires it, then run a fresh regular non-Pro auditNonce canary. open_workspace/read alone never passes.",
             "The built-in Codex Desktop DevSpace plugin is not valid evidence.",
             "On success run onboard.py record-final-gate --run-dir <Oracle run directory> --root <root> --evidence <summary> --listing <entry>.",
         ],

--- a/bin/devspace-compat/1.0.8/widget-domain.patch
+++ b/bin/devspace-compat/1.0.8/widget-domain.patch
@@ -1,0 +1,41 @@
+diff --git a/dist/server.js b/dist/server.js
+index e65aac9..5e26b95 100644
+--- a/dist/server.js
++++ b/dist/server.js
+@@ -742,6 +742,20 @@ function appCsp(config) {
+         connectDomains: [publicBaseUrl],
+     };
+ }
++function appDomain(config) {
++    const publicBaseUrl = new URL(config.publicBaseUrl);
++    const hostname = publicBaseUrl.hostname.toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
++    const loopback = hostname === "localhost"
++        || hostname.endsWith(".localhost")
++        || hostname === "::1"
++        || hostname.startsWith("::ffff:127.")
++        || hostname.startsWith("::ffff:7f")
++        || /^127(?:\.\d{1,3}){3}$/.test(hostname);
++    if (publicBaseUrl.protocol !== "https:" || publicBaseUrl.username || publicBaseUrl.password || loopback) {
++        throw new Error("DevSpace workspace app domain must be a credential-free HTTPS origin.");
++    }
++    return publicBaseUrl.origin;
++}
+ function uiBuildDirectory() {
+     return fileURLToPath(new URL("../dist/ui", import.meta.url));
+ }
+@@ -937,6 +951,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+         description: "Interactive card for viewing DevSpace file diffs.",
+         _meta: {
+             ui: {
++                domain: appDomain(config),
+                 csp: appCsp(config),
+             },
+         },
+@@ -950,6 +965,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+                     text: workspaceAppHtml(config),
+                     _meta: {
+                         ui: {
++                            domain: appDomain(config),
+                             csp: appCsp(config),
+                         },
+                     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,19 @@
 # 기술 변경 기록
 
+## 1.20.9 - Preserve registered apps across DevSpace updates
+
+- 기존 ChatGPT 개발 앱의 이름·MCP URL·OAuth 연결을 업그레이드가 보존하고,
+  도구 목록이 오래된 경우에는 앱 재생성 대신 기존 앱의 `새로 고침` 후 필요한
+  경우에만 `다시 연결`하도록 한영 온보딩과 진단 메시지를 바로잡았습니다.
+- DevSpace 1.0.8의 `ui://devspace/workspace-app.html` 리소스에 공개 HTTPS origin을
+  hash-gated `ui.domain`으로 결속해 앱 제출 화면의 widget-domain 누락 경고를
+  제거합니다. HTTP, 자격 증명이 포함된 URL, loopback origin은 fail-closed 됩니다.
+- 관리형 DevSpace 복구가 healthy 401만 보고 패치 적용을 건너뛰지 않고 매번 exact
+  package/native/compatibility 상태를 재검증합니다. 실제 restart marker가 있을 때만
+  서비스를 한 번 재기동하며 malformed marker 보고는 재시작 없이 거부합니다.
+- OAuth replay canary timeout을 구조화된 비밀 없는 오류로 남기고, Chrome의 분리된
+  Local Network/loopback 정책과 기존 온보딩 상태 마이그레이션을 회귀 테스트합니다.
+
 ## 1.20.8 - Decode Tailscale status as UTF-8 during onboarding
 
 - Windows 한국어 로케일에서도 `onboard.py start`가 `tailscale status --json`의

--- a/docs/DEVSPACE_TAILSCALE_SETUP.md
+++ b/docs/DEVSPACE_TAILSCALE_SETUP.md
@@ -42,8 +42,10 @@ environment only selects the tool mode.
 The managed service also advertises `offline_access` together with the
 `devspace` OAuth scope so ChatGPT can renew its authorization instead of losing
 the connector after the one-hour access token expires. After upgrading an
-existing setup from metadata that omitted `offline_access`, recreate or
-reconnect the app once so ChatGPT reads the corrected OAuth metadata.
+existing setup from metadata that omitted `offline_access`, keep the existing
+`codex` app and exact URL, then manually reconnect that app once so ChatGPT
+reads the corrected OAuth metadata. Recreate only if the existing app record is
+actually absent or corrupt.
 
 The managed launch also pins `DEVSPACE_SUBAGENTS=false`. DevSpace 1.0.8's
 optional local-agent daemon and provider CLI adapters remain disabled unless
@@ -71,9 +73,9 @@ do not yet have this explicit config.
 
 Approve the initial Owner-password page when DevSpace asks. This tooling never opens settings, creates/deletes apps, picks permissions, inspects app lists, or selects an app in the composer.
 
-After a manual first registration or requested reconnect, recycle the managed
-DevSpace process once without changing its roots, Owner credential, OAuth
-database, or Funnel hostname:
+After a manual first registration or requested reconnect, run the following
+managed refresh exactly once only when the stage or diagnosis requires it. It
+does not change roots, Owner credential, OAuth database, or Funnel hostname:
 
 ```powershell
 python skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py post-register --root C:\projects\one --hostname your-device.your-tailnet.ts.net
@@ -103,10 +105,23 @@ python skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py doctor
 
 Diagnosis checks local DevSpace `/mcp`, then `tailscale funnel status --json`,
 then the public `/mcp` endpoint. If the endpoint is healthy but a ChatGPT tool
-call fails just after manual registration or reconnect, run the explicit
-`post-register` refresh once and repeat only the regular read-only Oracle
-probe. If it still fails, keep the server running and report the same connector
-URL; do not automate deletion, re-registration, or repeated refreshes.
+call is stale, first preserve the existing `codex` app and exact URL: use the
+visible Refresh/New refresh control in its app detail to update Actions. If
+OAuth or calls remain stale, manually open `https://chatgpt.com/#settings/Plugins/`,
+select the existing app, and use Reconnect. Run the explicit `post-register`
+refresh exactly once only when the stage or diagnosis requires it, then repeat
+only the fresh regular non-Pro auditNonce read-only Oracle probe. If it still
+fails, keep the server running and report the same connector URL; do not
+automate deletion, re-registration, or repeated refreshes. Business UI or an
+unavailable Refresh control is not a re-registration fallback; recreation is
+exceptional for an app record that is actually absent or corrupt.
+
+A widget-domain warning concerns required app-submission UI metadata, not a
+`read_chunk` Action inventory. The managed 1.0.8 compatibility patch now binds
+that resource to the exact credential-free public HTTPS origin. If the warning
+remains after installation, Refresh the existing app's Actions; do not recreate
+the app. The warning alone still cannot establish that `read_chunk` is absent,
+so the fresh canary remains the action-availability proof.
 
 A local/public `401` proves that the DevSpace OAuth challenge is reachable; it
 does **not** prove that ChatGPT's registered `@codex` account binding can mint a

--- a/docs/FIRST_INSTALL.en.md
+++ b/docs/FIRST_INSTALL.en.md
@@ -61,14 +61,28 @@ required.
 
 ChatGPT keeps a registered app's Action list as a snapshot. If a fresh final
 canary sees `open_workspace` and `read` but no `read_chunk`, or it sees no
-server-generated Audit receipt IDs, do not accept the partial result. The user
-must manually open the exact `codex` app's overflow menu under **Workspace
-settings > Apps**, select **Action control > Refresh**, then review and enable
-the new Actions. On Business, or when Refresh is unavailable, recreate and
-publish the app with the same exact `/mcp` URL, review and enable the Actions
-currently exposed by the server, and complete Owner approval manually. Agents must not automate
-these ChatGPT settings. Afterwards run the one `post-register` command shown by
-stage `08_final_gate`, then run a fresh regular non-Pro auditNonce canary.
+server-generated Audit receipt IDs, do not accept the partial result. Keep the
+exact existing `codex` app name and `/mcp` URL. In the app detail, manually use
+the visible **Refresh** or **New refresh** control to update Actions, then
+review and enable the new Actions. Agents must not automate these ChatGPT
+settings.
+
+If OAuth or tool calls remain stale, manually open
+`https://chatgpt.com/#settings/Plugins/`, select the existing `codex` app, and
+use **Reconnect**. Do not delete or re-register the app merely because the
+workspace is Business or Refresh is unavailable. Run `post-register` exactly
+once only when `08_final_gate` or diagnosis requires it after registration or
+reconnection, then run a fresh regular non-Pro auditNonce canary. Recreate with
+the same exact name and `/mcp` URL only as an exception when the app record is
+actually absent or corrupt and the existing app cannot be selected, refreshed,
+or reconnected.
+
+A widget-domain warning concerns required app-submission UI metadata; it does
+not prove whether the `read_chunk` Action is present. The managed DevSpace
+compatibility patch supplies the exact credential-free public HTTPS origin. If
+the warning remains after installation, Refresh the existing app's Actions;
+do not recreate the app. Verify the actual `open_workspace → read → read_chunk`
+surface with the fresh canary instead of inferring it from that warning.
 
 ## Final gate
 

--- a/docs/FIRST_INSTALL.md
+++ b/docs/FIRST_INSTALL.md
@@ -107,14 +107,23 @@ Plus/Pro에서도 보통 등록할 수 있으므로 요금제는 마지막 가�
 
 ChatGPT의 등록 앱 Action 목록은 고정 스냅샷일 수 있습니다. 새 final canary에서
 `open_workspace`와 `read`만 보이고 `read_chunk`가 없거나 서버 생성 Audit receipt ID가
-보이지 않으면 부분 성공으로 처리하지 않습니다. Enterprise/Edu 관리자는
-`워크스페이스 설정 → 앱`에서 정확한 `codex` 앱의 더보기 메뉴를 열고
-`Action control → Refresh`를 직접 실행한 뒤 새 Action을 검토·활성화합니다.
-Business 또는 Refresh가 없는 UI에서는 같은 exact `/mcp` URL로 앱을 다시 만들고
-게시한 뒤 서버가 현재 노출한 Action을 검토·활성화하고 Owner 승인을 직접 완료합니다.
-에이전트는 이 ChatGPT 설정을
-자동 조작하지 않습니다. 그 뒤 `08_final_gate`가 출력한 `post-register`를 한 번 실행하고,
-새 일반 비-Pro auditNonce canary를 실행합니다.
+보이지 않으면 부분 성공으로 처리하지 않습니다. 정확한 기존 `codex` 앱의 이름과 `/mcp`
+URL을 보존하고, 앱 상세에서 보이는 `Refresh` 또는 `새로 고침`으로 Action을 갱신한 뒤
+새 Action을 검토·활성화합니다. 에이전트는 이 ChatGPT 설정을 자동 조작하지 않습니다.
+
+OAuth 또는 도구 호출이 계속 오래되면 `https://chatgpt.com/#settings/Plugins/`에서 기존
+`codex` 앱을 선택하고 `Reconnect`/`다시 연결`을 직접 실행합니다. Business라는 이유나
+`Refresh`가 보이지 않는다는 이유만으로 앱을 삭제·재등록하지 않습니다. `post-register`는
+방금 등록했거나 다시 연결한 뒤 `08_final_gate` 또는 진단이 요구할 때만 정확히 한 번
+실행하고, 이어서 새 일반 비-Pro auditNonce canary를 실행합니다. 앱 레코드가 실제로
+없거나 손상되어 기존 앱을 선택·갱신·재연결할 수 없을 때만 예외적으로 같은 정확한 이름과
+`/mcp` URL로 다시 만듭니다.
+
+위젯 도메인 경고는 앱 제출에 필요한 UI 메타데이터에 관한 경고이며 `read_chunk` Action의
+존재·부재를 증명하지 않습니다. 관리형 DevSpace 호환 패치는 정확한 자격 증명 없는 공개
+HTTPS origin을 제공합니다. 설치 뒤에도 경고가 남으면 기존 앱의 Action을 `새로 고침`하고
+앱을 다시 만들지 않습니다. 이 경우에도 Action 목록 추측 대신 새 canary로 실제
+`open_workspace → read → read_chunk`를 확인합니다.
 
 ### 실제 연결 확인
 

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.8",
+  "version": "1.20.9",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",
@@ -28,6 +28,7 @@
     "bin/devspace-compat/1.0.8/artifact-audit-readonly.patch",
     "bin/devspace-compat/1.0.8/workspace-write-and-read-bridge.patch",
     "bin/devspace-compat/1.0.8/tool-read-receipts.patch",
+    "bin/devspace-compat/1.0.8/widget-domain.patch",
     "bin/devspace-compat/1.0.8/workspaces.patch",
     "bin/chatgpt_oracle_compat.py",
     "bin/oracle-compat/0.17.1/assistantResponse.terminal-marker-fallback.patch",
@@ -228,7 +229,7 @@
         "version": "1.0.7",
         "integrity": "sha512-kP+Wk52qiMRwdqAP+nV4OZ4HU8feivZQ0k6u4ZUkvqxu8j0Rp/AU8H0K4T43G+zmu9WJKlYLTet7vIUeZHU72A=="
       },
-      "installation": "resolved by the explicit setup skill at 1.0.8; exact published hashes are compatibility-patched for bounded OAuth replay, workspace writes, large reads, and context discovery; 1.0.7 remains rollback LKG only"
+      "installation": "resolved by the explicit setup skill at 1.0.8; exact published hashes are compatibility-patched for bounded OAuth replay, workspace writes, large reads, context discovery, immutable read receipts, and a credential-free HTTPS workspace-app domain; 1.0.7 remains rollback LKG only"
     },
     "codexpro": {
       "package": "codexpro",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.8",
+  "version": "1.20.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.8",
+      "version": "1.20.9",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.8",
+  "version": "1.20.9",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/scripts/start_devspace_bootstrap.ps1
+++ b/scripts/start_devspace_bootstrap.ps1
@@ -108,7 +108,10 @@ try {
         }
         if ([bool]$Recovery.service_started) {
           $Service = $Recovery.service
-          Write-BootstrapLog ("DevSpace restarted (cycle={0}, attempt={1}, supervisor_pid={2}, child_pid={3}, state={4})." -f $Cycle, $Attempt, $Service.supervisor_pid, $Service.child_pid, $Service.state_path)
+          Write-BootstrapLog ("DevSpace started after listener absence (cycle={0}, attempt={1}, supervisor_pid={2}, child_pid={3}, state={4}, reason={5})." -f $Cycle, $Attempt, $Service.supervisor_pid, $Service.child_pid, $Service.state_path, $Recovery.reconciliation_reason)
+        } elseif ([bool]$Recovery.service_restarted) {
+          $Service = $Recovery.service
+          Write-BootstrapLog ("DevSpace restarted for compatibility reconciliation (cycle={0}, attempt={1}, supervisor_pid={2}, child_pid={3}, state={4}, reason={5})." -f $Cycle, $Attempt, $Service.supervisor_pid, $Service.child_pid, $Service.state_path, $Recovery.reconciliation_reason)
         }
         $Healthy = $true
         break

--- a/skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py
+++ b/skills/chatgpt-workspace-setup/scripts/devspace_tailscale_setup.py
@@ -241,6 +241,13 @@ def setup_plan(
 
 
 def run_checked(argv: Sequence[str], *, runner: Callable[..., Any] = subprocess.run) -> None:
+    run_checked_result(argv, runner=runner)
+
+
+def run_checked_result(
+    argv: Sequence[str], *, runner: Callable[..., Any] = subprocess.run
+) -> Any:
+    """Run a managed command and retain its checked result for a bounded caller."""
     completed = runner(
         list(argv), check=False, capture_output=True, text=True, encoding="utf-8", errors="replace",
         **windows_subprocess_kwargs(),
@@ -248,6 +255,23 @@ def run_checked(argv: Sequence[str], *, runner: Callable[..., Any] = subprocess.
     if completed.returncode != 0:
         summary = redact((completed.stderr or completed.stdout or "").strip())[-1200:]
         raise SetupError(f"MANAGED_COMMAND_FAILED:{completed.returncode}:{summary}")
+    return completed
+
+
+def checked_compatibility_report(
+    *, runner: Callable[..., Any] = subprocess.run,
+) -> dict[str, Any]:
+    """Run the exact compatibility gate and require its machine-readable result."""
+    completed = run_checked_result(devspace_compat_argv(), runner=runner)
+    try:
+        report = json.loads(completed.stdout or "")
+    except json.JSONDecodeError as error:
+        raise SetupError("DEVSPACE_COMPAT_REPORT_INVALID") from error
+    if not isinstance(report, dict) or report.get("ok") is not True:
+        raise SetupError("DEVSPACE_COMPAT_REPORT_INVALID")
+    if type(report.get("service_restart_required")) is not bool:
+        raise SetupError("DEVSPACE_COMPAT_REPORT_INVALID")
+    return report
 
 
 def run_interactive_checked(
@@ -437,14 +461,22 @@ def recover_service(
     popen_factory: Callable[..., Any] = subprocess.Popen,
     sleeper: Callable[[float], None] = time.sleep,
 ) -> dict[str, Any]:
-    """Idempotently restore the managed DevSpace service and its exact Funnel."""
+    """Reconcile the managed service without changing app registration or roots.
+
+    A healthy local MCP 401 only proves the listener is answering.  It does not
+    prove that a just-patched package has been restarted, so every recovery runs
+    the exact package/native/compatibility validations before deciding whether a
+    single exact-service restart is required.
+    """
     local = http_probe(config.local_mcp_url, opener=opener)
     service_started = not local.get("ok")
-    if service_started:
-        run_checked(devspace_package_prepare_argv(), runner=runner)
-        run_checked(devspace_native_prepare_argv(), runner=runner)
-        run_checked(devspace_native_argv(), runner=runner)
-        run_checked(devspace_compat_argv(), runner=runner)
+    run_checked(devspace_package_prepare_argv(), runner=runner)
+    run_checked(devspace_native_prepare_argv(), runner=runner)
+    run_checked(devspace_native_argv(), runner=runner)
+    compatibility = checked_compatibility_report(runner=runner)
+    restart_required = bool(compatibility.get("service_restart_required"))
+    service_restarted = service_started or restart_required
+    if service_restarted:
         run_checked(
             devspace_compat_argv(stop_exact_service=True, local_port=config.local_port),
             runner=runner,
@@ -454,11 +486,22 @@ def recover_service(
             devspace_compat_argv(confirm_restarted=True, local_port=config.local_port),
             runner=runner,
         )
+    if service_started and restart_required:
+        reconciliation_reason = "listener-absent-and-compatibility-restart-required"
+    elif service_started:
+        reconciliation_reason = "listener-absent"
+    elif restart_required:
+        reconciliation_reason = "compatibility-restart-required"
+    else:
+        reconciliation_reason = "healthy-listener-compatible"
     readiness = wait_for_local_readiness(config, opener=opener, sleeper=sleeper)
     result = ensure_public_route(config, opener=opener, runner=runner, sleeper=sleeper)
     return {
         **result,
         "service_started": service_started,
+        "service_restarted": service_restarted,
+        "reconciliation_reason": reconciliation_reason,
+        "compatibility": compatibility,
         "service": managed_service_evidence(locals().get("launch")),
         "local_readiness": readiness,
     }

--- a/tests/test_chatgpt_chrome_local_network.py
+++ b/tests/test_chatgpt_chrome_local_network.py
@@ -24,6 +24,38 @@ def test_new_entry_preserves_sparse_existing_names() -> None:
     assert module.next_policy_value_name({"1": "https://example.com", "3": "https://other.example"}) == "2"
 
 
+def test_split_policy_requires_loopback_allow_and_honors_blockers(monkeypatch) -> None:
+    policies = {
+        module.POLICY_SUBKEYS["legacy_allow"]: {"1": "https://chatgpt.com"},
+        module.POLICY_SUBKEYS["legacy_block"]: {},
+        module.POLICY_SUBKEYS["local_allow"]: {"1": "https://chatgpt.com"},
+        module.POLICY_SUBKEYS["local_block"]: {},
+        module.POLICY_SUBKEYS["loopback_allow"]: {"1": "https://chatgpt.com:443"},
+        module.POLICY_SUBKEYS["loopback_block"]: {},
+    }
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(module, "_read_windows_policy", lambda subkey: policies[subkey])
+    allowed = module.policy_status()
+    assert allowed["enabled"] is True
+    assert allowed["effective_permission"] == "loopback_network"
+    assert allowed["effective_policy"] == "allowed"
+
+    policies[module.POLICY_SUBKEYS["loopback_block"]] = {"1": "https://chatgpt.com"}
+    blocked = module.policy_status()
+    assert blocked["enabled"] is False
+    assert blocked["effective_policy"] == "blocked"
+
+
+def test_split_local_policy_cannot_authorize_loopback(monkeypatch) -> None:
+    policies = {subkey: {} for subkey in module.POLICY_SUBKEYS.values()}
+    policies[module.POLICY_SUBKEYS["local_allow"]] = {"1": "https://chatgpt.com"}
+    monkeypatch.setattr(module.sys, "platform", "win32")
+    monkeypatch.setattr(module, "_read_windows_policy", lambda subkey: policies[subkey])
+    status = module.policy_status()
+    assert status["enabled"] is False
+    assert status["effective_policy"] == "unset"
+
+
 def test_permission_denial_returns_bounded_manual_fallback(monkeypatch, capsys) -> None:
     def denied(**_kwargs):
         raise PermissionError("denied")

--- a/tests/test_chatgpt_devspace_compat.py
+++ b/tests/test_chatgpt_devspace_compat.py
@@ -156,6 +156,17 @@ def test_oauth_refresh_replay_probe_is_isolated_and_fail_closed(tmp_path: Path) 
         compat.check_oauth_refresh_replay(package_root=package, runner=failing)
     assert failure.value.code == "DEVSPACE_OAUTH_REFRESH_REPLAY_CHECK_FAILED"
 
+    def timing_out(argv, **kwargs):
+        raise subprocess.TimeoutExpired(argv, kwargs["timeout"])
+
+    with pytest.raises(compat.DevSpaceCompatError) as timeout:
+        compat.check_oauth_refresh_replay(package_root=package, runner=timing_out)
+    assert timeout.value.code == "DEVSPACE_OAUTH_REFRESH_REPLAY_CHECK_TIMEOUT"
+    assert timeout.value.evidence == {
+        "root": str(package.resolve()),
+        "timeout_seconds": 30,
+    }
+
 
 def test_large_read_bridge_probe_is_utf8_bounded_and_fail_closed(tmp_path: Path) -> None:
     compat = load_compat()
@@ -711,9 +722,10 @@ def test_108_workspace_bridge_patch_preserves_write_tools_and_adds_bounded_read_
     assert compat.PATCHES["dist/server.js"] == {
         "patch": "workspace-write-and-read-bridge.patch",
         "pristine": "bf3db902241b631d7c6fbaf12385243b46b4f2d4bb776b6ea7ca6c9d429a3263",
-        "patched": "1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c",
+        "patched": "efd7a769601aae31b1f4d8a2e22767bba6c587b56488100dea85ad2c17f02985",
         "upgrades": {
             "659cb1011cd7ab7fb75debb21a44f030001797c2160a42beac527354be93e497": "tool-read-receipts.patch",
+            "1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c": "widget-domain.patch",
         },
     }
     assert 'delete: "delete_file"' in patch
@@ -763,6 +775,90 @@ def test_108_workspace_bridge_patch_preserves_write_tools_and_adds_bounded_read_
     ):
         assert tool in receipt_patch
     assert "await writeToolReadReceipt" in receipt_patch
+    widget_patch = (
+        MODULE_PATH.parent
+        / "devspace-compat"
+        / compat.SUPPORTED_VERSION
+        / "widget-domain.patch"
+    ).read_text(encoding="utf-8")
+    assert widget_patch.count("domain: appDomain(config),") == 2
+    assert 'publicBaseUrl.protocol !== "https:"' in widget_patch
+    assert "publicBaseUrl.username || publicBaseUrl.password" in widget_patch
+    assert 'hostname === "localhost"' in widget_patch
+    assert '.replace(/\\.$/, "")' in widget_patch
+    assert 'hostname.endsWith(".localhost")' in widget_patch
+    assert 'hostname === "::1"' in widget_patch
+    assert 'hostname.startsWith("::ffff:127.")' in widget_patch
+    assert 'hostname.startsWith("::ffff:7f")' in widget_patch
+    assert r'/^127(?:\.\d{1,3}){3}$/.test(hostname)' in widget_patch
+    assert "return publicBaseUrl.origin;" in widget_patch
+
+
+def test_108_widget_domain_upgrade_is_hash_gated_to_the_public_app_origin(
+    tmp_path: Path,
+) -> None:
+    compat = load_compat()
+    try:
+        source_root = compat.resolve_package_roots()[0]
+    except compat.DevSpaceCompatError as exc:
+        pytest.skip(f"DevSpace {compat.SUPPORTED_VERSION} package unavailable: {exc.code}")
+    source = source_root / "dist" / "server.js"
+    prior_hash = "1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c"
+    if compat.sha256_file(source) != prior_hash:
+        pytest.skip("installed DevSpace server is not the prior hash-gated receipt payload")
+    package = tmp_path / "devspace"
+    (package / "dist").mkdir(parents=True)
+    shutil.copy2(source, package / "dist" / "server.js")
+    compat._apply_patch(
+        package,
+        MODULE_PATH.parent / "devspace-compat" / compat.SUPPORTED_VERSION / "widget-domain.patch",
+    )
+    server = (package / "dist" / "server.js").read_text(encoding="utf-8")
+    assert compat.sha256_file(package / "dist" / "server.js") == compat.PATCHES["dist/server.js"]["patched"]
+    assert server.count("domain: appDomain(config),") == 2
+    assert 'publicBaseUrl.protocol !== "https:"' in server
+    assert 'hostname === "localhost"' in server
+    assert '.replace(/\\.$/, "")' in server
+    assert 'hostname.endsWith(".localhost")' in server
+    assert 'hostname === "::1"' in server
+    assert 'hostname.startsWith("::ffff:127.")' in server
+    assert 'hostname.startsWith("::ffff:7f")' in server
+    assert r'/^127(?:\.\d{1,3}){3}$/.test(hostname)' in server
+    assert "return publicBaseUrl.origin;" in server
+    assert "domain: config.localBaseUrl" not in server
+
+    function_match = re.search(r"function appDomain\(config\) \{.*?\n\}", server, re.DOTALL)
+    assert function_match is not None
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node is required for the widget-domain runtime probe")
+    probe = function_match.group(0) + r'''
+const accepted = appDomain({ publicBaseUrl: "https://lasal-pc.tail46ec90.ts.net/mcp" });
+if (accepted !== "https://lasal-pc.tail46ec90.ts.net") process.exit(11);
+for (const candidate of [
+  "http://lasal-pc.tail46ec90.ts.net/mcp",
+  "https://user:password@lasal-pc.tail46ec90.ts.net/mcp",
+  "https://localhost:7676/mcp",
+  "https://localhost.:7676/mcp",
+  "https://dev.localhost:7676/mcp",
+  "https://dev.localhost.:7676/mcp",
+  "https://127.0.0.1:7676/mcp",
+  "https://127.42.0.9:7676/mcp",
+  "https://[::1]:7676/mcp",
+  "https://[::ffff:127.0.0.1]:7676/mcp",
+]) {
+  let rejected = false;
+  try { appDomain({ publicBaseUrl: candidate }); } catch { rejected = true; }
+  if (!rejected) process.exit(12);
+}
+'''
+    completed = subprocess.run(
+        [node, "--input-type=module", "--eval", probe],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
 
 
 def test_108_artifact_write_is_bound_to_audit_readonly_scope() -> None:

--- a/tests/test_chatgpt_devspace_preflight.py
+++ b/tests/test_chatgpt_devspace_preflight.py
@@ -190,9 +190,18 @@ def test_pro_gate_keeps_partial_registered_app_surface_fail_closed_with_manual_r
         "RUN_POST_REGISTER_ONCE",
         "RUN_FRESH_REGULAR_NON_PRO_AUDIT_NONCE_CANARY",
     ]
-    assert "Action control > Refresh" in "\n".join(evidence["registered_app_action_snapshot_guidance"]["en"])
-    assert "Business" in "\n".join(evidence["registered_app_action_snapshot_guidance"]["en"])
-    assert "read_chunk" in "\n".join(evidence["registered_app_action_snapshot_guidance"]["ko"])
+    english = "\n".join(evidence["registered_app_action_snapshot_guidance"]["en"])
+    korean = "\n".join(evidence["registered_app_action_snapshot_guidance"]["ko"])
+    assert "Refresh or New refresh" in english
+    assert "#settings/Plugins/" in english
+    assert "Reconnect" in english
+    assert "actually absent or corrupt" in english
+    assert "Business or Refresh is unavailable" in english
+    assert "recreate and publish" not in english
+    assert "새로 고침" in korean
+    assert "다시 연결" in korean
+    assert "실제로 없거나 손상" in korean
+    assert "read_chunk" in korean
 
 
 def test_pro_gate_does_not_recommend_app_refresh_for_unrelated_or_unknown_failures(tmp_path: Path) -> None:
@@ -252,7 +261,7 @@ def test_pro_gate_without_recorded_final_gate_keeps_only_conditional_snapshot_gu
     assert "post_refresh_actions" not in evidence
     conditional = evidence["conditional_registered_app_action_snapshot_guidance"]
     assert "read_chunk" in "\n".join(conditional["ko"])
-    assert "Action control > Refresh" in "\n".join(conditional["en"])
+    assert "Refresh or New refresh" in "\n".join(conditional["en"])
 
 
 def test_first_exact_root_qualification_is_cached_until_config_changes(tmp_path: Path) -> None:

--- a/tests/test_codex_web_gpt_onboarding.py
+++ b/tests/test_codex_web_gpt_onboarding.py
@@ -201,6 +201,22 @@ def test_configure_app_name_is_atomic_and_contains_only_public_name(tmp_path: Pa
     assert not list(tmp_path.glob("*.tmp"))
 
 
+def test_configure_app_name_preserves_existing_non_secret_fields(tmp_path: Path) -> None:
+    target = tmp_path / "chatgpt-workspace.json"
+    target.write_text(
+        json.dumps({"app_name": "old-name", "registration_url": "https://mcp.example.com/mcp", "future": {"enabled": True}}),
+        encoding="utf-8",
+    )
+
+    module.configure_app_name(codex_home=tmp_path, app_name="dongju")
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {
+        "app_name": "dongju",
+        "registration_url": "https://mcp.example.com/mcp",
+        "future": {"enabled": True},
+    }
+
+
 def test_plan_status_and_cli_share_the_same_arbitrary_app_name(tmp_path: Path) -> None:
     project = tmp_path / "project"
     project.mkdir()
@@ -279,7 +295,7 @@ def test_seed_profile_local_network_grant_is_accepted(tmp_path: Path) -> None:
                 "profile": {
                     "content_settings": {
                         "exceptions": {
-                            "local_network": {
+                            "loopback_network": {
                                 "https://chatgpt.com:443,*": {"setting": 1}
                             }
                         }
@@ -291,6 +307,58 @@ def test_seed_profile_local_network_grant_is_accepted(tmp_path: Path) -> None:
     )
     assert module.browser_profile_local_network_allowed(profile) is True
     assert module.browser_profile_local_network_allowed(tmp_path / "missing") is False
+
+
+def test_pre_migration_profile_grant_remains_accepted(tmp_path: Path) -> None:
+    profile = tmp_path / "browser-profile"
+    preferences = profile / "Default" / "Preferences"
+    preferences.parent.mkdir(parents=True)
+    preferences.write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "content_settings": {
+                        "exceptions": {
+                            "local_network_access": {
+                                "https://chatgpt.com:443,*": {"setting": 1}
+                            }
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert module.browser_profile_local_network_allowed(profile) is True
+
+
+def test_profile_split_permissions_require_loopback_allow_and_fail_closed(tmp_path: Path) -> None:
+    profile = tmp_path / "browser-profile"
+    preferences = profile / "Default" / "Preferences"
+    preferences.parent.mkdir(parents=True)
+    base = {
+        "profile": {
+            "content_settings": {
+                "exceptions": {
+                    "local_network": {"https://chatgpt.com:443,*": {"setting": 1}},
+                }
+            }
+        }
+    }
+    preferences.write_text(json.dumps(base), encoding="utf-8")
+    assert module.browser_profile_local_network_allowed(profile) is False
+
+    base["profile"]["content_settings"]["exceptions"]["loopback_network"] = {
+        "https://chatgpt.com:443,*": {"setting": 1}
+    }
+    preferences.write_text(json.dumps(base), encoding="utf-8")
+    assert module.browser_profile_local_network_allowed(profile) is True
+
+    base["profile"]["content_settings"]["exceptions"]["loopback_network"] = {
+        "https://chatgpt.com:443,*": {"setting": 2}
+    }
+    preferences.write_text(json.dumps(base), encoding="utf-8")
+    assert module.browser_profile_local_network_allowed(profile) is False
 
 
 @pytest.mark.parametrize("value", ["", "@dongju", "bad/name", "bad\\name", "bad\nname"])
@@ -928,9 +996,12 @@ def test_final_gate_instructions_require_manual_registered_app_action_refresh_be
     )
     instructions = "\n".join(module.stage_instructions("08_final_gate", state, language))
 
-    assert "Action control" in instructions
+    assert "Action" in instructions
     assert "Refresh" in instructions
     assert "Business" in instructions
+    assert "https://chatgpt.com/#settings/Plugins/" in instructions
+    assert ("다시 연결" in instructions) if language == "ko" else ("Reconnect" in instructions)
+    assert ("삭제·재등록하지" in instructions) if language == "ko" else ("Do not delete or re-register" in instructions)
     assert "read_chunk" in instructions
     assert "post-register" in instructions
     assert "open_workspace/read" in instructions
@@ -1615,6 +1686,57 @@ def test_load_state_backfills_missing_stage_defaults(tmp_path: Path) -> None:
     )
     reloaded = module.load_state(codex_home=environment["codex_home"])
     assert {"status", "verified_at", "evidence"}.issubset(reloaded["stages"]["01_install"])
+
+
+def test_load_state_migrates_additive_stage_without_erasing_verified_evidence(tmp_path: Path) -> None:
+    environment = _wizard_environment(tmp_path, ready=False)
+    module.start_onboarding(
+        provider="custom",
+        registration_url="https://mcp.example.com/mcp",
+        roots=[str(environment["project"])],
+        codex_home=environment["codex_home"],
+    )
+    path = module.state_path(codex_home=environment["codex_home"])
+    state = json.loads(path.read_text(encoding="utf-8"))
+    oracle_evidence = {"kind": "user-confirmed", "confirmed_at": "2026-08-27T00:00:00Z"}
+    app_evidence = {"kind": "user-confirmed", "confirmed_at": "2026-08-27T00:01:00Z"}
+    final_evidence = {"transport": "regular-non-pro-oracle", "read_ok": True, "evidence": "preserved"}
+    state["stages"]["06_oracle_login"] = {"status": "complete", "verified_at": "2026-08-27T00:00:00Z", "evidence": oracle_evidence}
+    state["stages"]["07_chatgpt_app"] = {"status": "complete", "verified_at": "2026-08-27T00:01:00Z", "evidence": app_evidence}
+    state["stages"]["08_final_gate"] = {"status": "complete", "verified_at": "2026-08-27T00:02:00Z", "evidence": final_evidence}
+    state["stages"].pop("06b_local_network_access")
+    state["stages"]["09_future_stage"] = {"status": "complete", "verified_at": "2026-08-27T00:03:00Z", "evidence": {"kind": "future"}}
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+    migrated = module.load_state(codex_home=environment["codex_home"])
+
+    assert migrated["stages"]["06b_local_network_access"] == {
+        "status": "pending",
+        "verified_at": None,
+        "evidence": None,
+    }
+    assert migrated["stages"]["06_oracle_login"]["evidence"] == oracle_evidence
+    assert migrated["stages"]["07_chatgpt_app"]["evidence"] == app_evidence
+    assert migrated["stages"]["08_final_gate"]["evidence"] == final_evidence
+    assert migrated["stages"]["09_future_stage"]["evidence"] == {"kind": "future"}
+
+
+def test_load_state_rejects_banned_state_content_before_migration(tmp_path: Path) -> None:
+    environment = _wizard_environment(tmp_path, ready=False)
+    module.start_onboarding(
+        provider="custom",
+        registration_url="https://mcp.example.com/mcp",
+        roots=[str(environment["project"])],
+        codex_home=environment["codex_home"],
+    )
+    path = module.state_path(codex_home=environment["codex_home"])
+    state = json.loads(path.read_text(encoding="utf-8"))
+    state["stages"].pop("06b_local_network_access")
+    state["stages"]["09_future_stage"] = {"status": "pending", "token": "must-not-be-stored"}
+    path.write_text(json.dumps(state), encoding="utf-8")
+
+    with pytest.raises(module.OnboardingError, match="ONBOARDING_STATE_MUST_NOT_CARRY_SECRETS"):
+        module.load_state(codex_home=environment["codex_home"])
 
 
 def _final_gate_record(root: Path, **overrides: object) -> dict[str, object]:

--- a/tests/test_devspace_tailscale_setup.py
+++ b/tests/test_devspace_tailscale_setup.py
@@ -431,6 +431,12 @@ def test_recover_starts_missing_service_then_restores_exact_funnel(
 
     def runner(argv, **kwargs):
         calls.append(list(argv))
+        if argv == module.devspace_compat_argv():
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"ok": True, "service_restart_required": False}),
+                stderr="",
+            )
         if argv[:4] == ["tailscale", "funnel", "status", "--json"]:
             return SimpleNamespace(
                 returncode=0,
@@ -454,6 +460,129 @@ def test_recover_starts_missing_service_then_restores_exact_funnel(
     assert launches[0] == module.managed_service_runner_argv()
     assert any("--stop-exact-service" in call for call in calls)
     assert any("--confirm-service-restarted" in call for call in calls)
+
+
+@pytest.mark.parametrize(
+    ("restart_required", "expected_restarted", "expected_reason"),
+    (
+        (True, True, "compatibility-restart-required"),
+        (False, False, "healthy-listener-compatible"),
+    ),
+)
+def test_recover_reconciles_healthy_listener_only_when_compatibility_requires_restart(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    restart_required: bool,
+    expected_restarted: bool,
+    expected_reason: str,
+) -> None:
+    module, current = config(tmp_path)
+    bash = tmp_path / "bash.exe"
+    bash.write_text("", encoding="utf-8")
+    monkeypatch.setenv("DEVSPACE_GIT_BASH", str(bash))
+    calls: list[list[str]] = []
+    launches: list[list[str]] = []
+
+    class Response:
+        status = 401
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            return False
+
+    def opener(request, timeout):
+        response = Response()
+        response.status = 200 if request.full_url.endswith("/healthz") else 401
+        return response
+
+    def runner(argv, **kwargs):
+        calls.append(list(argv))
+        if argv == module.devspace_compat_argv():
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"ok": True, "service_restart_required": restart_required}),
+                stderr="",
+            )
+        if argv == ["tailscale", "funnel", "status", "--json"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"Web": {current.hostname + ":443": {"Proxy": f"http://127.0.0.1:{current.local_port}"}}}),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    report = module.recover_service(
+        current,
+        opener=opener,
+        runner=runner,
+        popen_factory=lambda argv, **kwargs: (launches.append(list(argv)) or SimpleNamespace(pid=4567)),
+        sleeper=lambda _: None,
+    )
+
+    assert report["ok"] is True
+    assert report["service_started"] is False
+    assert report["service_restarted"] is expected_restarted
+    assert report["reconciliation_reason"] == expected_reason
+    assert report["compatibility"]["service_restart_required"] is restart_required
+    assert len(launches) == int(expected_restarted)
+    assert calls.count(module.devspace_compat_argv(stop_exact_service=True)) == int(expected_restarted)
+    assert calls.count(module.devspace_compat_argv(confirm_restarted=True)) == int(expected_restarted)
+    assert module.devspace_package_prepare_argv() in calls
+    assert module.devspace_native_prepare_argv() in calls
+    assert module.devspace_native_argv() in calls
+    assert not any("post-register" in call for call in calls)
+    assert not any(call[:3] == ["tailscale", "funnel", "reset"] for call in calls)
+    assert not any(call[-1:] == ["off"] for call in calls)
+
+
+@pytest.mark.parametrize(
+    "compatibility_payload",
+    (
+        {"ok": True},
+        {"ok": True, "service_restart_required": None},
+        {"ok": True, "service_restart_required": "false"},
+        {"ok": True, "service_restart_required": 0},
+        {"ok": True, "service_restart_required": 1},
+        {"ok": True, "service_restart_required": []},
+        {"ok": True, "service_restart_required": {}},
+    ),
+)
+def test_recover_rejects_non_boolean_compatibility_restart_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    compatibility_payload: dict[str, object],
+) -> None:
+    module, current = config(tmp_path)
+    bash = tmp_path / "bash.exe"
+    bash.write_text("", encoding="utf-8")
+    monkeypatch.setenv("DEVSPACE_GIT_BASH", str(bash))
+    launches: list[list[str]] = []
+
+    class Response:
+        status = 401
+        def __enter__(self):
+            return self
+        def __exit__(self, *args):
+            return False
+
+    def runner(argv, **kwargs):
+        if argv == module.devspace_compat_argv():
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(compatibility_payload),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with pytest.raises(module.SetupError, match="DEVSPACE_COMPAT_REPORT_INVALID"):
+        module.recover_service(
+            current,
+            opener=lambda request, timeout: Response(),
+            runner=runner,
+            popen_factory=lambda argv, **kwargs: launches.append(list(argv)),
+            sleeper=lambda _: None,
+        )
+    assert launches == []
 
 
 def test_post_register_always_recycles_service_and_preserves_oauth_state(

--- a/tests/test_global_gpt_browser_policy.py
+++ b/tests/test_global_gpt_browser_policy.py
@@ -147,6 +147,7 @@ def test_install_inventory_contains_new_active_runtime_and_keeps_legacy_recovery
         "bin/devspace-compat/1.0.8/artifact-audit-readonly.patch",
         "bin/devspace-compat/1.0.8/workspace-write-and-read-bridge.patch",
         "bin/devspace-compat/1.0.8/tool-read-receipts.patch",
+        "bin/devspace-compat/1.0.8/widget-domain.patch",
         "bin/devspace-compat/1.0.8/workspaces.patch",
         "bin/devspace-compat/1.0.7/tool-read-receipts.patch",
         "bin/devspace-compat/1.0.4/directory-read.patch",


### PR DESCRIPTION
## Summary

- promote the pinned official `@waishnav/devspace@1.0.8` runtime and preserve the existing ChatGPT `codex` app, OAuth connection, URL, roots, and browser profile across updates
- add a hash-gated `ui.domain` compatibility patch for `ui://devspace/workspace-app.html`; only a credential-free public HTTPS origin is accepted and loopback forms fail closed
- reconcile compatibility on an already-healthy managed listener and restart exactly once only when the validated compatibility report requires it
- make onboarding and diagnostics direct users to refresh the existing app Actions and, when needed, use Settings > Plugins > existing app > Reconnect; app recreation is exceptional only for a missing or corrupt record
- harden OAuth timeout reporting and Chrome Local Network/Loopback policy detection while preserving additive onboarding state

## Upstream provenance

- package: `@waishnav/devspace@1.0.8`
- npm integrity: `sha512-uyEgFUmt8UcxRy7xnH2rddYdEm6lLIPMKgS2JHwRP7qVnWFtC7j1l4//EOfEVhO4NqGMckWxixNkCWAHPvgZqg==`
- pristine `dist/server.js`: `bf3db902241b631d7c6fbaf12385243b46b4f2d4bb776b6ea7ca6c9d429a3263`
- existing receipt-patched predecessor: `1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c`
- final patched `dist/server.js`: `efd7a769601aae31b1f4d8a2e22767bba6c587b56488100dea85ad2c17f02985`
- rollback LKG remains `@waishnav/devspace@1.0.7`

## Verification

- independent final diff review: pass, including live Node probes for public origin, HTTP, credentials, localhost/trailing-dot localhost, 127/8, `::1`, and IPv4-mapped loopback
- promotion-focused pytest: `223 passed, 5 skipped`
- full v4 contract suite: `1364 passed, 22 skipped`
- v4 focused contract suite: `61 passed`
- v3 contract smoke: pass (6/6)
- fast gate: pass in 31.48s (100s budget)
- portability, docs, upstream policy, maintainer registration, golden-path no-submission smoke: pass
- exact published-package patch-chain test: pass

This validation incorporates the still-valid managed-recovery contracts previously raised in #20 and #22. It progresses #25; the issue should close only after the release, lifecycle install, safe managed restart, and live same-workspace canary all pass.