### PR TITLE
fix: harden Oracle Windows metadata prelaunch

### DIFF
--- a/bin/chatgpt_oracle_compat.py
+++ b/bin/chatgpt_oracle_compat.py
@@ -220,6 +220,11 @@ LKG_PATCHES = {
 # changed follow-up port/timeout and Windows copy-profile hunks are rebased in
 # the 0.18.0 directory.
 PATCHES = {
+    "dist/src/sessionManager.js": {
+        "patch": "sessionManager.windows-atomic-rename-retry.patch",
+        "pristine": "c9442c359117c059f1a2145042b119bd235af7695f22929b97bc014331135a69",
+        "patched": "5dd851474fb123a01421dd7650d6519f7933e5e385ec1f322291542be5521694",
+    },
     "dist/bin/oracle-cli.js": {
         "patch": "oracle-cli.followup-port-and-timeout.patch",
         "pristine": "6909a8fd25ff7e5459123637e90a79d72dc5733cc2af0c14220018cb663b1825",

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -5497,6 +5497,15 @@ def proven_pre_submit_oracle_metadata_rename_failure(
     state = load_state(state_path)
     run_dir = state_path.parent.resolve()
     run_id = str(state.get("run_id") or "").strip()
+    originating_task = (
+        state.get("originating_task")
+        if isinstance(state.get("originating_task"), dict)
+        else {}
+    )
+    source_thread_id = source_thread_id_from_state(state)
+    state_ownership = (
+        state.get("ownership") if isinstance(state.get("ownership"), dict) else {}
+    )
     authority = str(state.get("session_authority") or "")
     transport_status = str(state.get("transport_status") or "")
     oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
@@ -5510,6 +5519,13 @@ def proven_pre_submit_oracle_metadata_rename_failure(
         state.get("schema") != STATE_SCHEMA
         or not run_id
         or run_dir.name != run_id
+        or source_thread_id is None
+        or originating_task.get("schema") != "codex.chatgpt.oracle-task-owner/v1"
+        or originating_task.get("binding") != "bound"
+        or originating_task.get("source_thread_id") != source_thread_id
+        or state_ownership.get("schema") != "codex.chatgpt.oracle-ownership/v1"
+        or state_ownership.get("binding") != "bound"
+        or state_ownership.get("source_thread_id") != source_thread_id
         or authority not in {"submitted_unknown", "pre_submit"}
         or state.get("status") != "attention_required"
         or transport_status
@@ -5576,6 +5592,8 @@ def proven_pre_submit_oracle_metadata_rename_failure(
         return None
     if (
         not project_root.is_dir()
+        or ownership_payload.get("source_thread_id") != source_thread_id
+        or ownership_payload.get("binding") != "bound"
         or ownership_payload.get("project_root_sha256")
         != hashlib.sha256(str(project_root).casefold().encode("utf-8")).hexdigest()
         or hashlib.sha256(transport_bytes).hexdigest() != mission_sha256
@@ -5731,6 +5749,7 @@ def proven_pre_submit_oracle_metadata_rename_failure(
         "rename_destination": destination_text,
         "rename_writer_pid": writer_pid,
         "controller_pid": controller_pid,
+        "source_thread_id": source_thread_id,
         "ownership_receipt_sha256": ownership["sha256"],
         "stdout_sha256": hashlib.sha256(stdout_bytes).hexdigest(),
         "stderr_sha256": hashlib.sha256(stderr_bytes).hexdigest(),

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -107,6 +107,16 @@ ORACLE_FOLLOWUP_UNARCHIVE_MENU_ABSENT_MARKER = (
     "FOLLOWUP_ARCHIVED_PARENT_UNARCHIVE_FAILED: unarchive-menu-not-found"
 )
 ORACLE_FOLLOWUP_PRE_COMPOSER_STAGES = frozenset({"resume-conversation"})
+ORACLE_SESSION_METADATA_RENAME_RE = re.compile(
+    r"^(?P<prefix>.{1,4}\s+)?(?P<code>EPERM|EACCES|EBUSY): "
+    r"(?P<message>operation not permitted|permission denied|resource busy or locked), "
+    r"rename '(?P<source>[^'\r\n]+)' -> '(?P<destination>[^'\r\n]+)'$"
+)
+ORACLE_SESSION_METADATA_RENAME_MESSAGES = {
+    "EPERM": "operation not permitted",
+    "EACCES": "permission denied",
+    "EBUSY": "resource busy or locked",
+}
 
 
 def _process_may_be_alive(pid: int) -> bool:
@@ -5051,6 +5061,9 @@ def settle_user_confirmed_no_submission(
                 "user-confirmed-no-submission-after-devspace-restart-required"
                 if evidence.get("host_failure", {}).get("failure_reason")
                 == "devspace-service-restart-required"
+                else "user-confirmed-no-submission-after-oracle-metadata-rename-failure"
+                if evidence.get("host_failure", {}).get("failure_reason")
+                == "oracle-session-metadata-rename-failed-before-browser"
                 else "user-confirmed-no-submission-after-oracle-version-resolution-failure"
             )
             if evidence.get("settlement_eligibility") == "oracle-pre-submit-host/v1"
@@ -5469,6 +5482,268 @@ def proven_pre_submit_cdp_disconnect(state_path: Path) -> dict[str, Any] | None:
     }
 
 
+def proven_pre_submit_oracle_metadata_rename_failure(
+    state_path: Path,
+) -> dict[str, Any] | None:
+    """Prove Oracle 0.18.0 failed writing its pending ledger before Chrome.
+
+    This is intentionally narrower than a generic EPERM classifier.  It binds
+    the exact task/run/mission/locator, the immutable ownership receipt, the
+    pending Oracle ledger, the normal pre-browser banner, and the exact
+    ``meta.json.<pid>.<uuid>.tmp -> meta.json`` replacement.  Any browser
+    runtime, receipt, URL, output, recovery attempt, live process, or path
+    mismatch keeps the run submitted-unknown.
+    """
+    state = load_state(state_path)
+    run_dir = state_path.parent.resolve()
+    run_id = str(state.get("run_id") or "").strip()
+    authority = str(state.get("session_authority") or "")
+    transport_status = str(state.get("transport_status") or "")
+    oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
+    locator = str(oracle.get("session_locator") or oracle.get("slug") or "").strip()
+    command = tuple(str(item) for item in (oracle.get("command") or []))
+    try:
+        validated_command = validate_oracle_command(list(command))
+    except OracleStateError:
+        validated_command = ()
+    if (
+        state.get("schema") != STATE_SCHEMA
+        or not run_id
+        or run_dir.name != run_id
+        or authority not in {"submitted_unknown", "pre_submit"}
+        or state.get("status") != "attention_required"
+        or transport_status
+        not in {"failed", "failed_pre_submit", "not_submitted_user_confirmed"}
+        or state.get("task_outcome") != "pending"
+        or state.get("terminal_harvested") is not False
+        or int(state.get("exit_code") or 0) == 0
+        or str(state.get("mode") or "") != "browser"
+        or not is_devspace_transport(str(state.get("transport") or ""))
+        or state.get("parallel_parent_id") is not None
+        or state.get("requested_run_id") not in (None, run_id)
+        or state.get("web_multi_child_provenance") is not None
+        or state.get("attachments") not in (None, [])
+        or not locator
+        or oracle.get("slug") != locator
+        or str(oracle.get("resolved_version") or "").removeprefix("oracle ").strip()
+        != "0.18.0"
+        or validated_command != command
+        or _state_has_conversation_url(state)
+    ):
+        return None
+
+    ownership = proven_ownership_receipt(state_path)
+    if ownership is None:
+        return None
+    ownership_payload = ownership.get("payload") if isinstance(ownership.get("payload"), dict) else {}
+    controller_pid = int(ownership_payload.get("oracle_process_pid") or 0)
+    observer = state.get("browser_observer") if isinstance(state.get("browser_observer"), dict) else {}
+    if (
+        controller_pid <= 0
+        or int(observer.get("oracle_process_pid") or 0) != controller_pid
+        or observer.get("status") != "process-exited"
+        or _process_may_be_alive(controller_pid)
+    ):
+        return None
+
+    mission = state.get("mission") if isinstance(state.get("mission"), dict) else {}
+    mission_sha256 = str(mission.get("sha256") or "").casefold()
+    transport_path = Path(str(mission.get("transport_path") or ""))
+    artifacts = state.get("artifacts") if isinstance(state.get("artifacts"), dict) else {}
+    output_path = Path(str(artifacts.get("output") or ""))
+    browser_temp = Path(str(artifacts.get("browser_temp") or ""))
+    records = {name: _artifact_bytes(state, name) for name in ("stdout", "stderr", "transcript")}
+    if (
+        not re.fullmatch(r"[a-f0-9]{64}", mission_sha256)
+        or transport_path.resolve() != (run_dir / "mission.md").resolve()
+        or transport_path.is_symlink()
+        or output_path.resolve() != (run_dir / "output.md").resolve()
+        or output_path.exists()
+        or output_path.is_symlink()
+        or browser_temp.resolve() != (run_dir / "browser-temp").resolve()
+        or browser_temp.is_symlink()
+        or any(record is None for record in records.values())
+        or any(run_dir.glob("recovery-*-stdout.log"))
+        or any(run_dir.glob("recovery-*-stderr.log"))
+    ):
+        return None
+    try:
+        project_root = Path(str(state.get("project_root") or "")).resolve(strict=True)
+        transport_bytes = transport_path.read_bytes()
+        if not browser_temp.is_dir():
+            return None
+    except OSError:
+        return None
+    if (
+        not project_root.is_dir()
+        or ownership_payload.get("project_root_sha256")
+        != hashlib.sha256(str(project_root).casefold().encode("utf-8")).hexdigest()
+        or hashlib.sha256(transport_bytes).hexdigest() != mission_sha256
+        or ownership_payload.get("mission_sha256") != mission_sha256
+        or ownership_payload.get("run_id") != run_id
+        or ownership_payload.get("slug") != locator
+        or ownership_payload.get("project_root") != str(state.get("project_root") or "")
+    ):
+        return None
+
+    stdout_path, stdout_bytes = records["stdout"]  # type: ignore[misc]
+    stderr_path, stderr_bytes = records["stderr"]  # type: ignore[misc]
+    transcript_path, transcript_bytes = records["transcript"]  # type: ignore[misc]
+    if (
+        stdout_path.resolve() != (run_dir / "stdout.log").resolve()
+        or stderr_path.resolve() != (run_dir / "stderr.log").resolve()
+        or transcript_path.resolve() != (run_dir / "transcript.md").resolve()
+        or any(path.is_symlink() for path in (stdout_path, stderr_path, transcript_path))
+        or transcript_bytes != stdout_bytes + stderr_bytes
+    ):
+        return None
+    try:
+        stdout_text = stdout_bytes.decode("utf-8", errors="strict")
+        stderr_text = stderr_bytes.decode("utf-8", errors="strict")
+        transcript_text = transcript_bytes.decode("utf-8", errors="strict")
+    except UnicodeDecodeError:
+        return None
+    lines = stdout_text.splitlines()
+    if (
+        len(lines) != 6
+        or re.fullmatch(r".{1,4}\s+oracle 0\.18\.0\s+.{2,160}", lines[0]) is None
+        or lines[1:] != [
+            f"Session: {locator}",
+            "Mode: browser foreground",
+            "Models: 1",
+            "Detach: no",
+            f"Reattach: oracle session {locator}",
+        ]
+        or CHATGPT_CONVERSATION_URL_RE.search(transcript_text)
+    ):
+        return None
+    rename = ORACLE_SESSION_METADATA_RENAME_RE.fullmatch(stderr_text.strip())
+    if (
+        rename is None
+        or ORACLE_SESSION_METADATA_RENAME_MESSAGES.get(rename.group("code"))
+        != rename.group("message")
+    ):
+        return None
+
+    session_root = Path(
+        os.environ.get("ORACLE_SESSION_ROOT") or (Path.home() / ".oracle" / "sessions")
+    ).resolve()
+    meta_path = session_root / locator / "meta.json"
+    if meta_path.is_symlink() or meta_path.parent.is_symlink():
+        return None
+    try:
+        meta_bytes = meta_path.read_bytes()
+        meta = json.loads(meta_bytes.decode("utf-8", errors="strict"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    source_text = rename.group("source")
+    destination_text = rename.group("destination")
+    expected_destination = str(meta_path)
+    source_match = re.fullmatch(
+        re.escape(expected_destination)
+        + r"\.(?P<pid>[1-9][0-9]*)\.(?P<nonce>[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\.tmp",
+        source_text,
+        re.IGNORECASE,
+    )
+    if destination_text != expected_destination or source_match is None:
+        return None
+    writer_pid = int(source_match.group("pid"))
+    if _process_may_be_alive(writer_pid) or Path(source_text).exists():
+        return None
+
+    browser = meta.get("browser") if isinstance(meta.get("browser"), dict) else {}
+    config = browser.get("config") if isinstance(browser.get("config"), dict) else {}
+    options = meta.get("options") if isinstance(meta.get("options"), dict) else {}
+    option_browser = options.get("browserConfig") if isinstance(options.get("browserConfig"), dict) else {}
+    models = meta.get("models") if isinstance(meta.get("models"), list) else []
+    profile = state.get("profile") if isinstance(state.get("profile"), dict) else {}
+    browser_identity = state.get("browser_identity") if isinstance(state.get("browser_identity"), dict) else {}
+    provider = state.get("provider_session") if isinstance(state.get("provider_session"), dict) else {}
+    try:
+        meta_cwd = Path(str(meta.get("cwd") or "")).resolve()
+        meta_output = Path(str(options.get("writeOutputPath") or "")).resolve()
+        state_profile = Path(str(profile.get("copy_profile") or "")).resolve()
+        config_profile = Path(str(config.get("copyProfileSource") or "")).resolve()
+        option_profile = Path(str(option_browser.get("copyProfileSource") or "")).resolve()
+        provider_meta = Path(str(provider.get("oracle_meta_path") or "")).resolve()
+    except OSError:
+        return None
+
+    forbidden_runtime_keys = {"promptSubmitted", "conversationId", "tabUrl", "commitProbe"}
+
+    def contains_forbidden_runtime_key(value: Any) -> bool:
+        if isinstance(value, dict):
+            return any(
+                key in forbidden_runtime_keys or contains_forbidden_runtime_key(item)
+                for key, item in value.items()
+            )
+        if isinstance(value, list):
+            return any(contains_forbidden_runtime_key(item) for item in value)
+        return False
+
+    expected_port = int(browser_identity.get("expected_cdp_port") or 0)
+    browser_receipt = run_dir / "browser-identity-receipt.json"
+    if (
+        meta.get("id") != locator
+        or meta.get("status") != "pending"
+        or meta.get("model") != "gpt-5.6"
+        or meta.get("mode") != "browser"
+        or meta_cwd != project_root
+        or not str(meta.get("createdAt") or "").strip()
+        or models != [{"model": "gpt-5.6", "status": "pending", "log": {"path": "models\\gpt-5.6.log"}}]
+        or "runtime" in browser
+        or contains_forbidden_runtime_key(meta)
+        or expected_port <= 0
+        or profile.get("model") != "gpt-5.6"
+        or profile.get("model_strategy") != "select"
+        or profile.get("thinking_time") != "extra-high"
+        or config.get("debugPort") != expected_port
+        or option_browser.get("debugPort") != expected_port
+        or config.get("desiredModel") != "GPT-5.6 Sol"
+        or config.get("modelStrategy") != "select"
+        or config.get("thinkingTime") != "extra-high"
+        or options.get("model") != "gpt-5.6"
+        or options.get("slug") != locator
+        or options.get("mode") != "browser"
+        or meta_output != output_path.resolve()
+        or state_profile != config_profile
+        or state_profile != option_profile
+        or browser_identity.get("receipt_path") is not None
+        or browser_identity.get("receipt_sha256") is not None
+        or browser_receipt.exists()
+        or browser_receipt.is_symlink()
+        or provider.get("status") != "pending"
+        or provider.get("terminal_confirmed") is not False
+        or provider.get("binding") != "unconfirmed"
+        or provider.get("observed_conversation_url") is not None
+        or provider_meta != meta_path.resolve()
+        or provider.get("oracle_meta_sha256") != hashlib.sha256(meta_bytes).hexdigest()
+    ):
+        return None
+
+    return {
+        "schema": "codex.chatgpt.oracle-pre-submit-host-failure/v1",
+        "code": "ORACLE_SESSION_METADATA_RENAME_PRELAUNCH_FAILED",
+        "oracle_locator": locator,
+        "oracle_version": "0.18.0",
+        "rename_error_code": rename.group("code"),
+        "rename_source": source_text,
+        "rename_destination": destination_text,
+        "rename_writer_pid": writer_pid,
+        "controller_pid": controller_pid,
+        "ownership_receipt_sha256": ownership["sha256"],
+        "stdout_sha256": hashlib.sha256(stdout_bytes).hexdigest(),
+        "stderr_sha256": hashlib.sha256(stderr_bytes).hexdigest(),
+        "transcript_sha256": hashlib.sha256(transcript_bytes).hexdigest(),
+        "oracle_meta_path": str(meta_path),
+        "oracle_meta_sha256": hashlib.sha256(meta_bytes).hexdigest(),
+        "output_absent": True,
+        "conversation_url_absent": True,
+        "resolved_version": "0.18.0",
+        "failure_reason": "oracle-session-metadata-rename-failed-before-browser",
+    }
+
+
 def proven_pre_submit_host_failure(state_path: Path) -> dict[str, Any] | None:
     """Prove a host failure happened before Oracle/browser launch.
 
@@ -5476,6 +5751,9 @@ def proven_pre_submit_host_failure(state_path: Path) -> dict[str, Any] | None:
     process is created.  The additional immutable-state checks keep this from
     reclassifying a real submitted or live session.
     """
+    metadata_rename = proven_pre_submit_oracle_metadata_rename_failure(state_path)
+    if metadata_rename is not None:
+        return metadata_rename
     manual_login = proven_pre_submit_manual_login_profile_uninitialized(state_path)
     if manual_login is not None:
         return manual_login
@@ -5711,6 +5989,7 @@ def _pre_submit_host_no_submission_evidence(state_path: Path) -> dict[str, Any] 
         failure is None
         or failure.get("code") not in {
             "DEVSPACE_SERVICE_RESTART_PRELAUNCH_FAILED",
+            "ORACLE_SESSION_METADATA_RENAME_PRELAUNCH_FAILED",
             "ORACLE_VERSION_RESOLUTION_PRELAUNCH_FAILED",
         }
     ):
@@ -5746,7 +6025,8 @@ def _pre_submit_host_no_submission_evidence(state_path: Path) -> dict[str, Any] 
         or transcript_path.resolve() != (run_dir / "transcript.md").resolve()
         or transcript_path.is_symlink()
         or hashlib.sha256(transport_bytes).hexdigest() != mission_sha256
-        or hashlib.sha256(transcript_bytes).hexdigest() != failure["stderr_sha256"]
+        or hashlib.sha256(transcript_bytes).hexdigest()
+        != failure.get("transcript_sha256", failure["stderr_sha256"])
     ):
         return None
     return {
@@ -6057,6 +6337,7 @@ def settle_proven_pre_submit_failure(state_path: Path) -> dict[str, Any] | None:
                 "ORACLE_LAUNCH_FLAGS_MUTUALLY_EXCLUSIVE_PRELAUNCH_FAILED",
                 "ORACLE_MANUAL_LOGIN_PROFILE_UNINITIALIZED_PRELAUNCH_FAILED",
                 "ORACLE_CDP_DISCONNECT_PRE_SUBMIT_FAILED",
+                "ORACLE_SESSION_METADATA_RENAME_PRELAUNCH_FAILED",
             }
             else "pending"
         ),
@@ -6073,6 +6354,8 @@ def settle_proven_pre_submit_failure(state_path: Path) -> dict[str, Any] | None:
             if evidence["code"] == "ORACLE_MANUAL_LOGIN_PROFILE_UNINITIALIZED_PRELAUNCH_FAILED"
             else "oracle-cdp-disconnect-pre-submit"
             if evidence["code"] == "ORACLE_CDP_DISCONNECT_PRE_SUBMIT_FAILED"
+            else "oracle-session-metadata-rename-pre-submit"
+            if evidence["code"] == "ORACLE_SESSION_METADATA_RENAME_PRELAUNCH_FAILED"
             else "oracle-model-switcher-pre-submit"
             if evidence["code"] == "ORACLE_MODEL_SWITCHER_PRE_SUBMIT_FAILED"
             else "prelaunch-host-failure"

--- a/bin/oracle-compat/0.18.0/sessionManager.windows-atomic-rename-retry.patch
+++ b/bin/oracle-compat/0.18.0/sessionManager.windows-atomic-rename-retry.patch
@@ -1,0 +1,34 @@
+diff --git a/dist/src/sessionManager.js b/dist/src/sessionManager.js
+--- a/dist/src/sessionManager.js
++++ b/dist/src/sessionManager.js
+@@ -134,5 +134,21 @@ function metaPath(id) {
+     return path.join(sessionDir(id), METADATA_FILENAME);
+ }
++const WINDOWS_ATOMIC_RENAME_RETRY_CODES = new Set(["EPERM", "EACCES", "EBUSY"]);
++const WINDOWS_ATOMIC_RENAME_RETRY_DELAYS_MS = [25, 50, 100, 200, 400, 800, 1600];
++async function renameMetadataAtomically(temporaryPath, targetPath) {
++    for (let attempt = 0;; attempt += 1) {
++        try {
++            await fs.rename(temporaryPath, targetPath);
++            return;
++        }
++        catch (error) {
++            const code = typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
++            if (process.platform !== "win32" || !WINDOWS_ATOMIC_RENAME_RETRY_CODES.has(code) || attempt >= WINDOWS_ATOMIC_RENAME_RETRY_DELAYS_MS.length)
++                throw error;
++            await new Promise((resolve) => setTimeout(resolve, WINDOWS_ATOMIC_RENAME_RETRY_DELAYS_MS[attempt]));
++        }
++    }
++}
+ async function writeSessionMetadataFile(sessionId, metadata) {
+     const targetPath = metaPath(sessionId);
+     const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.tmp`;
+@@ -141,7 +157,7 @@ async function writeSessionMetadataFile(sessionId, metadata) {
+             encoding: "utf8",
+             mode: 0o600,
+         });
+-        await fs.rename(temporaryPath, targetPath);
++        await renameMetadataAtomically(temporaryPath, targetPath);
+     }
+     finally {
+         await fs.rm(temporaryPath, { force: true }).catch(() => undefined);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 기술 변경 기록
 
+## 1.20.12 - Retry transient Windows Oracle metadata replacement
+
+- Oracle 0.18.0 session metadata now retries only transient Windows `EPERM`,
+  `EACCES`, and `EBUSY` failures while atomically replacing `meta.json`. This
+  prevents a pre-submit run from dying when antivirus or another short-lived
+  reader briefly holds the destination, while preserving fail-closed behavior
+  for every other platform and error.
+
 ## 1.20.11 - Recover exact ordinary DevSpace prompt timeouts
 
 - task-bound 일반 `devspace` 실행이 prompt commit timeout 뒤 browser identity

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,9 @@
   immutable mission and ownership receipt, pending session metadata, exited
   controller, empty output/conversation/browser identity, and the exact Windows
   atomic-rename error; path, runtime, URL, output, or receipt contradictions
-  remain ineligible.
+  remain ineligible. The state, ownership block, and append-only receipt must
+  all bind the same valid Codex task UUID; legacy-unbound and foreign-task
+  settlement attempts remain forbidden.
 
 ## 1.20.11 - Recover exact ordinary DevSpace prompt timeouts
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,13 @@
   prevents a pre-submit run from dying when antivirus or another short-lived
   reader briefly holds the destination, while preserving fail-closed behavior
   for every other platform and error.
+- If the bounded retry still exhausts before any browser runtime or conversation
+  exists, the exact task owner may use the normal explicit
+  `settle-no-submission` path. The evidence binds the exact Oracle locator,
+  immutable mission and ownership receipt, pending session metadata, exited
+  controller, empty output/conversation/browser identity, and the exact Windows
+  atomic-rename error; path, runtime, URL, output, or receipt contradictions
+  remain ineligible.
 
 ## 1.20.11 - Recover exact ordinary DevSpace prompt timeouts
 

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -69,6 +69,7 @@
     "bin/oracle-compat/0.18.0/browserConfig.followup-port-binding.patch",
     "bin/oracle-compat/0.18.0/browserConfig.copy-profile-windows.patch",
     "bin/oracle-compat/0.18.0/chromeLifecycle.disable-session-crash-bubble.patch",
+    "bin/oracle-compat/0.18.0/sessionManager.windows-atomic-rename-retry.patch",
     "bin/chatgpt_oracle_state.py",
     "bin/chatgpt_oracle_profiles.py",
     "bin/chatgpt_oracle_dispatch.py",

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.11",
+  "version": "1.20.12",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.11",
+  "version": "1.20.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.11",
+      "version": "1.20.12",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.11",
+  "version": "1.20.12",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/tests/test_chatgpt_oracle_compat.py
+++ b/tests/test_chatgpt_oracle_compat.py
@@ -400,6 +400,98 @@ def test_published_0180_default_contract_applies_every_current_patch(tmp_path: P
     chrome_lifecycle = package / "dist/src/browser/chromeLifecycle.js"
     chrome_lifecycle_text = chrome_lifecycle.read_text(encoding="utf-8")
     assert chrome_lifecycle_text.count('"--disable-session-crashed-bubble"') == 1
+    session_manager = package / "dist/src/sessionManager.js"
+    session_manager_text = session_manager.read_text(encoding="utf-8")
+    assert 'new Set(["EPERM", "EACCES", "EBUSY"])' in session_manager_text
+    assert "process.platform !== \"win32\"" in session_manager_text
+    assert "WINDOWS_ATOMIC_RENAME_RETRY_DELAYS_MS[attempt]" in session_manager_text
+    assert "await renameMetadataAtomically(temporaryPath, targetPath);" in session_manager_text
+    retry_probe = subprocess.run(
+        [
+            node,
+            "--input-type=module",
+            "--eval",
+            """
+import fs from "node:fs/promises";
+const WINDOWS_ATOMIC_RENAME_RETRY_CODES = new Set(["EPERM", "EACCES", "EBUSY"]);
+const WINDOWS_ATOMIC_RENAME_RETRY_DELAYS_MS = [25, 50, 100, 200, 400, 800, 1600];
+async function renameMetadataAtomically(temporaryPath, targetPath) {
+  for (let attempt = 0;; attempt += 1) {
+    try {
+      await fs.rename(temporaryPath, targetPath);
+      return;
+    } catch (error) {
+      const code = typeof error === "object" && error !== null && "code" in error ? error.code : undefined;
+      if (process.platform !== "win32" || !WINDOWS_ATOMIC_RENAME_RETRY_CODES.has(code) || attempt >= WINDOWS_ATOMIC_RENAME_RETRY_DELAYS_MS.length)
+        throw error;
+      await new Promise((resolve) => setTimeout(resolve, WINDOWS_ATOMIC_RENAME_RETRY_DELAYS_MS[attempt]));
+    }
+  }
+}
+Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+let attempts = 0;
+fs.rename = async () => {
+  attempts += 1;
+  if (attempts < 3) {
+    const error = new Error("transient Windows metadata lock");
+    error.code = "EPERM";
+    throw error;
+  }
+};
+await renameMetadataAtomically("temporary", "target");
+if (attempts !== 3) throw new Error(`expected 3 rename attempts, observed ${attempts}`);
+
+attempts = 0;
+fs.rename = async () => {
+  attempts += 1;
+  const error = new Error("persistent Windows metadata lock");
+  error.code = "EPERM";
+  throw error;
+};
+try {
+  await renameMetadataAtomically("temporary", "target");
+  throw new Error("persistent EPERM unexpectedly succeeded");
+} catch (error) {
+  if (error.code !== "EPERM" || attempts !== 8) throw error;
+}
+
+Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+attempts = 0;
+fs.rename = async () => {
+  attempts += 1;
+  const error = new Error("non-Windows metadata error");
+  error.code = "EPERM";
+  throw error;
+};
+try {
+  await renameMetadataAtomically("temporary", "target");
+  throw new Error("non-Windows EPERM unexpectedly retried");
+} catch (error) {
+  if (error.code !== "EPERM" || attempts !== 1) throw error;
+}
+""",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert retry_probe.returncode == 0, retry_probe.stderr
+
+
+def test_oracle_session_metadata_retry_patch_is_bounded_to_windows_transient_errors() -> None:
+    patch_text = (
+        Path(__file__).resolve().parents[1]
+        / "bin"
+        / "oracle-compat"
+        / "0.18.0"
+        / "sessionManager.windows-atomic-rename-retry.patch"
+    ).read_text(encoding="utf-8")
+
+    assert 'new Set(["EPERM", "EACCES", "EBUSY"])' in patch_text
+    assert "process.platform !== \"win32\"" in patch_text
+    assert "attempt >= WINDOWS_ATOMIC_RENAME_RETRY_DELAYS_MS.length" in patch_text
+    assert "throw error;" in patch_text
+    assert "fs.rm(temporaryPath, { force: true })" in patch_text
 
 
 def test_published_0171_patch_requires_extra_high_and_pro_selection_proof(tmp_path: Path) -> None:

--- a/tests/test_chatgpt_oracle_state.py
+++ b/tests/test_chatgpt_oracle_state.py
@@ -236,6 +236,251 @@ def test_write_json_atomic_uses_short_same_directory_temp_name(tmp_path: Path) -
     assert list(directory.glob(".t-*")) == []
 
 
+def _oracle_metadata_rename_fixture(
+    tmp_path: Path,
+    state,
+    *,
+    source_thread_id: str = "019ff05c-bad3-7770-a902-6b1b62588a7d",
+) -> tuple[Path, Path]:
+    project_root = tmp_path / "project"
+    run_id = "20260827T075513Z-23acae337024"
+    locator = "oracle-project-23acae3370"
+    run_dir = tmp_path / "state" / "projects" / "project" / "runs" / run_id
+    browser_temp = run_dir / "browser-temp"
+    session_root = tmp_path / "oracle-sessions"
+    meta_path = session_root / locator / "meta.json"
+    profile_path = tmp_path / "oracle-profile"
+    project_root.mkdir()
+    run_dir.mkdir(parents=True)
+    browser_temp.mkdir()
+    profile_path.mkdir()
+    meta_path.parent.mkdir(parents=True)
+    mission_bytes = b"verify registered app read route\n"
+    mission_sha256 = hashlib.sha256(mission_bytes).hexdigest()
+    (run_dir / "mission.md").write_bytes(mission_bytes)
+    output_path = run_dir / "output.md"
+    expected_cdp_port = 56853
+    controller_pid = 10796
+    writer_pid = 12312
+    nonce = "97ee88b0-7c8d-46d0-bfee-5aa74901def3"
+    stdout_bytes = (
+        "🧿 oracle 0.18.0 — Fine, I'll write the test for the AI too.\n"
+        f"Session: {locator}\n"
+        "Mode: browser foreground\n"
+        "Models: 1\n"
+        "Detach: no\n"
+        f"Reattach: oracle session {locator}\n"
+    ).encode("utf-8")
+    stderr_bytes = (
+        "✖ EPERM: operation not permitted, rename "
+        f"'{meta_path}.{writer_pid}.{nonce}.tmp' -> '{meta_path}'\n"
+    ).encode("utf-8")
+    (run_dir / "stdout.log").write_bytes(stdout_bytes)
+    (run_dir / "stderr.log").write_bytes(stderr_bytes)
+    (run_dir / "transcript.md").write_bytes(stdout_bytes + stderr_bytes)
+    browser_config = {
+        "debugPort": expected_cdp_port,
+        "copyProfileSource": str(profile_path),
+        "desiredModel": "GPT-5.6 Sol",
+        "modelStrategy": "select",
+        "thinkingTime": "extra-high",
+    }
+    meta = {
+        "id": locator,
+        "createdAt": "2026-08-27T07:55:18.733Z",
+        "status": "pending",
+        "model": "gpt-5.6",
+        "models": [
+            {"model": "gpt-5.6", "status": "pending", "log": {"path": "models\\gpt-5.6.log"}}
+        ],
+        "cwd": str(project_root),
+        "mode": "browser",
+        "browser": {"config": browser_config},
+        "options": {
+            "model": "gpt-5.6",
+            "slug": locator,
+            "mode": "browser",
+            "writeOutputPath": str(output_path),
+            "browserConfig": dict(browser_config),
+        },
+    }
+    meta_bytes = json.dumps(meta, indent=2).encode("utf-8")
+    meta_path.write_bytes(meta_bytes)
+    project_hash = hashlib.sha256(
+        str(project_root).casefold().encode("utf-8")
+    ).hexdigest()
+    payload = {
+        "schema": state.STATE_SCHEMA,
+        "run_id": run_id,
+        "project_root": str(project_root),
+        "mode": "browser",
+        "transport": "devspace",
+        "app_name": "codex",
+        "profile": {
+            "model": "gpt-5.6",
+            "model_strategy": "select",
+            "thinking_time": "extra-high",
+            "copy_profile": str(profile_path),
+        },
+        "parallel_parent_id": None,
+        "requested_run_id": None,
+        "web_multi_child_provenance": None,
+        "originating_task": {
+            "schema": "codex.chatgpt.oracle-task-owner/v1",
+            "source_thread_id": source_thread_id,
+            "binding": "bound",
+        },
+        "ownership": {
+            "schema": "codex.chatgpt.oracle-ownership/v1",
+            "source_thread_id": source_thread_id,
+            "binding": "bound",
+            "project_root_sha256": project_hash,
+            "run_id": run_id,
+            "mission_sha256": mission_sha256,
+            "slug": locator,
+        },
+        "transport_status": "failed",
+        "task_outcome_contract": "v1",
+        "task_outcome": "pending",
+        "mission": {
+            "path": str(project_root / "mission-source.md"),
+            "transport_path": str(run_dir / "mission.md"),
+            "sha256": mission_sha256,
+        },
+        "attachments": [],
+        "oracle": {
+            "resolved_version": "0.18.0",
+            "command": ["npx.cmd", "-y", "@steipete/oracle@0.18.0"],
+            "slug": locator,
+            "session_locator": locator,
+        },
+        "artifacts": {
+            "output": str(output_path),
+            "transcript": str(run_dir / "transcript.md"),
+            "stdout": str(run_dir / "stdout.log"),
+            "stderr": str(run_dir / "stderr.log"),
+            "browser_temp": str(browser_temp),
+        },
+        "browser_identity": {
+            "schema": "codex.chatgpt.oracle-browser-identity/v1",
+            "expected_cdp_port": expected_cdp_port,
+            "receipt_path": None,
+            "receipt_sha256": None,
+        },
+        "provider_session": {
+            "schema": "codex.chatgpt.oracle-provider-session/v1",
+            "status": "pending",
+            "terminal_confirmed": False,
+            "binding": "unconfirmed",
+            "reason": "browser-identity-receipt-unavailable",
+            "oracle_meta_path": str(meta_path),
+            "observed_conversation_url": None,
+            "completed_at": None,
+            "oracle_meta_sha256": hashlib.sha256(meta_bytes).hexdigest(),
+        },
+        "status": "attention_required",
+        "exit_code": 1,
+        "session_authority": "submitted_unknown",
+        "terminal_harvested": False,
+        "artifact_sha256": None,
+        "browser_observer": {
+            "status": "process-exited",
+            "oracle_process_pid": controller_pid,
+            "timeout_is_terminal": False,
+        },
+    }
+    state_path = run_dir / "state.json"
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+    ownership_receipt = {
+        "schema": "codex.chatgpt.oracle-ownership-receipt/v1",
+        "source_thread_id": source_thread_id,
+        "binding": "bound",
+        "project_root": str(project_root),
+        "project_root_sha256": project_hash,
+        "run_id": run_id,
+        "mission_sha256": mission_sha256,
+        "slug": locator,
+        "oracle_process_pid": controller_pid,
+        "expected_cdp_port": expected_cdp_port,
+        "browser_temp": str(browser_temp),
+        "created_at": "2026-08-27T07:55:16.726047+00:00",
+    }
+    (run_dir / "ownership-receipt.json").write_text(
+        json.dumps(ownership_receipt), encoding="utf-8"
+    )
+    return state_path, meta_path
+
+
+def test_oracle_metadata_rename_prelaunch_failure_is_exactly_settleable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = load_state()
+    source_thread_id = "019ff05c-bad3-7770-a902-6b1b62588a7d"
+    state_path, _ = _oracle_metadata_rename_fixture(
+        tmp_path, state, source_thread_id=source_thread_id
+    )
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(tmp_path / "oracle-sessions"))
+    monkeypatch.setenv("CODEX_THREAD_ID", source_thread_id)
+    monkeypatch.setattr(state, "_process_may_be_alive", lambda _pid: False)
+
+    failure = state.proven_pre_submit_oracle_metadata_rename_failure(state_path)
+    assert failure is not None
+    assert failure["code"] == "ORACLE_SESSION_METADATA_RENAME_PRELAUNCH_FAILED"
+    assert state._pre_submit_host_no_submission_evidence(state_path) is not None
+
+    settled = state.settle_user_confirmed_no_submission(
+        state_path,
+        confirmation=state.USER_CONFIRMED_NO_SUBMISSION,
+        reason="exact Oracle metadata replacement exhausted before browser launch",
+    )
+    assert settled["session_authority"] == "pre_submit"
+    assert settled["transport_status"] == "not_submitted_user_confirmed"
+    assert settled["task_outcome_reason"] == (
+        "user-confirmed-no-submission-after-oracle-metadata-rename-failure"
+    )
+    assert state.proven_user_confirmed_no_submission(state_path) is not None
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["wrong-path", "output", "browser-runtime", "browser-receipt", "live-controller"],
+)
+def test_oracle_metadata_rename_prelaunch_failure_rejects_contradictions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mutation: str,
+) -> None:
+    state = load_state()
+    state_path, meta_path = _oracle_metadata_rename_fixture(tmp_path, state)
+    run_dir = state_path.parent
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(tmp_path / "oracle-sessions"))
+    monkeypatch.setenv("CODEX_THREAD_ID", "019ff05c-bad3-7770-a902-6b1b62588a7d")
+    monkeypatch.setattr(state, "_process_may_be_alive", lambda pid: mutation == "live-controller" and pid == 10796)
+
+    if mutation == "wrong-path":
+        stderr = (run_dir / "stderr.log").read_bytes().replace(
+            str(meta_path).encode("utf-8"), str(meta_path.with_name("other.json")).encode("utf-8")
+        )
+        (run_dir / "stderr.log").write_bytes(stderr)
+        (run_dir / "transcript.md").write_bytes((run_dir / "stdout.log").read_bytes() + stderr)
+    elif mutation == "output":
+        (run_dir / "output.md").write_text("unexpected provider output", encoding="utf-8")
+    elif mutation == "browser-runtime":
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["browser"]["runtime"] = {"promptSubmitted": False}
+        meta_bytes = json.dumps(meta, indent=2).encode("utf-8")
+        meta_path.write_bytes(meta_bytes)
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+        payload["provider_session"]["oracle_meta_sha256"] = hashlib.sha256(meta_bytes).hexdigest()
+        state_path.write_text(json.dumps(payload), encoding="utf-8")
+    elif mutation == "browser-receipt":
+        (run_dir / "browser-identity-receipt.json").write_text("{}", encoding="utf-8")
+
+    assert state.proven_pre_submit_oracle_metadata_rename_failure(state_path) is None
+    assert state._pre_submit_host_no_submission_evidence(state_path) is None
+
+
 def test_v1_task_outcome_accepts_exact_provider_reference_footer(tmp_path: Path) -> None:
     state = load_state()
     output = tmp_path / "output.md"

--- a/tests/test_chatgpt_oracle_state.py
+++ b/tests/test_chatgpt_oracle_state.py
@@ -444,7 +444,14 @@ def test_oracle_metadata_rename_prelaunch_failure_is_exactly_settleable(
 
 @pytest.mark.parametrize(
     "mutation",
-    ["wrong-path", "output", "browser-runtime", "browser-receipt", "live-controller"],
+    [
+        "wrong-path",
+        "output",
+        "browser-runtime",
+        "browser-receipt",
+        "live-controller",
+        "legacy-unbound",
+    ],
 )
 def test_oracle_metadata_rename_prelaunch_failure_rejects_contradictions(
     tmp_path: Path,
@@ -476,9 +483,47 @@ def test_oracle_metadata_rename_prelaunch_failure_rejects_contradictions(
         state_path.write_text(json.dumps(payload), encoding="utf-8")
     elif mutation == "browser-receipt":
         (run_dir / "browser-identity-receipt.json").write_text("{}", encoding="utf-8")
+    elif mutation == "legacy-unbound":
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+        payload["originating_task"] = {
+            "schema": "codex.chatgpt.oracle-task-owner/v1",
+            "source_thread_id": None,
+            "binding": "legacy-unbound",
+        }
+        payload["ownership"]["source_thread_id"] = None
+        payload["ownership"]["binding"] = "legacy-unbound"
+        state_path.write_text(json.dumps(payload), encoding="utf-8")
+        receipt_path = run_dir / "ownership-receipt.json"
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        receipt["source_thread_id"] = None
+        receipt["binding"] = "legacy-unbound"
+        receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
 
     assert state.proven_pre_submit_oracle_metadata_rename_failure(state_path) is None
     assert state._pre_submit_host_no_submission_evidence(state_path) is None
+
+
+def test_oracle_metadata_rename_settlement_rejects_foreign_task(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = load_state()
+    owner_thread_id = "019ff05c-bad3-7770-a902-6b1b62588a7d"
+    state_path, _ = _oracle_metadata_rename_fixture(
+        tmp_path, state, source_thread_id=owner_thread_id
+    )
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(tmp_path / "oracle-sessions"))
+    monkeypatch.setenv("CODEX_THREAD_ID", "01a028dd-843a-76c2-b316-376f10c53ddd")
+    monkeypatch.setattr(state, "_process_may_be_alive", lambda _pid: False)
+
+    assert state.proven_pre_submit_oracle_metadata_rename_failure(state_path) is not None
+    with pytest.raises(state.OracleStateError) as caught:
+        state.settle_user_confirmed_no_submission(
+            state_path,
+            confirmation=state.USER_CONFIRMED_NO_SUBMISSION,
+            reason="foreign task must not settle the exact run",
+        )
+    assert caught.value.code == "FOREIGN_TASK_SESSION"
 
 
 def test_v1_task_outcome_accepts_exact_provider_reference_footer(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- hash-gate a narrow Oracle 0.18.0 patch for transient Windows meta.json rename locks
- retry only EPERM/EACCES/EBUSY for a bounded 3.175 seconds, then rethrow
- make an exhausted pre-browser rename failure officially settleable only with exact task/run/mission/locator/ownership, pending Oracle meta, absent runtime/receipt/URL/output/recovery, and dead controller/writer evidence

## Verification
- metadata settlement regression: 6 passed
- Oracle state: 94 passed
- Oracle runner: 190 passed, 3 skipped
- Oracle compatibility: 44 passed, 3 skipped
- fast gate: PASS (29.44s)
- v3 contracts: PASS
- docs and portability: PASS
- v4 focused: running on final head

Exact source commit: 44a502abbf030b4961a78dcb1cb4ef9876289a49