### PR TITLE
fix: persist Oracle network access and audit receipts

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -103,7 +103,7 @@ for exact commands and provider-specific branches.
 2. **Configure DevSpace** — register every exact project root and public origin
 3. **Protect Owner approval data** — never copy the password into CLI, Git, or logs
 4. **Verify restart recovery** — confirm local/public endpoints and root persistence
-5. **Sign in and persist Local network access** — keep the Oracle browser separate; on Windows use the exact-origin `chatgpt.com` policy helper
+5. **Sign in and persist Local network access** — keep the Oracle browser separate; on Windows the helper prefers the exact-origin `chatgpt.com` policy and falls back to a backed-up, receipted Oracle seed-profile grant when policy ACLs are locked
 6. **Register the ChatGPT app manually** — name `codex`, URL `https://stable-host/mcp`
 7. **Run a regular GPT read probe** — validate `@codex` without consuming Pro
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ python3 doctor.py
 2. **DevSpace 설정** — 사용할 모든 exact project root와 public origin 등록
 3. **Owner 승인 정보 보존** — 암호를 CLI·Git·로그에 복사하지 않음
 4. **상주 복구 검증** — 로그인 watchdog, local/public endpoint, root persistence 확인
-5. **Oracle 전용 브라우저 로그인 및 Local network 영속 허용** — 일상 Chrome과 분리; Windows는 정확한 `chatgpt.com` 정책 helper 사용
+5. **Oracle 전용 브라우저 로그인 및 Local network 영속 허용** — 일상 Chrome과 분리; Windows helper는 정확한 `chatgpt.com` 정책을 우선하고 정책 ACL이 잠겨 있으면 Oracle seed 프로필에만 백업·영수증과 함께 저장
 6. **ChatGPT 앱 수동 등록** — 이름 `codex`, URL `https://고정주소/mcp`
 7. **일반 GPT 연결 검사** — Pro를 소비하지 않고 `@codex` read probe 수행
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ python3 doctor.py
 2. **DevSpace 설정** — 사용할 모든 exact project root와 public origin 등록
 3. **Owner 승인 정보 보존** — 암호를 CLI·Git·로그에 복사하지 않음
 4. **상주 복구 검증** — 로그인 watchdog, local/public endpoint, root persistence 확인
-5. **Oracle 전용 브라우저 로그인 및 Local network 영속 허용** — 일상 Chrome과 분리; Windows helper는 정확한 `chatgpt.com` 정책을 우선하고 정책 ACL이 잠겨 있으면 Oracle seed 프로필에만 백업·영수증과 함께 저장
+5. **Oracle 전용 브라우저 로그인 및 Local network 영속 허용** — 일상 Chrome과 분리; Windows helper는 정확한 `chatgpt.com` 정책을 우선하고 정책 ACL이 잠겨 있으면 Oracle seed 프로필에만 백업·영수증과 함께 저장하며, Oracle 격리 Chrome의 반복 복구 팝업도 일반 Chrome 설정을 건드리지 않고 억제
 6. **ChatGPT 앱 수동 등록** — 이름 `codex`, URL `https://고정주소/mcp`
 7. **일반 GPT 연결 검사** — Pro를 소비하지 않고 `@codex` read probe 수행
 

--- a/bin/chatgpt_chrome_local_network.py
+++ b/bin/chatgpt_chrome_local_network.py
@@ -10,6 +10,8 @@ import argparse
 import datetime as dt
 import json
 import os
