### PR TITLE
fix: bind Oracle liveness to exact run identity

### DIFF
--- a/bin/chatgpt_oracle_run.py
+++ b/bin/chatgpt_oracle_run.py
@@ -737,6 +737,28 @@ def process_is_alive(pid: int) -> bool:
     return True
 
 
+_RAW_PROCESS_IS_ALIVE = process_is_alive
+
+
+def run_owned_process_is_alive(
+    run_dir: Path,
+    state: dict[str, Any],
+    pid: int,
+    *,
+    process_alive: Callable[[int], bool] | None = None,
+) -> bool:
+    """Bind a live PID to this exact run before treating it as active."""
+    probe = process_alive or process_is_alive
+    if probe is not _RAW_PROCESS_IS_ALIVE:
+        return bool(probe(pid))
+    return STATE.exact_run_process_may_be_alive(
+        run_dir,
+        state,
+        pid,
+        process_probe=probe,
+    )
+
+
 def historical_session_authority(run_dir: Path, state: dict[str, Any]) -> str:
     """Recover the strongest exact-session authority from durable observer logs."""
     current = str(state.get("session_authority") or "submitted_unknown")
@@ -1007,7 +1029,10 @@ def seal_saved_output_browser_identity(
             "terminal Oracle browser identity is not exactly bound to the saved-output settlement",
         )
     checked_pids = tuple(sorted(set(run_owned_process_ids(directory, state)) | {chrome_pid, parent_pid}))
