### PR TITLE
fix: recover task-bound DevSpace prompt timeouts

### DIFF
--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -3509,17 +3509,17 @@ def _standalone_pro_no_submission_evidence(
     }
 
 
-def bounded_task_owned_prompt_timeout_harvest_evidence(
+def _bounded_task_owned_prompt_timeout_evidence(
     state_path: Path,
+    *,
+    allow_recovery_evidence: bool,
 ) -> dict[str, Any] | None:
-    """Authorize one prompt-free harvest when browser binding never completed.
+    """Validate the exact zero-turn timeout tuple before/after its one harvest.
 
-    A task-bound run normally needs the immutable browser identity receipt before
-    any recovery.  Oracle can fail while committing the prompt, however, before
-    a conversation URL exists and therefore before that receipt can be sealed.
-    This predicate breaks only that evidence deadlock: it validates the exact
-    task/run ownership receipt and Oracle's completed, zero-turn commit probe.
-    It never settles ownership and is used only to permit ``session --harvest``.
+    Before recovery this admits only zero recovery records; after the exact
+    harvest it admits the same direct evidence so the pre-harvest proof can be
+    persisted and revalidated for settlement. Callers choose the phase rather
+    than weakening the public harvest predicate.
     """
     followup = _followup_no_submission_evidence(state_path, require_recovery_evidence=False)
     if (
@@ -3546,7 +3546,14 @@ def bounded_task_owned_prompt_timeout_harvest_evidence(
     # The ordinary DevSpace predicate already verifies the exact state/log/mission
     # tuple. It needs recovery evidence for settlement, but the separate zero-turn
     # Oracle ledger proof below permits one exact harvest to create that evidence.
-    if direct_evidence is not None and direct_evidence.get("recovery_evidence") == []:
+    direct_recovery_evidence = (
+        direct_evidence.get("recovery_evidence") if direct_evidence is not None else None
+    )
+    if (
+        direct_evidence is not None
+        and isinstance(direct_recovery_evidence, list)
+        and (allow_recovery_evidence or direct_recovery_evidence == [])
+    ):
         evidence = direct_evidence
     else:
         evidence = _standalone_pro_no_submission_evidence(
@@ -3555,7 +3562,14 @@ def bounded_task_owned_prompt_timeout_harvest_evidence(
         )
     if (
         evidence is None
-        or evidence.get("recovery_evidence") != []
+        or (
+            evidence.get("recovery_evidence") != []
+            and not (
+                allow_recovery_evidence
+                and evidence.get("settlement_eligibility") == "oracle-direct-devspace/v1"
+                and bool(evidence.get("recovery_evidence"))
+            )
+        )
     ):
         return None
     if evidence.get("settlement_eligibility") == "oracle-standalone-qualified-pro/v1":
@@ -3693,7 +3707,17 @@ def bounded_task_owned_prompt_timeout_harvest_evidence(
     ):
         return None
     return {
-        "schema": "codex.chatgpt.oracle-bounded-prompt-timeout-harvest/v1",
+        # Retain the ordinary direct-DevSpace settlement fields so the bridge
+        # remains a refinement of that exact predicate, not a parallel weaker
+        # eligibility class.  Its schema is deliberately not named ``schema``:
+        # this evidence is embedded in a user-settlement artifact with its own
+        # outer schema.
+        **{
+            key: value
+            for key, value in evidence.items()
+            if not key.startswith("_") and key != "schema"
+        },
+        "evidence_schema": "codex.chatgpt.oracle-bounded-prompt-timeout-harvest/v1",
         "source_thread_id": source_thread_id,
         "run_id": state.get("run_id"),
         "slug": locator,
@@ -3704,11 +3728,59 @@ def bounded_task_owned_prompt_timeout_harvest_evidence(
         "expected_cdp_port": cdp_port,
         "browser_profile": str(runtime_profile),
         "browser_target_id": str(runtime.get("chromeTargetId")),
+        "transport": str(state.get("transport") or ""),
+        "profile": {
+            key: profile.get(key)
+            for key in ("model", "model_strategy", "thinking_time", "research")
+        },
+        "profile_sha256": hashlib.sha256(
+            json.dumps(
+                {
+                    key: profile.get(key)
+                    for key in ("model", "model_strategy", "thinking_time", "research")
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest(),
+        "browser_config": {
+            "desired_model": expected_model_label,
+            "model_strategy": profile.get("model_strategy"),
+            "thinking_time": profile.get("thinking_time"),
+        },
+        "browser_config_sha256": hashlib.sha256(
+            json.dumps(
+                {
+                    "desired_model": expected_model_label,
+                    "model_strategy": profile.get("model_strategy"),
+                    "thinking_time": profile.get("thinking_time"),
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest(),
+        "recovery_evidence": evidence.get("recovery_evidence"),
         "prompt_submitted_claim": True,
         "commit_probe_turns": 0,
         "conversation_url_absent": True,
         "output_absent": True,
     }
+
+
+def bounded_task_owned_prompt_timeout_harvest_evidence(
+    state_path: Path,
+) -> dict[str, Any] | None:
+    """Authorize one prompt-free harvest when browser binding never completed.
+
+    A task-bound run normally needs the immutable browser identity receipt before
+    any recovery. Oracle can fail while committing the prompt, however, before
+    a conversation URL exists and therefore before that receipt can be sealed.
+    This predicate never persists, settles, or permits live recovery.
+    """
+    return _bounded_task_owned_prompt_timeout_evidence(
+        state_path,
+        allow_recovery_evidence=False,
+    )
 
 
 def followup_archived_parent_settle_without_harvest_evidence(
@@ -4577,6 +4649,16 @@ def _direct_devspace_no_submission_evidence(
 
 def persist_direct_devspace_prompt_not_observed_recovery(state_path: Path) -> dict[str, Any] | None:
     """Persist a hash-bound exact recovery receipt without releasing ownership."""
+    bounded = persist_bounded_task_owned_prompt_timeout_harvest(state_path)
+    if bounded is not None:
+        return bounded
+    # Once the exact zero-turn bridge has been recorded, settlement must
+    # continue to prove that stronger receipt.  In particular, do not let a
+    # subsequently malformed/tampered bridge silently fall back to the older
+    # generic direct-DevSpace recovery proof.
+    payload = load_state(state_path)
+    if payload.get("bounded_prompt_timeout_harvest") is not None:
+        return None
     evidence = _direct_devspace_no_submission_evidence(
         state_path, require_persisted_recovery=False
     )
@@ -4584,7 +4666,6 @@ def persist_direct_devspace_prompt_not_observed_recovery(state_path: Path) -> di
         return None
     if _direct_devspace_no_submission_evidence(state_path, require_persisted_recovery=True) is not None:
         return evidence
-    payload = load_state(state_path)
     if payload.get("prompt_not_observed_recovery") is not None:
         return None
     receipt_path = state_path.parent / "prompt-not-observed-recovery.json"
@@ -4607,6 +4688,87 @@ def persist_direct_devspace_prompt_not_observed_recovery(state_path: Path) -> di
     )
 
 
+def proven_bounded_task_owned_prompt_timeout_harvest(
+    state_path: Path,
+) -> dict[str, Any] | None:
+    """Revalidate the append-only zero-turn proof recorded by exact harvest."""
+    evidence = _bounded_task_owned_prompt_timeout_evidence(
+        state_path,
+        allow_recovery_evidence=True,
+    )
+    if evidence is None or evidence.get("transport") != "devspace":
+        return None
+    state = load_state(state_path)
+    run_dir = state_path.parent
+    reference = state.get("bounded_prompt_timeout_harvest")
+    receipt_path = run_dir / "bounded-prompt-timeout-harvest.json"
+    if (
+        not isinstance(reference, dict)
+        or reference.get("schema")
+        != "codex.chatgpt.oracle-bounded-prompt-timeout-harvest-reference/v1"
+        or Path(str(reference.get("path") or "")).resolve() != receipt_path.resolve()
+        or receipt_path.is_symlink()
+    ):
+        return None
+    try:
+        raw = receipt_path.read_bytes()
+        if hashlib.sha256(raw).hexdigest() != str(reference.get("sha256") or ""):
+            return None
+        recorded = json.loads(raw.decode("utf-8", errors="strict"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    expected = {
+        "schema": "codex.chatgpt.oracle-bounded-prompt-timeout-harvest/v1",
+        "code": "ORACLE_ZERO_TURN_PROMPT_TIMEOUT_HARVEST",
+        **{key: value for key, value in evidence.items() if not key.startswith("_")},
+    }
+    if recorded != expected:
+        return None
+    return {
+        **evidence,
+        "bounded_prompt_timeout_harvest": {
+            "schema": reference["schema"],
+            "path": str(receipt_path),
+            "sha256": str(reference["sha256"]),
+        },
+    }
+
+
+def persist_bounded_task_owned_prompt_timeout_harvest(
+    state_path: Path,
+) -> dict[str, Any] | None:
+    """Seal the pre-harvest zero-turn proof after its exact harvest completes."""
+    evidence = _bounded_task_owned_prompt_timeout_evidence(
+        state_path,
+        allow_recovery_evidence=True,
+    )
+    if evidence is None or evidence.get("transport") != "devspace":
+        return None
+    if not evidence.get("recovery_evidence"):
+        return None
+    if proven_bounded_task_owned_prompt_timeout_harvest(state_path) is not None:
+        return proven_bounded_task_owned_prompt_timeout_harvest(state_path)
+    payload = load_state(state_path)
+    if payload.get("bounded_prompt_timeout_harvest") is not None:
+        return None
+    receipt_path = state_path.parent / "bounded-prompt-timeout-harvest.json"
+    if receipt_path.exists() or receipt_path.is_symlink():
+        return None
+    recorded = {
+        "schema": "codex.chatgpt.oracle-bounded-prompt-timeout-harvest/v1",
+        "code": "ORACLE_ZERO_TURN_PROMPT_TIMEOUT_HARVEST",
+        **{key: value for key, value in evidence.items() if not key.startswith("_")},
+    }
+    write_json_atomic(receipt_path, recorded)
+    payload["bounded_prompt_timeout_harvest"] = {
+        "schema": "codex.chatgpt.oracle-bounded-prompt-timeout-harvest-reference/v1",
+        "path": str(receipt_path),
+        "sha256": sha256_file(receipt_path),
+    }
+    write_json_atomic(state_path, payload)
+    return proven_bounded_task_owned_prompt_timeout_harvest(state_path)
+
+
 def _user_confirmable_no_submission_evidence(state_path: Path) -> dict[str, Any] | None:
     """Return exact evidence for supported user-adjudicable Oracle runs."""
     # A follow-up session necessarily stores its already-existing parent URL in
@@ -4626,6 +4788,13 @@ def _user_confirmable_no_submission_evidence(state_path: Path) -> dict[str, Any]
     browser_session_absent = _browser_session_absent_no_submission_evidence(state_path)
     if browser_session_absent is not None:
         return browser_session_absent
+    state = load_state(state_path)
+    if state.get("bounded_prompt_timeout_harvest") is not None:
+        # A run that entered the bounded zero-turn harvest path must keep that
+        # stronger append-only proof through settlement. Never fall back to the
+        # generic direct DevSpace predicate if its bound receipt is malformed,
+        # tampered, or no longer matches the Oracle/ownership tuple.
+        return proven_bounded_task_owned_prompt_timeout_harvest(state_path)
     direct_devspace = _direct_devspace_no_submission_evidence(
         state_path, require_persisted_recovery=True
     )
@@ -4723,6 +4892,14 @@ def proven_user_confirmed_no_submission(state_path: Path) -> dict[str, Any] | No
             "source_mission_sha256", "transport_mission_path", "transport_mission_sha256",
             "oracle_version",
         )
+        if current.get("bounded_prompt_timeout_harvest") is not None:
+            required += (
+                "bounded_prompt_timeout_harvest", "source_thread_id",
+                "ownership_receipt_sha256", "oracle_meta_path", "oracle_meta_sha256",
+                "expected_cdp_port", "browser_profile", "browser_target_id",
+                "profile_sha256", "browser_config", "browser_config_sha256",
+                "recovery_evidence", "prompt_submitted_claim", "commit_probe_turns",
+            )
         if current.get("pre_submit_marker") == "oracle-model-option-missing/v1":
             required += (
                 "pre_submit_marker", "desired_model", "oracle_meta_path",
@@ -4850,11 +5027,13 @@ def settle_user_confirmed_no_submission(
             "run lacks the exact pre-submit UI and recovery-binding evidence required for user adjudication",
         )
     recorded = {
+        **{key: value for key, value in evidence.items() if not key.startswith("_")},
+        # The eligibility proof may carry its own schema.  Keep the outer
+        # settlement artifact unambiguous so it can be proven on a later pass.
         "schema": "codex.chatgpt.oracle-user-confirmed-no-submission/v1",
         "code": "ORACLE_USER_CONFIRMED_NO_SUBMISSION",
         "confirmation": USER_CONFIRMED_NO_SUBMISSION,
         "reason": normalized_reason,
-        **{key: value for key, value in evidence.items() if not key.startswith("_")},
     }
     settlement_path = state_path.parent / "user-confirmed-no-submission.json"
     write_json_atomic(settlement_path, recorded)

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -3527,31 +3527,41 @@ def bounded_task_owned_prompt_timeout_harvest_evidence(
         and followup.get("failure_kind") != "archived-parent-unarchive-menu-absent"
     ):
         return followup
-    direct_model_option = _direct_devspace_no_submission_evidence(
+    direct_evidence = _direct_devspace_no_submission_evidence(
         state_path,
         require_persisted_recovery=False,
         require_recovery_evidence=False,
     )
     if (
-        direct_model_option is not None
-        and direct_model_option.get("pre_submit_marker")
+        direct_evidence is not None
+        and direct_evidence.get("pre_submit_marker")
         == "oracle-model-option-missing/v1"
-        and direct_model_option.get("recovery_evidence") == []
+        and direct_evidence.get("recovery_evidence") == []
     ):
         return {
-            **direct_model_option,
+            **direct_evidence,
             "schema": "codex.chatgpt.oracle-bounded-model-option-harvest/v1",
             "_bounded_harvest_kind": "direct-devspace-model-option-missing",
         }
-    evidence = _standalone_pro_no_submission_evidence(
-        state_path,
-        require_recovery_evidence=False,
-    )
+    # The ordinary DevSpace predicate already verifies the exact state/log/mission
+    # tuple. It needs recovery evidence for settlement, but the separate zero-turn
+    # Oracle ledger proof below permits one exact harvest to create that evidence.
+    if direct_evidence is not None and direct_evidence.get("recovery_evidence") == []:
+        evidence = direct_evidence
+    else:
+        evidence = _standalone_pro_no_submission_evidence(
+            state_path,
+            require_recovery_evidence=False,
+        )
     if (
         evidence is None
-        or evidence.get("_pre_submit_failure_kind") != "prompt-not-observed"
         or evidence.get("recovery_evidence") != []
     ):
+        return None
+    if evidence.get("settlement_eligibility") == "oracle-standalone-qualified-pro/v1":
+        if evidence.get("_pre_submit_failure_kind") != "prompt-not-observed":
+            return None
+    elif evidence.get("settlement_eligibility") != "oracle-direct-devspace/v1":
         return None
     state = load_state(state_path)
     run_dir = state_path.parent.resolve()
@@ -3601,6 +3611,11 @@ def bounded_task_owned_prompt_timeout_harvest_evidence(
         options.get("browserConfig") if isinstance(options.get("browserConfig"), dict) else {}
     )
     profile = state.get("profile") if isinstance(state.get("profile"), dict) else {}
+    model_id = str(profile.get("model") or "")
+    expected_model_label = {
+        "gpt-5.6": "GPT-5.6 Sol",
+        "gpt-5.6-sol": "GPT-5.6 Sol",
+    }.get(model_id)
     artifacts = state.get("artifacts") if isinstance(state.get("artifacts"), dict) else {}
     try:
         chrome_pid = int(runtime.get("chromePid"))
@@ -3629,9 +3644,10 @@ def bounded_task_owned_prompt_timeout_harvest_evidence(
         "inConversation",
     )
     if (
-        meta.get("id") != locator
+        expected_model_label is None
+        or meta.get("id") != locator
         or meta.get("status") != "error"
-        or meta.get("model") != "gpt-5.6-sol"
+        or meta.get("model") != model_id
         or meta.get("mode") != "browser"
         or not str(meta.get("completedAt") or "").strip()
         or meta_cwd != Path(str(state.get("project_root") or "")).resolve()
@@ -3651,14 +3667,14 @@ def bounded_task_owned_prompt_timeout_harvest_evidence(
         or not str(profile.get("copy_profile") or "").strip()
         or config_profile != state_profile
         or option_profile != state_profile
-        or config.get("desiredModel") != "GPT-5.6 Sol"
-        or config.get("modelStrategy") != "select"
-        or config.get("thinkingTime") != "heavy"
-        or options.get("model") != "gpt-5.6-sol"
+        or config.get("desiredModel") != expected_model_label
+        or config.get("modelStrategy") != profile.get("model_strategy")
+        or config.get("thinkingTime") != profile.get("thinking_time")
+        or options.get("model") != model_id
         or options.get("slug") != locator
-        or option_browser.get("desiredModel") != "GPT-5.6 Sol"
-        or option_browser.get("modelStrategy") != "select"
-        or option_browser.get("thinkingTime") != "heavy"
+        or option_browser.get("desiredModel") != expected_model_label
+        or option_browser.get("modelStrategy") != profile.get("model_strategy")
+        or option_browser.get("thinkingTime") != profile.get("thinking_time")
         or runtime.get("promptSubmitted") is not True
         or runtime.get("tabUrl") != "https://chatgpt.com/"
         or runtime.get("conversationId") not in {None, ""}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # 기술 변경 기록
 
+## 1.20.11 - Recover exact ordinary DevSpace prompt timeouts
+
+- task-bound 일반 `devspace` 실행이 prompt commit timeout 뒤 browser identity
+  receipt를 만들기 전에 끝나도, 동일한 Oracle zero-turn commit probe와
+  profile-bound browser 메타가 정확히 일치할 때에만 `harvest --dry-run`을
+  허용합니다. live recovery는 계속 receipt 없이 거부되고, harvest 뒤에도
+  hash-bound recovery evidence와 명시적 사용자 no-submission 확인이 있어야만
+  정산·잠금 해제가 가능합니다.
+- 모델 ID `gpt-5.6`은 실제 Oracle browser 메타의 선택 라벨 `GPT-5.6 Sol`에
+  정확히 결속합니다. 다른 모델·전략·thinking time 또는 zero-turn 증거의
+  모순은 계속 fail-closed 합니다.
+
 ## 1.20.10 - Persist Oracle Local network access and expose audit receipts
 
 - Oracle 0.18.0이 띄우는 격리 Chrome에만 `--disable-session-crashed-bubble`을

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@
   허용합니다. live recovery는 계속 receipt 없이 거부되고, harvest 뒤에도
   hash-bound recovery evidence와 명시적 사용자 no-submission 확인이 있어야만
   정산·잠금 해제가 가능합니다.
+- exact harvest는 zero-turn/ownership/mission/profile/browser-config 증거를
+  append-only 영수증으로 봉인합니다. 정산과 이후 잠금 판정은 그 영수증의
+  SHA-256과 현재 불변 증거를 다시 대조하므로, generic recovery 로그만으로
+  정산 권한을 얻을 수 없습니다.
 - 모델 ID `gpt-5.6`은 실제 Oracle browser 메타의 선택 라벨 `GPT-5.6 Sol`에
   정확히 결속합니다. 다른 모델·전략·thinking time 또는 zero-turn 증거의
   모순은 계속 fail-closed 합니다.

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.10",
+  "version": "1.20.11",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.10",
+  "version": "1.20.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.10",
+      "version": "1.20.11",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.10",
+  "version": "1.20.11",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -381,10 +381,17 @@ def write_prompt_timeout_oracle_meta(
         f"@codex Then read the read-only mission file: "
         f"{Path(state['mission']['path']).resolve()}. Read the mission fully."
     )
+    model_id = str(state["profile"]["model"])
+    desired_model = {
+        "gpt-5.6": "GPT-5.6 Sol",
+        "gpt-5.6-sol": "GPT-5.6 Sol",
+    }[model_id]
+    model_strategy = str(state["profile"]["model_strategy"])
+    thinking_time = str(state["profile"]["thinking_time"])
     meta = {
         "id": slug,
         "status": "error",
-        "model": "gpt-5.6-sol",
+        "model": model_id,
         "mode": "browser",
         "cwd": str(Path(state["project_root"]).resolve()),
         "completedAt": "2026-08-23T00:00:00Z",
@@ -416,9 +423,9 @@ def write_prompt_timeout_oracle_meta(
             "config": {
                 "debugPort": expected_port,
                 "copyProfileSource": str(copy_profile),
-                "desiredModel": "GPT-5.6 Sol",
-                "modelStrategy": "select",
-                "thinkingTime": "heavy",
+                "desiredModel": desired_model,
+                "modelStrategy": model_strategy,
+                "thinkingTime": thinking_time,
             },
             "runtime": {
                 "chromePid": 41001,
@@ -434,15 +441,15 @@ def write_prompt_timeout_oracle_meta(
         },
         "options": {
             "prompt": prompt,
-            "model": "gpt-5.6-sol",
+            "model": model_id,
             "slug": slug,
             "writeOutputPath": str(Path(state["artifacts"]["output"]).resolve()),
             "browserConfig": {
                 "debugPort": expected_port,
                 "copyProfileSource": str(copy_profile),
-                "desiredModel": "GPT-5.6 Sol",
-                "modelStrategy": "select",
-                "thinkingTime": "heavy",
+                "desiredModel": desired_model,
+                "modelStrategy": model_strategy,
+                "thinkingTime": thinking_time,
             },
         },
     }
@@ -3335,6 +3342,111 @@ def test_task_bound_readonly_prompt_timeout_can_harvest_without_browser_receipt(
         source_thread_id=owner,
     )
     assert [item["run_id"] for item in owners] == ["c" * 32]
+
+
+def test_task_bound_direct_devspace_prompt_timeout_can_harvest_without_browser_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    owner = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("CODEX_THREAD_ID", owner)
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    initial = execute_run(
+        runner,
+        manifest(
+            tmp_path,
+            run_id="f" * 32,
+            model="gpt-5.6",
+            model_strategy="select",
+            thinking_time="extra-high",
+            research="off",
+            task_outcome_contract="v1",
+        ),
+        run_factory=version_0171_runner,
+        popen_factory=prompt_not_observed_popen,
+    )
+    run_dir = Path(initial["run_dir"])
+    state_path = run_dir / "state.json"
+    write_prompt_timeout_oracle_meta(runner, run_dir, session_root)
+
+    evidence = runner.STATE.bounded_task_owned_prompt_timeout_harvest_evidence(state_path)
+    assert evidence is not None
+    assert evidence["source_thread_id"] == owner
+    assert evidence["commit_probe_turns"] == 0
+    assert evidence["conversation_url_absent"] is True
+    assert runner.STATE.proven_browser_identity_receipt(state_path) is None
+    with pytest.raises(runner.OracleRunError) as live_exc:
+        runner.recover_run(run_dir, action="live", dry_run=True, oracle_command=["oracle"])
+    assert live_exc.value.code == "BROWSER_IDENTITY_RECEIPT_REQUIRED"
+
+    dry_run = runner.recover_run(
+        run_dir,
+        action="harvest",
+        dry_run=True,
+        oracle_command=["oracle"],
+    )
+    assert dry_run["browser_identity_mode"] == "bounded-prompt-timeout-harvest"
+    assert "--harvest" in dry_run["argv"]
+    assert "--prompt" not in dry_run["argv"]
+
+    recovered = runner.recover_run(
+        run_dir,
+        action="harvest",
+        oracle_command=["oracle"],
+        popen_factory=recovery_binding_unavailable_popen,
+    )
+    assert recovered["status"] == "recovery_binding_unavailable"
+    assert runner.STATE.bounded_task_owned_prompt_timeout_harvest_evidence(state_path) is None
+    settled = runner.settle_user_confirmed_no_submission(
+        run_dir,
+        confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
+        reason="user inspected the exact ChatGPT history and confirmed no prompt or response",
+    )
+    proof = runner.STATE.proven_user_confirmed_no_submission(state_path)
+
+    assert settled["safe_for_fresh_run"] is True
+    assert settled["unresolved_owners"] == []
+    assert proof is not None
+    assert proof["settlement_eligibility"] == "oracle-direct-devspace/v1"
+    assert proof["transport"] == "devspace"
+
+
+def test_task_bound_direct_devspace_prompt_timeout_rejects_profile_bound_meta_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("CODEX_THREAD_ID", "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    initial = execute_run(
+        runner,
+        manifest(
+            tmp_path,
+            run_id="g" * 32,
+            model="gpt-5.6",
+            model_strategy="select",
+            thinking_time="extra-high",
+            research="off",
+            task_outcome_contract="v1",
+        ),
+        run_factory=version_0171_runner,
+        popen_factory=prompt_not_observed_popen,
+    )
+    run_dir = Path(initial["run_dir"])
+    meta_path = write_prompt_timeout_oracle_meta(runner, run_dir, session_root)
+    meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    meta["model"] = "gpt-5.6-sol"
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    assert runner.STATE.bounded_task_owned_prompt_timeout_harvest_evidence(
+        run_dir / "state.json"
+    ) is None
+    with pytest.raises(runner.OracleRunError) as exc:
+        runner.recover_run(run_dir, action="harvest", dry_run=True, oracle_command=["oracle"])
+    assert exc.value.code == "BROWSER_IDENTITY_RECEIPT_REQUIRED"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -3399,6 +3399,14 @@ def test_task_bound_direct_devspace_prompt_timeout_can_harvest_without_browser_r
     )
     assert recovered["status"] == "recovery_binding_unavailable"
     assert runner.STATE.bounded_task_owned_prompt_timeout_harvest_evidence(state_path) is None
+    bounded_receipt = run_dir / "bounded-prompt-timeout-harvest.json"
+    assert bounded_receipt.is_file()
+    sealed = runner.STATE.proven_bounded_task_owned_prompt_timeout_harvest(state_path)
+    assert sealed is not None
+    assert sealed["ownership_receipt_sha256"]
+    assert sealed["commit_probe_turns"] == 0
+    assert sealed["profile"]["model"] == "gpt-5.6"
+    assert sealed["browser_config"]["desired_model"] == "GPT-5.6 Sol"
     settled = runner.settle_user_confirmed_no_submission(
         run_dir,
         confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
@@ -3411,6 +3419,65 @@ def test_task_bound_direct_devspace_prompt_timeout_can_harvest_without_browser_r
     assert proof is not None
     assert proof["settlement_eligibility"] == "oracle-direct-devspace/v1"
     assert proof["transport"] == "devspace"
+    assert proof["bounded_prompt_timeout_harvest"]["sha256"] == runner.STATE.sha256_file(
+        bounded_receipt
+    )
+
+
+@pytest.mark.parametrize("tamper", ("receipt", "oracle-meta", "ownership"))
+def test_task_bound_direct_devspace_prompt_timeout_settlement_revalidates_bounded_chain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    tamper: str,
+) -> None:
+    runner = load_runner()
+    owner = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("CODEX_THREAD_ID", owner)
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    initial = execute_run(
+        runner,
+        manifest(
+            tmp_path,
+            run_id="h" * 32,
+            model="gpt-5.6",
+            model_strategy="select",
+            thinking_time="extra-high",
+            research="off",
+            task_outcome_contract="v1",
+        ),
+        run_factory=version_0171_runner,
+        popen_factory=prompt_not_observed_popen,
+    )
+    run_dir = Path(initial["run_dir"])
+    state_path = run_dir / "state.json"
+    meta_path = write_prompt_timeout_oracle_meta(runner, run_dir, session_root)
+    runner.recover_run(
+        run_dir,
+        action="harvest",
+        oracle_command=["oracle"],
+        popen_factory=recovery_binding_unavailable_popen,
+    )
+    assert runner.STATE.proven_bounded_task_owned_prompt_timeout_harvest(state_path) is not None
+
+    if tamper == "receipt":
+        (run_dir / "bounded-prompt-timeout-harvest.json").write_text("{}", encoding="utf-8")
+    elif tamper == "oracle-meta":
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["browser"]["runtime"]["promptSubmitted"] = False
+        meta_path.write_text(json.dumps(meta), encoding="utf-8")
+    else:
+        ownership_path = run_dir / "ownership-receipt.json"
+        ownership_path.write_text("{}", encoding="utf-8")
+
+    assert runner.STATE.proven_bounded_task_owned_prompt_timeout_harvest(state_path) is None
+    with pytest.raises(runner.STATE.OracleStateError) as exc:
+        runner.settle_user_confirmed_no_submission(
+            run_dir,
+            confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
+            reason="bounded zero-turn evidence was tampered",
+        )
+    assert exc.value.code == "NO_SUBMISSION_EVIDENCE_INCOMPLETE"
 
 
 def test_task_bound_direct_devspace_prompt_timeout_rejects_profile_bound_meta_mismatch(


### PR DESCRIPTION
## Summary
- recognize exact task-bound ordinary DevSpace prompt-commit timeouts only when the existing zero-turn Oracle ledger and profile-bound metadata agree
- keep live recovery blocked without a browser identity receipt; allow one prompt-free exact-slug harvest followed by the existing explicit user no-submission settlement
- preserve exact gpt-5.6 / GPT-5.6 Sol model binding and add regression coverage

## Verification
- python -m pytest -q tests/test_chatgpt_oracle_run.py: 187 passed, 3 skipped
- python scripts/run_fast_gate.py: PASS within 100s budget
- independent verifier pending exact-head review