+import shutil
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -92,22 +94,42 @@ def browser_profile_loopback_allowed(profile_dir: Path) -> bool:
     split preference has been created; this avoids treating a partially migrated
     profile as ready.
     """
+    return browser_profile_network_status(profile_dir)["loopback_network"] is True
+
+
+def browser_profile_network_status(profile_dir: Path) -> dict[str, Any]:
+    preferences_path = profile_dir.expanduser().resolve() / "Default" / "Preferences"
     try:
-        preferences = json.loads((profile_dir / "Default" / "Preferences").read_text(encoding="utf-8"))
+        preferences = json.loads(preferences_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return False
-    if not isinstance(preferences, dict):
-        return False
-    exceptions = preferences.get("profile", {}).get("content_settings", {}).get("exceptions", {})
+        return {
+            "profile_dir": str(profile_dir.expanduser().resolve()),
+            "preferences_path": str(preferences_path),
+            "initialized": False,
+            "local_network": False,
+            "loopback_network": False,
+        }
+    exceptions = (
+        preferences.get("profile", {}).get("content_settings", {}).get("exceptions", {})
+        if isinstance(preferences, dict)
+        else {}
+    )
     if not isinstance(exceptions, dict):
-        return False
+        exceptions = {}
     split_present = any(key in exceptions for key in _PROFILE_SPLIT_KEYS)
+    legacy_setting = _profile_setting(exceptions.get(_PROFILE_LEGACY_KEY))
+    local_setting = _profile_setting(exceptions.get("local_network"))
     loopback_setting = _profile_setting(exceptions.get("loopback_network"))
-    if loopback_setting is not None:
-        return loopback_setting == 1
-    if split_present:
-        return False
-    return _profile_setting(exceptions.get(_PROFILE_LEGACY_KEY)) == 1
+    if not split_present:
+        local_setting = local_setting if local_setting is not None else legacy_setting
+        loopback_setting = loopback_setting if loopback_setting is not None else legacy_setting
+    return {
+        "profile_dir": str(profile_dir.expanduser().resolve()),
+        "preferences_path": str(preferences_path),
+        "initialized": True,
+        "local_network": local_setting == 1,
+        "loopback_network": loopback_setting == 1,
+    }
 
 
 def next_policy_value_name(values: Mapping[str, object]) -> str:
@@ -192,6 +214,149 @@ def _write_json_atomic(path: Path, value: object) -> None:
             os.unlink(temporary)
 
 
+def _write_profile_json_atomic(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+            json.dump(value, handle, ensure_ascii=False, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _sha256(path: Path) -> str:
+    import hashlib
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _chrome_timestamp() -> str:
+    chrome_epoch = dt.datetime(1601, 1, 1, tzinfo=dt.timezone.utc)
+    return str(int((dt.datetime.now(dt.timezone.utc) - chrome_epoch).total_seconds() * 1_000_000))
+
+
+def _profile_in_use(profile_dir: Path) -> bool:
+    if sys.platform != "win32":
+        return False
+    env = os.environ.copy()
+    env["CODEX_ORACLE_PROFILE_TARGET"] = str(profile_dir.expanduser().resolve())
+    script = (
+        "$target=[Environment]::GetEnvironmentVariable('CODEX_ORACLE_PROFILE_TARGET');"
+        "$count=@(Get-CimInstance Win32_Process -Filter \"Name='chrome.exe'\" -ErrorAction Stop | "
+        "Where-Object { $_.CommandLine -and $_.CommandLine.IndexOf($target, "
+        "[StringComparison]::OrdinalIgnoreCase) -ge 0 }).Count; Write-Output $count"
+    )
+    try:
+        completed = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", script],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+            env=env,
+            creationflags=0x08000000,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise RuntimeError("ORACLE_CHROME_PROFILE_PROCESS_CHECK_FAILED") from exc
+    if completed.returncode != 0 or not completed.stdout.strip().isdigit():
+        raise RuntimeError("ORACLE_CHROME_PROFILE_PROCESS_CHECK_FAILED")
+    return int(completed.stdout.strip()) > 0
+
+
+def enable_profile_permission(
+    *,
+    profile_dir: Path,
+    codex_home: Path | None = None,
+) -> dict[str, Any]:
+    profile = profile_dir.expanduser().resolve()
+    preferences_path = profile / "Default" / "Preferences"
+    if _profile_in_use(profile):
+        raise RuntimeError("ORACLE_CHROME_PROFILE_IN_USE")
+    try:
+        preferences = json.loads(preferences_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise RuntimeError("ORACLE_CHROME_PROFILE_PREFERENCES_UNREADABLE") from exc
+    if not isinstance(preferences, dict):
+        raise RuntimeError("ORACLE_CHROME_PROFILE_PREFERENCES_INVALID")
+    root = (codex_home or Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))).resolve()
+    before_sha256 = _sha256(preferences_path)
+    before_status = browser_profile_network_status(profile)
+    changed = not (before_status["local_network"] and before_status["loopback_network"])
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S%f")
+    backup_path: Path | None = None
+    if changed:
+        backup_path = root / "backups" / "chrome-local-network" / stamp / "Preferences"
+        backup_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(preferences_path, backup_path)
+        profile_value = preferences.setdefault("profile", {})
+        if not isinstance(profile_value, dict):
+            raise RuntimeError("ORACLE_CHROME_PROFILE_SECTION_INVALID")
+        content_settings = profile_value.setdefault("content_settings", {})
+        if not isinstance(content_settings, dict):
+            raise RuntimeError("ORACLE_CHROME_CONTENT_SETTINGS_INVALID")
+        exceptions = content_settings.setdefault("exceptions", {})
+        if not isinstance(exceptions, dict):
+            raise RuntimeError("ORACLE_CHROME_CONTENT_EXCEPTIONS_INVALID")
+        modified = _chrome_timestamp()
+        pattern = "https://chatgpt.com:443,*"
+        for permission in _PROFILE_SPLIT_KEYS:
+            entries = exceptions.setdefault(permission, {})
+            if not isinstance(entries, dict):
+                raise RuntimeError("ORACLE_CHROME_NETWORK_PERMISSION_INVALID")
+            existing = entries.get(pattern)
+            entry = dict(existing) if isinstance(existing, dict) else {}
+            entry.update({"last_modified": modified, "setting": 1})
+            entries[pattern] = entry
+        _write_profile_json_atomic(preferences_path, preferences)
+    after_status = browser_profile_network_status(profile)
+    if not (after_status["local_network"] and after_status["loopback_network"]):
+        raise RuntimeError("ORACLE_CHROME_LOCAL_NETWORK_PERMISSION_NOT_DURABLE")
+    receipt = root / "receipts" / f"chatgpt-local-network-profile-{stamp}.json"
+    payload = {
+        "schema": "codex-web-gpt.chrome-local-network-profile-receipt/v1",
+        "applied_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "origin": CHATGPT_ORIGIN,
+        "profile_dir": str(profile),
+        "preferences_path": str(preferences_path),
+        "changed": changed,
+        "backup_path": str(backup_path) if backup_path else None,
+        "before_sha256": before_sha256,
+        "after_sha256": _sha256(preferences_path),
+        "local_network": True,
+        "loopback_network": True,
+    }
+    _write_json_atomic(receipt, payload)
+    return {**after_status, "enabled": True, "mode": "oracle-seed-profile", "changed": changed, "receipt": str(receipt)}
+
+
+def durable_status(*, profile_dir: Path) -> dict[str, Any]:
+    policy = policy_status()
+    profile = browser_profile_network_status(profile_dir)
+    profile_enabled = bool(profile["local_network"] and profile["loopback_network"])
+    return {
+        **policy,
+        "enabled": bool(policy.get("enabled")) or profile_enabled,
+        "mode": "chrome-policy" if policy.get("enabled") else "oracle-seed-profile" if profile_enabled else "unset",
+        "oracle_profile": profile,
+    }
+
+
+def enable_durable_permission(*, profile_dir: Path, codex_home: Path | None = None) -> dict[str, Any]:
+    try:
+        policy = enable_policy(codex_home=codex_home)
+    except PermissionError:
+        return enable_profile_permission(profile_dir=profile_dir, codex_home=codex_home)
+    if policy.get("enabled"):
+        return {**durable_status(profile_dir=profile_dir), "changed": policy.get("changed"), "receipt": policy.get("receipt")}
+    if policy.get("effective_policy") == "blocked":
+        raise RuntimeError("CHATGPT_LOCAL_NETWORK_POLICY_BLOCKED")
+    return enable_profile_permission(profile_dir=profile_dir, codex_home=codex_home)
+
+
 def enable_policy(*, codex_home: Path | None = None) -> dict[str, Any]:
     if sys.platform != "win32":
         raise RuntimeError("WINDOWS_CHROME_POLICY_ONLY")
@@ -233,13 +398,18 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Manage exact chatgpt.com Chrome Local Network Access")
     parser.add_argument("command", choices=("status", "enable"))
     parser.add_argument("--codex-home", type=Path)
+    parser.add_argument("--profile-dir", type=Path, default=Path.home() / ".oracle" / "browser-profile")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parser().parse_args(argv)
     try:
-        result = policy_status() if args.command == "status" else enable_policy(codex_home=args.codex_home)
+        result = (
+            durable_status(profile_dir=args.profile_dir)
+            if args.command == "status"
+            else enable_durable_permission(profile_dir=args.profile_dir, codex_home=args.codex_home)
+        )
     except PermissionError:
         print(
             json.dumps(
@@ -247,8 +417,7 @@ def main(argv: list[str] | None = None) -> int:
                     "ok": False,
                     "error": "CHROME_POLICY_WRITE_DENIED",
                     "next_action": (
-                        "Grant Local network once in the dedicated Oracle browser profile, "
-                        "then fully exit Chrome."
+                        "Close the dedicated Oracle browser profile and rerun this command."
                     ),
                 },
                 ensure_ascii=False,

--- a/bin/chatgpt_chrome_local_network.py
+++ b/bin/chatgpt_chrome_local_network.py
@@ -337,10 +337,19 @@ def durable_status(*, profile_dir: Path) -> dict[str, Any]:
     policy = policy_status()
     profile = browser_profile_network_status(profile_dir)
     profile_enabled = bool(profile["local_network"] and profile["loopback_network"])
+    policy_blocked = policy.get("effective_policy") == "blocked"
     return {
         **policy,
-        "enabled": bool(policy.get("enabled")) or profile_enabled,
-        "mode": "chrome-policy" if policy.get("enabled") else "oracle-seed-profile" if profile_enabled else "unset",
+        "enabled": False if policy_blocked else bool(policy.get("enabled")) or profile_enabled,
+        "mode": (
+            "blocked-by-chrome-policy"
+            if policy_blocked
+            else "chrome-policy"
+            if policy.get("enabled")
+            else "oracle-seed-profile"
+            if profile_enabled
+            else "unset"
+        ),
         "oracle_profile": profile,
     }
 
@@ -349,6 +358,9 @@ def enable_durable_permission(*, profile_dir: Path, codex_home: Path | None = No
     try:
         policy = enable_policy(codex_home=codex_home)
     except PermissionError:
+        policy = policy_status()
+        if policy.get("effective_policy") == "blocked":
+            raise RuntimeError("CHATGPT_LOCAL_NETWORK_POLICY_BLOCKED")
         return enable_profile_permission(profile_dir=profile_dir, codex_home=codex_home)
     if policy.get("enabled"):
         return {**durable_status(profile_dir=profile_dir), "changed": policy.get("changed"), "receipt": policy.get("receipt")}

--- a/bin/chatgpt_chrome_local_network.py
+++ b/bin/chatgpt_chrome_local_network.py
@@ -108,7 +108,13 @@ def browser_profile_network_status(profile_dir: Path) -> dict[str, Any]:
             "initialized": False,
             "local_network": False,
             "loopback_network": False,
+            "exit_type": None,
+            "exited_cleanly": False,
+            "crash_restore_ready": False,
         }
+    profile_value = preferences.get("profile", {}) if isinstance(preferences, dict) else {}
+    if not isinstance(profile_value, dict):
+        profile_value = {}
     exceptions = (
         preferences.get("profile", {}).get("content_settings", {}).get("exceptions", {})
         if isinstance(preferences, dict)
@@ -129,6 +135,12 @@ def browser_profile_network_status(profile_dir: Path) -> dict[str, Any]:
         "initialized": True,
         "local_network": local_setting == 1,
         "loopback_network": loopback_setting == 1,
+        "exit_type": profile_value.get("exit_type"),
+        "exited_cleanly": profile_value.get("exited_cleanly") is True,
+        "crash_restore_ready": (
+            profile_value.get("exit_type") == "Normal"
+            and profile_value.get("exited_cleanly") is True
+        ),
     }
 
 
@@ -285,7 +297,11 @@ def enable_profile_permission(
     root = (codex_home or Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex"))).resolve()
     before_sha256 = _sha256(preferences_path)
     before_status = browser_profile_network_status(profile)
-    changed = not (before_status["local_network"] and before_status["loopback_network"])
+    changed = not (
+        before_status["local_network"]
+        and before_status["loopback_network"]
+        and before_status["crash_restore_ready"]
+    )
     stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d-%H%M%S%f")
     backup_path: Path | None = None
     if changed:
@@ -295,6 +311,10 @@ def enable_profile_permission(
         profile_value = preferences.setdefault("profile", {})
         if not isinstance(profile_value, dict):
             raise RuntimeError("ORACLE_CHROME_PROFILE_SECTION_INVALID")
+        # This seed is copied into isolated Oracle Chrome profiles. Mark only
+        # the seed as clean; never change the user's ordinary Chrome profile.
+        profile_value["exit_type"] = "Normal"
+        profile_value["exited_cleanly"] = True
         content_settings = profile_value.setdefault("content_settings", {})
         if not isinstance(content_settings, dict):
             raise RuntimeError("ORACLE_CHROME_CONTENT_SETTINGS_INVALID")
@@ -313,11 +333,15 @@ def enable_profile_permission(
             entries[pattern] = entry
         _write_profile_json_atomic(preferences_path, preferences)
     after_status = browser_profile_network_status(profile)
-    if not (after_status["local_network"] and after_status["loopback_network"]):
+    if not (
+        after_status["local_network"]
+        and after_status["loopback_network"]
+        and after_status["crash_restore_ready"]
+    ):
         raise RuntimeError("ORACLE_CHROME_LOCAL_NETWORK_PERMISSION_NOT_DURABLE")
     receipt = root / "receipts" / f"chatgpt-local-network-profile-{stamp}.json"
     payload = {
-        "schema": "codex-web-gpt.chrome-local-network-profile-receipt/v1",
+        "schema": "codex-web-gpt.chrome-local-network-profile-receipt/v2",
         "applied_at": dt.datetime.now(dt.timezone.utc).isoformat(),
         "origin": CHATGPT_ORIGIN,
         "profile_dir": str(profile),
@@ -328,6 +352,9 @@ def enable_profile_permission(
         "after_sha256": _sha256(preferences_path),
         "local_network": True,
         "loopback_network": True,
+        "exit_type": "Normal",
+        "exited_cleanly": True,
+        "crash_restore_ready": True,
     }
     _write_json_atomic(receipt, payload)
     return {**after_status, "enabled": True, "mode": "oracle-seed-profile", "changed": changed, "receipt": str(receipt)}
@@ -363,7 +390,13 @@ def enable_durable_permission(*, profile_dir: Path, codex_home: Path | None = No
             raise RuntimeError("CHATGPT_LOCAL_NETWORK_POLICY_BLOCKED")
         return enable_profile_permission(profile_dir=profile_dir, codex_home=codex_home)
     if policy.get("enabled"):
-        return {**durable_status(profile_dir=profile_dir), "changed": policy.get("changed"), "receipt": policy.get("receipt")}
+        profile = enable_profile_permission(profile_dir=profile_dir, codex_home=codex_home)
+        return {
+            **durable_status(profile_dir=profile_dir),
+            "changed": bool(policy.get("changed")) or bool(profile.get("changed")),
+            "receipt": profile.get("receipt"),
+            "policy_receipt": policy.get("receipt"),
+        }
     if policy.get("effective_policy") == "blocked":
         raise RuntimeError("CHATGPT_LOCAL_NETWORK_POLICY_BLOCKED")
     return enable_profile_permission(profile_dir=profile_dir, codex_home=codex_home)

--- a/bin/chatgpt_devspace_compat.py
+++ b/bin/chatgpt_devspace_compat.py
@@ -41,10 +41,11 @@ PATCHES = {
     "dist/server.js": {
         "patch": "workspace-write-and-read-bridge.patch",
         "pristine": "bf3db902241b631d7c6fbaf12385243b46b4f2d4bb776b6ea7ca6c9d429a3263",
-        "patched": "efd7a769601aae31b1f4d8a2e22767bba6c587b56488100dea85ad2c17f02985",
+        "patched": "d35a4cd7b5678b4fa16c05ba8ca1d8cc0937d9f4c2bdd48e454a46ffa28da598",
         "upgrades": {
             "659cb1011cd7ab7fb75debb21a44f030001797c2160a42beac527354be93e497": "tool-read-receipts.patch",
             "1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c": "widget-domain.patch",
+            "efd7a769601aae31b1f4d8a2e22767bba6c587b56488100dea85ad2c17f02985": "receipt-structured-output.patch",
         },
     },
     "dist/workspaces.js": {

--- a/bin/chatgpt_oracle_compat.py
+++ b/bin/chatgpt_oracle_compat.py
@@ -235,6 +235,11 @@ PATCHES = {
         "pristine": "956eff0b47da8bc35abb940b37c7f55e64177733cc668931daf53fb444e8f9cb",
         "patched": "3c24dbb5fb78e56a069103bbdb6dfe0d4f394215d9d1223a6f0b541c867b4b4d",
     },
+    "dist/src/browser/chromeLifecycle.js": {
+        "patch": "chromeLifecycle.disable-session-crash-bubble.patch",
+        "pristine": "312b45c44d4cd69a3a057e7bd1584b58182b4b37bc88f6ce6c7d11e216267c81",
+        "patched": "f3b405464515e858c9f773d67fa0e94bca07dadff8ea49caa7859ad37e730ff7",
+    },
     "dist/src/browser/actions/assistantResponse.js": {
         "patch": "../0.17.1/assistantResponse.terminal-marker-fallback.patch",
         "pristine": "93d2465ed7dce43d8093a91bada7656bc9ba7ba3729d2fcc43229fa8aa6e36de",

--- a/bin/codex_web_gpt_onboarding.py
+++ b/bin/codex_web_gpt_onboarding.py
@@ -1395,7 +1395,7 @@ def stage_instructions(stage_id: str, state: dict[str, Any], language: str = "ko
                     "동의가 기록되었습니다. chatgpt.com 의 Local network 권한만 영속 등록합니다.",
                     "python bin/chatgpt_chrome_local_network.py enable",
                     "python bin/chatgpt_chrome_local_network.py status",
-                    "Windows 정책 쓰기가 거부되면 전용 Oracle 프로필에서 직접 한 번 허용합니다.",
+                    "Windows 정책 쓰기가 거부되면 helper가 닫힌 전용 Oracle seed 프로필에 정확한 chatgpt.com local/loopback 권한만 백업·영수증과 함께 저장합니다.",
                 ]
             ),
         ],
@@ -1473,7 +1473,7 @@ def stage_instructions(stage_id: str, state: dict[str, Any], language: str = "ko
                     "Consent is recorded. Persist the Local Network grant for chatgpt.com only.",
                     "python bin/chatgpt_chrome_local_network.py enable",
                     "python bin/chatgpt_chrome_local_network.py status",
-                    "If the Windows policy write is denied, grant it once in the dedicated Oracle profile.",
+                    "If the Windows policy write is denied, the helper backs up the closed Oracle seed profile and persists only the exact chatgpt.com local/loopback permissions with a receipt.",
                 ]
             ),
         ],

--- a/bin/devspace-compat/1.0.8/receipt-structured-output.patch
+++ b/bin/devspace-compat/1.0.8/receipt-structured-output.patch
@@ -1,0 +1,54 @@
+diff --git a/dist/server.js b/dist/server.js
+index 4559b97..0c95162 100644
+--- a/dist/server.js
++++ b/dist/server.js
+@@ -1012,6 +1012,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             agents: z.array(workspaceLocalAgentOutputSchema).optional(),
+             skillDiagnostics: z.array(z.unknown()).optional(),
+             instruction: z.string(),
++            auditReceiptId: z.string().uuid().optional(),
+         },
+         ...toolWidgetDescriptorMeta(config, "workspace"),
+         annotations: { readOnlyHint: true },
+@@ -1152,6 +1153,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+                     }
+                     : {}),
+                 instruction,
++                ...(auditReceiptResult ? { auditReceiptId: auditReceiptResult.receiptId } : {}),
+             },
+         };
+     });
+@@ -1189,7 +1191,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+                 .describe("Maximum number of lines to read."),
+             auditNonce: z.string().regex(AUDIT_NONCE_PATTERN).optional().describe("Optional 16-128 character audit nonce for a local immutable tool-read receipt."),
+         },
+-        outputSchema: resultOutputSchema(),
++        outputSchema: resultOutputSchema({ auditReceiptId: z.string().uuid().optional() }),
+         ...toolWidgetDescriptorMeta(config, "read"),
+         annotations: { readOnlyHint: true },
+     }, async ({ workspaceId, auditNonce, ...input }, { _meta }) => {
+@@ -1238,6 +1240,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             },
+             structuredContent: {
+                 result: contentText(response.content),
++                ...(auditReceiptResult ? { auditReceiptId: auditReceiptResult.receiptId } : {}),
+             },
+         };
+     });
+@@ -1259,6 +1262,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             totalBytes: z.number().int().nonnegative(),
+             eof: z.boolean(),
+             sha256: z.string().regex(/^[0-9a-f]{64}$/),
++            auditReceiptId: z.string().uuid().optional(),
+         },
+         ...toolWidgetDescriptorMeta(config, "read"),
+         annotations: { readOnlyHint: true },
+@@ -1273,7 +1277,7 @@ export function createMcpServer(config, workspaces, reviewCheckpoints, processSe
+             const auditReceiptResult = await writeToolReadReceipt({ auditNonce, auditStep: auditReceipt.auditStep, tool: toolNames.readChunk, workspaceId, canonicalRoot: await realpath(workspace.root), requestedRelativePath: requestedReceiptPath(path), readChunkSha256: result.eof ? result.sha256 : null, readChunkOffsetBytes: result.offsetBytes, readChunkBytesReturned: result.bytesReturned, readChunkTotalBytes: result.totalBytes, readChunkEof: result.eof, conversationScopeId: auditReceipt.conversationScopeId });
+             logToolCall(config, { tool: toolNames.readChunk, workspaceId, path, success: true, durationMs: Math.round(performance.now() - startedAt) });
+             return {
+-                content: [textBlock(result.content), ...(auditReceiptResult ? [textBlock(`Audit receipt ID: ${auditReceiptResult.receiptId}`)] : [])], structuredContent: result,
++                content: [textBlock(result.content), ...(auditReceiptResult ? [textBlock(`Audit receipt ID: ${auditReceiptResult.receiptId}`)] : [])], structuredContent: { ...result, ...(auditReceiptResult ? { auditReceiptId: auditReceiptResult.receiptId } : {}) },
+                 _meta: { tool: toolNames.readChunk, card: { workspaceId, path, summary: { offsetBytes: result.offsetBytes, bytesReturned: result.bytesReturned, totalBytes: result.totalBytes, eof: result.eof, sha256: result.sha256 } } },
+             };
+         }

--- a/bin/oracle-compat/0.18.0/chromeLifecycle.disable-session-crash-bubble.patch
+++ b/bin/oracle-compat/0.18.0/chromeLifecycle.disable-session-crash-bubble.patch
@@ -1,0 +1,10 @@
+diff --git a/dist/src/browser/chromeLifecycle.js b/dist/src/browser/chromeLifecycle.js
+--- a/dist/src/browser/chromeLifecycle.js
++++ b/dist/src/browser/chromeLifecycle.js
+@@ -531,5 +531,6 @@ function buildChromeFlags(headless, debugBindAddress, hideWindow = false) {
+         "--disable-background-timer-throttling",
+         "--disable-breakpad",
++        "--disable-session-crashed-bubble",
+         "--disable-client-side-phishing-detection",
+         "--disable-default-apps",
+         "--disable-hang-monitor",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.20.10 - Persist Oracle Local network access and expose audit receipts
 
+- Oracle 0.18.0이 띄우는 격리 Chrome에만 `--disable-session-crashed-bubble`을
+  해시 결속 패치로 추가하고, Oracle seed 프로필의 `exit_type=Normal` 및
+  `exited_cleanly=true`를 백업·SHA 영수증과 함께 고정합니다. 일반 Chrome의
+  세션 복원 설정과 열린 탭은 변경하지 않습니다.
 - 사용자 범위 Chrome 정책 ACL이 쓰기 금지인 Windows에서도 `enable`이 실패 안내로
   끝나지 않고, 닫힌 Oracle seed 프로필의 정확한 `chatgpt.com` origin에 Chrome 151+
   `local_network`와 `loopback_network` 허용을 백업·원자적 쓰기·SHA 영수증과 함께

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # 기술 변경 기록
 
+## 1.20.10 - Persist Oracle Local network access and expose audit receipts
+
+- 사용자 범위 Chrome 정책 ACL이 쓰기 금지인 Windows에서도 `enable`이 실패 안내로
+  끝나지 않고, 닫힌 Oracle seed 프로필의 정확한 `chatgpt.com` origin에 Chrome 151+
+  `local_network`와 `loopback_network` 허용을 백업·원자적 쓰기·SHA 영수증과 함께
+  저장합니다. 일반 Chrome 프로필, 로그인, 쿠키, 다른 사이트 권한은 변경하지 않습니다.
+- `status`는 enterprise policy와 Oracle seed 프로필을 함께 검증하므로 throwaway 실행이
+  복제 전에 실제 영속 권한을 갖는지 판정합니다.
+- DevSpace 1.0.8의 `open_workspace`, `read`, `read_chunk`가 서버 생성 Audit receipt ID를
+  텍스트뿐 아니라 각 도구의 `structuredContent`와 output schema에도 노출해, ChatGPT 앱
+  렌더러가 보조 text block을 생략하더라도 final canary challenge-response를 완결합니다.
+
 ## 1.20.9 - Preserve registered apps across DevSpace updates
 
 - 기존 ChatGPT 개발 앱의 이름·MCP URL·OAuth 연결을 업그레이드가 보존하고,

--- a/docs/FIRST_INSTALL.en.md
+++ b/docs/FIRST_INSTALL.en.md
@@ -58,7 +58,11 @@ Chrome. It preserves logins, cookies, and unrelated site permissions while
 atomically adding only the exact `https://chatgpt.com` origin to the closed
 Oracle seed profile's `local_network` and `loopback_network` settings. A backup
 and SHA-bound receipt make the grant durable across disposable run profiles and
-future upgrades without app re-registration.
+future upgrades without app re-registration. The same Oracle-only update marks
+the seed profile as cleanly exited, while the hash-gated Oracle launcher adds
+Chrome's crash-bubble suppression flag. This removes repeated Restore pages
+prompts without changing the everyday Chrome profile, its open tabs, or its
+session-restore behavior.
 
 Register the app as `codex` with the exact stable `/mcp` URL. Depending on the
 account UI, check either Settings > Apps > Advanced settings > Developer mode,

--- a/docs/FIRST_INSTALL.en.md
+++ b/docs/FIRST_INSTALL.en.md
@@ -53,6 +53,13 @@ python onboard.py consent 06b_local_network_access
 The change is scoped to `https://chatgpt.com`; unrelated Chrome policy entries
 and the everyday Chrome profile remain untouched.
 
+If Windows policy ACLs deny the write, the helper does not elevate or reset
+Chrome. It preserves logins, cookies, and unrelated site permissions while
+atomically adding only the exact `https://chatgpt.com` origin to the closed
+Oracle seed profile's `local_network` and `loopback_network` settings. A backup
+and SHA-bound receipt make the grant durable across disposable run profiles and
+future upgrades without app re-registration.
+
 Register the app as `codex` with the exact stable `/mcp` URL. Depending on the
 account UI, check either Settings > Apps > Advanced settings > Developer mode,
 or Settings > Plugins > Developer mode. A missing Create button is first a UI,

--- a/docs/FIRST_INSTALL.md
+++ b/docs/FIRST_INSTALL.md
@@ -371,7 +371,10 @@ python .\bin\chatgpt_chrome_local_network.py status
 우회하지 않습니다. helper가 로그인·쿠키·다른 사이트 권한은 건드리지 않고 닫힌
 전용 Oracle seed 프로필의 `local_network`와 `loopback_network`에 정확한
 `https://chatgpt.com` origin만 백업·원자적 쓰기·SHA 영수증과 함께 저장합니다.
-따라서 업그레이드마다 다시 묻지 않으며 앱 재등록도 필요하지 않습니다.
+동시에 그 seed 프로필만 정상 종료 상태로 표시하고 Oracle 격리 Chrome에 복구 버블
+억제 플래그를 적용하므로 반복적인 "페이지 복원" 안내도 뜨지 않습니다. 일반 Chrome의
+프로필·열린 탭·세션 복원 설정은 건드리지 않습니다. 따라서 업그레이드마다 다시 묻지
+않으며 앱 재등록도 필요하지 않습니다.
 
 macOS 등 비-Windows 환경에서는 전용 Oracle 프로필에서 `chatgpt.com`의 **Local
 network**를 한 번 허용한 뒤 Chrome을 완전히 종료해 seed profile에 저장합니다.

--- a/docs/FIRST_INSTALL.md
+++ b/docs/FIRST_INSTALL.md
@@ -367,9 +367,11 @@ python .\bin\chatgpt_chrome_local_network.py enable
 python .\bin\chatgpt_chrome_local_network.py status
 ```
 
-조직 정책 ACL이나 일반 사용자 권한 때문에 `CHROME_POLICY_WRITE_DENIED`가 나오면
-관리자 권한을 우회하지 않습니다. 아래 비-Windows 절차와 똑같이 전용 Oracle
-프로필에서 한 번 직접 허용합니다.
+조직 정책 ACL이나 일반 사용자 권한 때문에 정책 쓰기가 거부되면 관리자 권한을
+우회하지 않습니다. helper가 로그인·쿠키·다른 사이트 권한은 건드리지 않고 닫힌
+전용 Oracle seed 프로필의 `local_network`와 `loopback_network`에 정확한
+`https://chatgpt.com` origin만 백업·원자적 쓰기·SHA 영수증과 함께 저장합니다.
+따라서 업그레이드마다 다시 묻지 않으며 앱 재등록도 필요하지 않습니다.
 
 macOS 등 비-Windows 환경에서는 전용 Oracle 프로필에서 `chatgpt.com`의 **Local
 network**를 한 번 허용한 뒤 Chrome을 완전히 종료해 seed profile에 저장합니다.

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -68,6 +68,7 @@
     "bin/oracle-compat/0.18.0/oracle-cli.followup-port-and-timeout.patch",
     "bin/oracle-compat/0.18.0/browserConfig.followup-port-binding.patch",
     "bin/oracle-compat/0.18.0/browserConfig.copy-profile-windows.patch",
+    "bin/oracle-compat/0.18.0/chromeLifecycle.disable-session-crash-bubble.patch",
     "bin/chatgpt_oracle_state.py",
     "bin/chatgpt_oracle_profiles.py",
     "bin/chatgpt_oracle_dispatch.py",

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.9",
+  "version": "1.20.10",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",
@@ -28,6 +28,7 @@
     "bin/devspace-compat/1.0.8/artifact-audit-readonly.patch",
     "bin/devspace-compat/1.0.8/workspace-write-and-read-bridge.patch",
     "bin/devspace-compat/1.0.8/tool-read-receipts.patch",
+    "bin/devspace-compat/1.0.8/receipt-structured-output.patch",
     "bin/devspace-compat/1.0.8/widget-domain.patch",
     "bin/devspace-compat/1.0.8/workspaces.patch",
     "bin/chatgpt_oracle_compat.py",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.9",
+  "version": "1.20.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.9",
+      "version": "1.20.10",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.9",
+  "version": "1.20.10",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/tests/test_chatgpt_chrome_local_network.py
+++ b/tests/test_chatgpt_chrome_local_network.py
@@ -131,3 +131,36 @@ def test_profile_fallback_refuses_a_live_seed_profile(monkeypatch, tmp_path: Pat
     else:
         raise AssertionError("a live Oracle seed profile must fail closed")
     assert (profile / "Default" / "Preferences").read_bytes() == before
+
+
+def test_explicit_policy_block_overrides_seed_profile_allow(monkeypatch, tmp_path: Path) -> None:
+    profile = _profile(tmp_path)
+    module.enable_profile_permission(profile_dir=profile, codex_home=tmp_path / "codex-home")
+    monkeypatch.setattr(
+        module,
+        "policy_status",
+        lambda: {"enabled": False, "effective_policy": "blocked", "supported": True},
+    )
+    status = module.durable_status(profile_dir=profile)
+    assert status["enabled"] is False
+    assert status["mode"] == "blocked-by-chrome-policy"
+    assert status["oracle_profile"]["local_network"] is True
+    assert status["oracle_profile"]["loopback_network"] is True
+
+
+def test_permission_denial_does_not_bypass_explicit_policy_block(monkeypatch, tmp_path: Path) -> None:
+    profile = _profile(tmp_path)
+    before = (profile / "Default" / "Preferences").read_bytes()
+    monkeypatch.setattr(module, "enable_policy", lambda **_kwargs: (_ for _ in ()).throw(PermissionError()))
+    monkeypatch.setattr(
+        module,
+        "policy_status",
+        lambda: {"enabled": False, "effective_policy": "blocked", "supported": True},
+    )
+    try:
+        module.enable_durable_permission(profile_dir=profile, codex_home=tmp_path / "codex-home")
+    except RuntimeError as exc:
+        assert str(exc) == "CHATGPT_LOCAL_NETWORK_POLICY_BLOCKED"
+    else:
+        raise AssertionError("an explicit Chrome policy block must fail closed")
+    assert (profile / "Default" / "Preferences").read_bytes() == before

--- a/tests/test_chatgpt_chrome_local_network.py
+++ b/tests/test_chatgpt_chrome_local_network.py
@@ -90,7 +90,12 @@ def test_profile_fallback_persists_both_split_permissions_and_preserves_unrelate
     status = module.browser_profile_network_status(profile)
     assert status["local_network"] is True
     assert status["loopback_network"] is True
+    assert status["exit_type"] == "Normal"
+    assert status["exited_cleanly"] is True
+    assert status["crash_restore_ready"] is True
     preferences = json.loads((profile / "Default" / "Preferences").read_text(encoding="utf-8"))
+    assert preferences["profile"]["exit_type"] == "Normal"
+    assert preferences["profile"]["exited_cleanly"] is True
     exceptions = preferences["profile"]["content_settings"]["exceptions"]
     assert exceptions["notifications"]["https://example.com:443,*"]["setting"] == 2
     assert exceptions["local_network"]["https://chatgpt.com:443,*"]["setting"] == 1
@@ -98,6 +103,17 @@ def test_profile_fallback_persists_both_split_permissions_and_preserves_unrelate
     receipt = json.loads(Path(result["receipt"]).read_text(encoding="utf-8"))
     assert Path(receipt["backup_path"]).is_file()
     assert receipt["before_sha256"] != receipt["after_sha256"]
+    assert receipt["crash_restore_ready"] is True
+
+
+def test_profile_fallback_is_idempotent_after_network_and_clean_exit_are_durable(
+    tmp_path: Path,
+) -> None:
+    profile = _profile(tmp_path)
+    module.enable_profile_permission(profile_dir=profile, codex_home=tmp_path / "codex-home")
+    result = module.enable_profile_permission(profile_dir=profile, codex_home=tmp_path / "codex-home")
+    assert result["changed"] is False
+    assert result["crash_restore_ready"] is True
 
 
 def test_permission_denial_uses_bounded_seed_profile_fallback(monkeypatch, tmp_path: Path, capsys) -> None:
@@ -118,6 +134,27 @@ def test_permission_denial_uses_bounded_seed_profile_fallback(monkeypatch, tmp_p
     output = capsys.readouterr().out
     assert '"mode": "oracle-seed-profile"' in output
     assert module.browser_profile_loopback_allowed(profile) is True
+
+
+def test_policy_success_still_normalizes_only_the_oracle_seed_profile(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    profile = _profile(tmp_path)
+    monkeypatch.setattr(
+        module,
+        "enable_policy",
+        lambda **_kwargs: {"enabled": True, "changed": False, "receipt": "policy-receipt.json"},
+    )
+    monkeypatch.setattr(
+        module,
+        "policy_status",
+        lambda: {"enabled": True, "effective_policy": "allowed", "supported": True},
+    )
+    result = module.enable_durable_permission(profile_dir=profile, codex_home=tmp_path / "codex-home")
+    status = module.browser_profile_network_status(profile)
+    assert result["enabled"] is True
+    assert result["policy_receipt"] == "policy-receipt.json"
+    assert status["crash_restore_ready"] is True
 
 
 def test_profile_fallback_refuses_a_live_seed_profile(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_chatgpt_chrome_local_network.py
+++ b/tests/test_chatgpt_chrome_local_network.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from pathlib import Path
 
 
@@ -56,12 +57,77 @@ def test_split_local_policy_cannot_authorize_loopback(monkeypatch) -> None:
     assert status["effective_policy"] == "unset"
 
 
-def test_permission_denial_returns_bounded_manual_fallback(monkeypatch, capsys) -> None:
+def _profile(tmp_path: Path) -> Path:
+    profile = tmp_path / "oracle-profile"
+    preferences = profile / "Default" / "Preferences"
+    preferences.parent.mkdir(parents=True)
+    preferences.write_text(
+        json.dumps(
+            {
+                "profile": {
+                    "content_settings": {
+                        "exceptions": {
+                            "notifications": {"https://example.com:443,*": {"setting": 2}},
+                            "local_network": {},
+                            "loopback_network": {},
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    return profile
+
+
+def test_profile_fallback_persists_both_split_permissions_and_preserves_unrelated_settings(
+    tmp_path: Path,
+) -> None:
+    profile = _profile(tmp_path)
+    result = module.enable_profile_permission(profile_dir=profile, codex_home=tmp_path / "codex-home")
+    assert result["enabled"] is True
+    assert result["mode"] == "oracle-seed-profile"
+    status = module.browser_profile_network_status(profile)
+    assert status["local_network"] is True
+    assert status["loopback_network"] is True
+    preferences = json.loads((profile / "Default" / "Preferences").read_text(encoding="utf-8"))
+    exceptions = preferences["profile"]["content_settings"]["exceptions"]
+    assert exceptions["notifications"]["https://example.com:443,*"]["setting"] == 2
+    assert exceptions["local_network"]["https://chatgpt.com:443,*"]["setting"] == 1
+    assert exceptions["loopback_network"]["https://chatgpt.com:443,*"]["setting"] == 1
+    receipt = json.loads(Path(result["receipt"]).read_text(encoding="utf-8"))
+    assert Path(receipt["backup_path"]).is_file()
+    assert receipt["before_sha256"] != receipt["after_sha256"]
+
+
+def test_permission_denial_uses_bounded_seed_profile_fallback(monkeypatch, tmp_path: Path, capsys) -> None:
     def denied(**_kwargs):
         raise PermissionError("denied")
 
+    profile = _profile(tmp_path)
     monkeypatch.setattr(module, "enable_policy", denied)
-    assert module.main(["enable"]) == 2
+    assert module.main(
+        [
+            "enable",
+            "--profile-dir",
+            str(profile),
+            "--codex-home",
+            str(tmp_path / "codex-home"),
+        ]
+    ) == 0
     output = capsys.readouterr().out
-    assert "CHROME_POLICY_WRITE_DENIED" in output
-    assert "dedicated Oracle browser profile" in output
+    assert '"mode": "oracle-seed-profile"' in output
+    assert module.browser_profile_loopback_allowed(profile) is True
+
+
+def test_profile_fallback_refuses_a_live_seed_profile(monkeypatch, tmp_path: Path) -> None:
+    profile = _profile(tmp_path)
+    before = (profile / "Default" / "Preferences").read_bytes()
+    monkeypatch.setattr(module, "_profile_in_use", lambda _profile: True)
+    try:
+        module.enable_profile_permission(profile_dir=profile, codex_home=tmp_path / "codex-home")
+    except RuntimeError as exc:
+        assert str(exc) == "ORACLE_CHROME_PROFILE_IN_USE"
+    else:
+        raise AssertionError("a live Oracle seed profile must fail closed")
+    assert (profile / "Default" / "Preferences").read_bytes() == before

--- a/tests/test_chatgpt_devspace_compat.py
+++ b/tests/test_chatgpt_devspace_compat.py
@@ -722,10 +722,11 @@ def test_108_workspace_bridge_patch_preserves_write_tools_and_adds_bounded_read_
     assert compat.PATCHES["dist/server.js"] == {
         "patch": "workspace-write-and-read-bridge.patch",
         "pristine": "bf3db902241b631d7c6fbaf12385243b46b4f2d4bb776b6ea7ca6c9d429a3263",
-        "patched": "efd7a769601aae31b1f4d8a2e22767bba6c587b56488100dea85ad2c17f02985",
+        "patched": "d35a4cd7b5678b4fa16c05ba8ca1d8cc0937d9f4c2bdd48e454a46ffa28da598",
         "upgrades": {
             "659cb1011cd7ab7fb75debb21a44f030001797c2160a42beac527354be93e497": "tool-read-receipts.patch",
             "1370524581b75d6b91d281dea52e427004a5ac71c19ac8090d66fe521748760c": "widget-domain.patch",
+            "efd7a769601aae31b1f4d8a2e22767bba6c587b56488100dea85ad2c17f02985": "receipt-structured-output.patch",
         },
     }
     assert 'delete: "delete_file"' in patch
@@ -885,6 +886,49 @@ def test_108_artifact_write_is_bound_to_audit_readonly_scope() -> None:
     assert "beforeMutation(input, _meta);" in artifact_patch
     assert 'assertAuditReadonly(_meta, "download_artifact")' in server_patch
     assert server_patch.index('assertAuditReadonly(_meta, "download_artifact")') < server_patch.index("return server;")
+
+
+def test_108_audit_receipt_ids_are_exposed_in_structured_tool_outputs() -> None:
+    compat = load_compat()
+    patch = (
+        MODULE_PATH.parent
+        / "devspace-compat"
+        / compat.SUPPORTED_VERSION
+        / "receipt-structured-output.patch"
+    ).read_text(encoding="utf-8")
+
+    assert patch.count("auditReceiptId: z.string().uuid().optional()") == 3
+    assert patch.count("auditReceiptId: auditReceiptResult.receiptId") == 3
+    assert 'structuredContent: { ...result, ...(auditReceiptResult ? { auditReceiptId:' in patch
+    assert compat.PATCHES["dist/server.js"]["upgrades"][
+        "efd7a769601aae31b1f4d8a2e22767bba6c587b56488100dea85ad2c17f02985"
+    ] == "receipt-structured-output.patch"
+
+
+def test_108_structured_receipt_upgrade_is_hash_gated(tmp_path: Path) -> None:
+    compat = load_compat()
+    try:
+        source_root = compat.resolve_package_roots()[0]
+    except compat.DevSpaceCompatError as exc:
+        pytest.skip(f"DevSpace {compat.SUPPORTED_VERSION} package unavailable: {exc.code}")
+    source = source_root / "dist" / "server.js"
+    prior_hash = "efd7a769601aae31b1f4d8a2e22767bba6c587b56488100dea85ad2c17f02985"
+    if compat.sha256_file(source) != prior_hash:
+        pytest.skip("installed DevSpace server is not the prior structured-receipt payload")
+    package = tmp_path / "devspace"
+    (package / "dist").mkdir(parents=True)
+    shutil.copy2(source, package / "dist" / "server.js")
+    compat._apply_patch(
+        package,
+        MODULE_PATH.parent
+        / "devspace-compat"
+        / compat.SUPPORTED_VERSION
+        / "receipt-structured-output.patch",
+    )
+    server = (package / "dist" / "server.js").read_text(encoding="utf-8")
+    assert compat.sha256_file(package / "dist" / "server.js") == compat.PATCHES["dist/server.js"]["patched"]
+    assert server.count("auditReceiptId: z.string().uuid().optional()") == 3
+    assert server.count("auditReceiptId: auditReceiptResult.receiptId") == 3
 
 
 def test_108_tool_read_receipt_upgrade_is_immutable_and_records_only_successes(

--- a/tests/test_chatgpt_oracle_compat.py
+++ b/tests/test_chatgpt_oracle_compat.py
@@ -397,6 +397,9 @@ def test_published_0180_default_contract_applies_every_current_patch(tmp_path: P
         assert compat.sha256_file(target) == contract["patched"]
         syntax = subprocess.run([node, "--check", str(target)], capture_output=True, text=True, check=False)
         assert syntax.returncode == 0, f"{relative}: {syntax.stderr}"
+    chrome_lifecycle = package / "dist/src/browser/chromeLifecycle.js"
+    chrome_lifecycle_text = chrome_lifecycle.read_text(encoding="utf-8")
+    assert chrome_lifecycle_text.count('"--disable-session-crashed-bubble"') == 1
 
 
 def test_published_0171_patch_requires_extra_high_and_pro_selection_proof(tmp_path: Path) -> None:
@@ -420,7 +423,7 @@ def test_published_0171_patch_requires_extra_high_and_pro_selection_proof(tmp_pa
 
     result = compat.ensure_oracle_compatibility("oracle 0.17.1", package_root=package, backup_root=backup)
     touched = set(result["changed"]) | set(result["already_patched"])
-    assert set(compat.PATCHES) <= touched
+    assert set(compat.LKG_PATCHES) <= touched
     node = shutil.which("node")
     assert node is not None, "Node.js is required to validate the patched Oracle source"
     followup = package / "dist/src/cli/followup.js"

--- a/tests/test_global_gpt_browser_policy.py
+++ b/tests/test_global_gpt_browser_policy.py
@@ -159,6 +159,7 @@ def test_install_inventory_contains_new_active_runtime_and_keeps_legacy_recovery
         "bin/oracle-compat/0.18.0/oracle-cli.followup-port-and-timeout.patch",
         "bin/oracle-compat/0.18.0/browserConfig.followup-port-binding.patch",
         "bin/oracle-compat/0.18.0/browserConfig.copy-profile-windows.patch",
+        "bin/oracle-compat/0.18.0/chromeLifecycle.disable-session-crash-bubble.patch",
         "upstream-runtime-policy.json",
         "scripts/check_upstream_runtime_policy.py",
         "skills/chatgpt-workspace-setup/SKILL.md",

--- a/tests/test_global_gpt_browser_policy.py
+++ b/tests/test_global_gpt_browser_policy.py
@@ -147,6 +147,7 @@ def test_install_inventory_contains_new_active_runtime_and_keeps_legacy_recovery
         "bin/devspace-compat/1.0.8/artifact-audit-readonly.patch",
         "bin/devspace-compat/1.0.8/workspace-write-and-read-bridge.patch",
         "bin/devspace-compat/1.0.8/tool-read-receipts.patch",
+        "bin/devspace-compat/1.0.8/receipt-structured-output.patch",
         "bin/devspace-compat/1.0.8/widget-domain.patch",
         "bin/devspace-compat/1.0.8/workspaces.patch",
         "bin/devspace-compat/1.0.7/tool-read-receipts.patch",


### PR DESCRIPTION
## Summary
- persist exact chatgpt.com local and loopback network grants in the Oracle seed profile when Windows policy ACLs are read-only
- expose DevSpace audit receipt IDs in structured outputs for open_workspace, read, and read_chunk
- add backup, SHA receipt, live-profile fail-closed behavior, docs, and regression coverage

## Verification
- 1366 full contract tests passed, 23 skipped
- 61 focused contract tests passed
- v3 contract suite PASS
- portability, docs, upstream policy, maintainer contract, fast gate PASS
- focused v1.20.10 tests: 10 passed

No Pro prompt was submitted and no user project files were modified.