-    active_pids = [pid for pid in checked_pids if process_alive(pid)]
+    active_pids = [
+        pid for pid in checked_pids
+        if run_owned_process_is_alive(directory, state, pid, process_alive=process_alive)
+    ]
     if active_pids:
         raise OracleRunError(
             "SAVED_IDENTITY_PROCESS_ACTIVE",
@@ -1298,7 +1323,10 @@ def settle_saved_terminal_output(
             "Oracle terminal metadata is not exactly bound to this follow-up conversation and browser profile",
         )
     checked_pids = tuple(sorted(set(run_owned_process_ids(directory, state)) | set(runtime_pids)))
-    active_pids = [pid for pid in checked_pids if process_alive(pid)]
+    active_pids = [
+        pid for pid in checked_pids
+        if run_owned_process_is_alive(directory, state, pid, process_alive=process_alive)
+    ]
     if active_pids:
         raise OracleRunError(
             "SAVED_OUTPUT_PROCESS_ACTIVE",
@@ -2682,7 +2710,10 @@ def settle_user_confirmed_delivery_timeout_execution(
             "EXECUTION_ENDED_TIMEOUT_EVIDENCE_REQUIRED",
             "exact run does not retain provider delivery-timeout evidence",
         )
-    active_pids = [pid for pid in run_owned_process_ids(directory, state) if process_alive(pid)]
+    active_pids = [
+        pid for pid in run_owned_process_ids(directory, state)
+        if run_owned_process_is_alive(directory, state, pid, process_alive=process_alive)
+    ]
     if active_pids:
         raise OracleRunError(
             "EXECUTION_ENDED_PROCESS_ACTIVE",
@@ -2778,7 +2809,10 @@ def settle_user_confirmed_no_submission(
     state_path = directory / "state.json"
     stored = STATE.load_state(state_path)
     require_current_task_owns_run(stored)
-    active_pids = [pid for pid in run_owned_process_ids(directory, stored) if process_is_alive(pid)]
+    active_pids = [
+        pid for pid in run_owned_process_ids(directory, stored)
+        if run_owned_process_is_alive(directory, stored, pid)
+    ]
     if active_pids:
         raise OracleRunError(
             "NO_SUBMISSION_PROCESS_ACTIVE",
@@ -2895,7 +2929,10 @@ def settle_recursive_self_observation_fresh_run(
             "RECURSIVE_SELF_OBSERVATION_EVIDENCE_REQUIRED",
             "exact terminal output does not satisfy the bounded self-observation signature",
         )
-    active_pids = [pid for pid in run_owned_process_ids(directory, state) if process_is_alive(pid)]
+    active_pids = [
+        pid for pid in run_owned_process_ids(directory, state)
+        if run_owned_process_is_alive(directory, state, pid)
+    ]
     if active_pids:
         raise OracleRunError(
             "RECURSIVE_SELF_OBSERVATION_PROCESS_ACTIVE",
@@ -3095,7 +3132,10 @@ def settle_terminal_devspace_nonexecution_fresh_run(
             "TERMINAL_DEVSPACE_NONEXECUTION_EVIDENCE_REQUIRED",
             "terminal output lacks bounded DevSpace failure and explicit nonexecution proof",
         )
-    active_pids = [pid for pid in run_owned_process_ids(directory, state) if process_alive(pid)]
+    active_pids = [
+        pid for pid in run_owned_process_ids(directory, state)
+        if run_owned_process_is_alive(directory, state, pid, process_alive=process_alive)
+    ]
     if active_pids:
         raise OracleRunError(
             "TERMINAL_DEVSPACE_NONEXECUTION_PROCESS_ACTIVE",
@@ -3307,7 +3347,10 @@ def settle_terminal_devspace_read_route_refresh_fresh_run(
             "DEVSPACE_READ_ROUTE_REFRESH_EVIDENCE_REQUIRED",
             "terminal output does not prove the exact read-only read_chunk exposure failure",
         )
-    active_pids = [pid for pid in run_owned_process_ids(directory, state) if process_alive(pid)]
+    active_pids = [
+        pid for pid in run_owned_process_ids(directory, state)
+        if run_owned_process_is_alive(directory, state, pid, process_alive=process_alive)
+    ]
     if active_pids:
         raise OracleRunError(
             "DEVSPACE_READ_ROUTE_REFRESH_PROCESS_ACTIVE",

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -138,6 +138,127 @@ def _process_may_be_alive(pid: int) -> bool:
     except (PermissionError, OSError):
         return True
     return True
+
+
+def _windows_process_snapshot(pid: int) -> dict[str, Any] | None:
+    """Return one bounded Windows process identity, or None after exact exit.
+
+    The PID alone is not an identity: Windows may reuse it after Oracle exits.
+    Keep this query fixed and pass only the integer PID as data.
+    """
+    script = r'''
+$targetPid = [int]$args[0]
+$p = Get-CimInstance Win32_Process -Filter "ProcessId=$targetPid" -ErrorAction Stop
+if ($null -eq $p) { exit 3 }
+[pscustomobject]@{
+  ProcessId = [int]$p.ProcessId
+  ParentProcessId = [int]$p.ParentProcessId
+  CreationDate = [string]$p.CreationDate
+  Name = [string]$p.Name
+  ExecutablePath = [string]$p.ExecutablePath
+  CommandLine = [string]$p.CommandLine
+} | ConvertTo-Json -Compress -Depth 3
+'''
+    completed = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            script,
+            str(int(pid)),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=15,
+        creationflags=CREATE_NO_WINDOW,
+    )
+    if completed.returncode == 3:
+        return None
+    if completed.returncode != 0:
+        raise OSError(completed.stderr.strip() or "Windows process identity query failed")
+    raw = completed.stdout.strip()
+    if not raw:
+        return None
+    value = json.loads(raw)
+    if not isinstance(value, dict) or int(value.get("ProcessId") or 0) != int(pid):
+        raise OSError("Windows process identity query returned an ambiguous record")
+    return value
+
+
+def _normalized_process_identity_text(value: object) -> str:
+    return re.sub(r"/+", "/", str(value or "").replace("\\", "/").casefold())
+
+
+def exact_run_process_may_be_alive(
+    run_dir: Path,
+    state: dict[str, Any],
+    pid: int,
+    *,
+    process_probe: Any = None,
+    windows_snapshot: Any = _windows_process_snapshot,
+    platform_name: str | None = None,
+) -> bool:
+    """Fail closed for a live exact-run process, but reject a reused PID.
+
+    Modern Oracle controller and recovery commands contain the exact slug;
+    Oracle Chrome contains the exact run-local browser profile.  A live PID
+    whose readable command line contains neither is a different process and
+    must not keep an old run locked.  Unreadable or contradictory evidence is
+    deliberately still treated as active.
+    """
+    probe = process_probe or _process_may_be_alive
+    if not probe(pid):
+        return False
+    if (platform_name or os.name) != "nt":
+        return True
+    try:
+        snapshot = windows_snapshot(pid)
+    except (OSError, ValueError, TypeError, json.JSONDecodeError, subprocess.SubprocessError):
+        return True
+    if snapshot is None:
+        return bool(probe(pid))
+
+    command_line = _normalized_process_identity_text(snapshot.get("CommandLine"))
+    oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
+    artifacts = state.get("artifacts") if isinstance(state.get("artifacts"), dict) else {}
+    slug = str(oracle.get("slug") or "").strip().casefold()
+    markers = {
+        _normalized_process_identity_text(run_dir.resolve()),
+        _normalized_process_identity_text(artifacts.get("browser_temp")),
+        _normalized_process_identity_text(artifacts.get("output")),
+        _normalized_process_identity_text(Path.home() / ".oracle" / "sessions" / slug)
+        if slug
+        else "",
+        slug,
+    }
+    markers.discard("")
+    if command_line and any(marker in command_line for marker in markers):
+        return True
+    if command_line:
+        return False
+
+    image_name = Path(
+        str(snapshot.get("ExecutablePath") or snapshot.get("Name") or "")
+    ).name.casefold()
+    oracle_runtime_images = {
+        "chrome.exe",
+        "cmd.exe",
+        "node.exe",
+        "npx.exe",
+        "npx.cmd",
+        "powershell.exe",
+        "pwsh.exe",
+        "python.exe",
+        "pythonw.exe",
+    }
+    if image_name and image_name not in oracle_runtime_images:
+        return False
+    return True
 LEGACY_V1184_FOLLOWUP_MANAGED_HASHES = {
     "bin/chatgpt_oracle_compat.py": "f41d3fb50b911f882a8e23e71cb02a5e9e81ee5ebe16f548ee48e7f815da0ee1",
     "bin/chatgpt_oracle_run.py": "957cd75a52cbe9258a994e66b557987cda4617de561307acaff5632a66fdfdf7",
@@ -3958,7 +4079,7 @@ def _followup_no_submission_evidence(
             or not isinstance(observer_pid, int)
             or isinstance(observer_pid, bool)
             or observer_pid <= 0
-            or _process_may_be_alive(observer_pid)
+            or exact_run_process_may_be_alive(state_path.parent, state, observer_pid)
             or error.get("category") != "browser-automation"
         ):
             return None

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@
 - DevSpace 1.0.8의 `open_workspace`, `read`, `read_chunk`가 서버 생성 Audit receipt ID를
   텍스트뿐 아니라 각 도구의 `structuredContent`와 output schema에도 노출해, ChatGPT 앱
   렌더러가 보조 text block을 생략하더라도 final canary challenge-response를 완결합니다.
+- Oracle 실행 종료 뒤 Windows가 PID를 재사용하더라도 PID 존재만으로 과거 실행을
+  살아 있다고 오판하지 않습니다. 현재 프로세스의 exact slug·run 디렉터리·격리
+  브라우저 프로필 결속을 확인하며, 읽을 수 없거나 모호한 신원은 계속 fail-closed 합니다.
 
 ## 1.20.9 - Preserve registered apps across DevSpace updates
 

--- a/tests/test_chatgpt_oracle_state.py
+++ b/tests/test_chatgpt_oracle_state.py
@@ -26,6 +26,113 @@ def load_state():
     return module
 
 
+def _run_process_state(run_dir: Path) -> dict[str, object]:
+    return {
+        "oracle": {"slug": "oracle-demo-abc123"},
+        "artifacts": {
+            "browser_temp": str(run_dir / "browser-temp"),
+            "output": str(run_dir / "output.md"),
+        },
+    }
+
+
+def test_exact_run_process_identity_rejects_reused_unrelated_pid(tmp_path: Path) -> None:
+    state = load_state()
+    run_dir = tmp_path / "runs" / "abc123"
+    snapshot = {
+        "ProcessId": 4242,
+        "Name": "csrss.exe",
+        "ExecutablePath": r"C:\Windows\System32\csrss.exe",
+        "CommandLine": "",
+    }
+
+    assert state.exact_run_process_may_be_alive(
+        run_dir,
+        _run_process_state(run_dir),
+        4242,
+        process_probe=lambda _pid: True,
+        windows_snapshot=lambda _pid: snapshot,
+        platform_name="nt",
+    ) is False
+
+
+@pytest.mark.parametrize(
+    "command_line",
+    [
+        r'node.exe oracle --slug oracle-demo-abc123 --write-output C:\result.md',
+        r'chrome.exe --user-data-dir="{browser_temp}" --remote-debugging-port=61234',
+    ],
+)
+def test_exact_run_process_identity_keeps_bound_controller_or_chrome_active(
+    tmp_path: Path,
+    command_line: str,
+) -> None:
+    state = load_state()
+    run_dir = tmp_path / "runs" / "abc123"
+    rendered = command_line.format(browser_temp=run_dir / "browser-temp")
+
+    assert state.exact_run_process_may_be_alive(
+        run_dir,
+        _run_process_state(run_dir),
+        4242,
+        process_probe=lambda _pid: True,
+        windows_snapshot=lambda _pid: {
+            "ProcessId": 4242,
+            "Name": "node.exe" if rendered.startswith("node") else "chrome.exe",
+            "CommandLine": rendered,
+        },
+        platform_name="nt",
+    ) is True
+
+
+def test_exact_run_process_identity_rejects_live_foreign_runtime(tmp_path: Path) -> None:
+    state = load_state()
+    run_dir = tmp_path / "runs" / "abc123"
+
+    assert state.exact_run_process_may_be_alive(
+        run_dir,
+        _run_process_state(run_dir),
+        4242,
+        process_probe=lambda _pid: True,
+        windows_snapshot=lambda _pid: {
+            "ProcessId": 4242,
+            "Name": "node.exe",
+            "CommandLine": "node.exe unrelated-server.mjs --port 8080",
+        },
+        platform_name="nt",
+    ) is False
+
+
+def test_exact_run_process_identity_keeps_ambiguous_live_pid_blocking(tmp_path: Path) -> None:
+    state = load_state()
+    run_dir = tmp_path / "runs" / "abc123"
+
+    def denied(_pid: int):
+        raise OSError("access denied")
+
+    assert state.exact_run_process_may_be_alive(
+        run_dir,
+        _run_process_state(run_dir),
+        4242,
+        process_probe=lambda _pid: True,
+        windows_snapshot=denied,
+        platform_name="nt",
+    ) is True
+
+    assert state.exact_run_process_may_be_alive(
+        run_dir,
+        _run_process_state(run_dir),
+        4242,
+        process_probe=lambda _pid: True,
+        windows_snapshot=lambda _pid: {
+            "ProcessId": 4242,
+            "Name": "node.exe",
+            "CommandLine": "",
+        },
+        platform_name="nt",
+    ) is True
+
+
 @pytest.mark.parametrize("winerror", [5, 32])
 def test_write_json_atomic_retries_bounded_windows_replace_race(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- prevent Windows PID reuse from keeping an ended Oracle run locked
- bind live-process settlement gates to the exact slug, run directory, output, or isolated browser profile
- keep unreadable or ambiguous process identity fail-closed
- retain injected process probes for deterministic settlement tests

## Verification
- 360 passed, 9 skipped: Oracle state/run/follow-up focused suites
- 5 new exact PID identity tests
- fast gate PASS in 32.67s
- docs contract PASS
- upstream runtime policy in-sync
- git diff --check clean

This is the final lifecycle hardening before the unpublished v1.20.10 tag; no project, account, browser, or run state was modified.