### PR TITLE
fix: preserve task-bound Oracle settlements

### DIFF
--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -4961,8 +4961,40 @@ def proven_user_confirmed_no_submission(state_path: Path) -> dict[str, Any] | No
     elif current.get("settlement_eligibility") == "oracle-pre-submit-host/v1":
         required = (
             "settlement_eligibility", "transport", "transport_mission_path",
-            "transport_mission_sha256", "transcript_sha256", "host_failure",
+            "transport_mission_sha256", "transcript_sha256",
         )
+        recorded_host_failure = recorded.get("host_failure")
+        current_host_failure = current.get("host_failure")
+        if recorded_host_failure != current_host_failure:
+            # v1.20.12 briefly emitted the exact metadata-rename settlement
+            # before the task-bound proof added ``source_thread_id`` to the
+            # re-derived host failure.  Preserve only that append-only receipt:
+            # every earlier field, including the ownership-receipt hash, must
+            # still match byte-for-byte, and the current predicate must have
+            # independently re-proven the bound task from state + receipt.
+            historical_metadata_task_binding_upgrade = (
+                isinstance(recorded_host_failure, dict)
+                and isinstance(current_host_failure, dict)
+                and recorded_host_failure.get("code")
+                == "ORACLE_SESSION_METADATA_RENAME_PRELAUNCH_FAILED"
+                and current_host_failure.get("code")
+                == "ORACLE_SESSION_METADATA_RENAME_PRELAUNCH_FAILED"
+                and "source_thread_id" not in recorded_host_failure
+                and isinstance(current_host_failure.get("source_thread_id"), str)
+                and bool(
+                    SOURCE_THREAD_ID_RE.fullmatch(
+                        current_host_failure["source_thread_id"]
+                    )
+                )
+                and recorded_host_failure
+                == {
+                    key: value
+                    for key, value in current_host_failure.items()
+                    if key != "source_thread_id"
+                }
+            )
+            if not historical_metadata_task_binding_upgrade:
+                return None
     elif current.get("settlement_eligibility") == "oracle-web-multi-child/v1":
         required = (
             "settlement_eligibility", "parallel_parent_id", "source_mission_path",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # 기술 변경 기록
 
+## 1.20.13 - Preserve exact task-bound metadata settlements
+
+- A `v1.20.12` Oracle metadata-rename settlement created immediately before
+  the final task-binding hardening remains valid when its append-only artifact
+  lacks only the later `host_failure.source_thread_id` field. Revalidation
+  still requires the current state, originating task, ownership block, and
+  immutable ownership receipt to bind the same valid Codex task UUID, and
+  every pre-existing host-failure field and hash must match exactly.
+- Legacy-unbound runs, foreign-task settlement attempts, changed ownership
+  receipt hashes, provider output/conversation evidence, and any other field
+  drift remain fail-closed. This prevents an already settled pre-submit run
+  from resurrecting its task-scoped project lock after upgrading.
+
 ## 1.20.12 - Retry transient Windows Oracle metadata replacement
 
 - Oracle 0.18.0 session metadata now retries only transient Windows `EPERM`,

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.12",
+  "version": "1.20.13",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.12",
+  "version": "1.20.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.12",
+      "version": "1.20.13",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.12",
+  "version": "1.20.13",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/tests/test_chatgpt_oracle_state.py
+++ b/tests/test_chatgpt_oracle_state.py
@@ -442,6 +442,79 @@ def test_oracle_metadata_rename_prelaunch_failure_is_exactly_settleable(
     assert state.proven_user_confirmed_no_submission(state_path) is not None
 
 
+def test_oracle_metadata_rename_settlement_revalidates_pre_task_field_receipt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = load_state()
+    source_thread_id = "019ff05c-bad3-7770-a902-6b1b62588a7d"
+    state_path, _ = _oracle_metadata_rename_fixture(
+        tmp_path, state, source_thread_id=source_thread_id
+    )
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(tmp_path / "oracle-sessions"))
+    monkeypatch.setenv("CODEX_THREAD_ID", source_thread_id)
+    monkeypatch.setattr(state, "_process_may_be_alive", lambda _pid: False)
+
+    state.settle_user_confirmed_no_submission(
+        state_path,
+        confirmation=state.USER_CONFIRMED_NO_SUBMISSION,
+        reason="exact Oracle metadata replacement exhausted before browser launch",
+    )
+    run_dir = state_path.parent
+    artifact_path = run_dir / "user-confirmed-no-submission.json"
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    del artifact["host_failure"]["source_thread_id"]
+    artifact_bytes = json.dumps(artifact, ensure_ascii=False, indent=2).encode("utf-8")
+    artifact_path.write_bytes(artifact_bytes)
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    payload["user_confirmed_no_submission"]["sha256"] = hashlib.sha256(
+        artifact_bytes
+    ).hexdigest()
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    proven = state.proven_user_confirmed_no_submission(state_path)
+    assert proven is not None
+    assert proven["host_failure"]["ownership_receipt_sha256"]
+    assert state.unresolved_project_sessions(
+        run_dir.parent,
+        Path(payload["project_root"]),
+        source_thread_id=source_thread_id,
+    ) == []
+
+
+def test_oracle_metadata_rename_legacy_settlement_rejects_other_field_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = load_state()
+    source_thread_id = "019ff05c-bad3-7770-a902-6b1b62588a7d"
+    state_path, _ = _oracle_metadata_rename_fixture(
+        tmp_path, state, source_thread_id=source_thread_id
+    )
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(tmp_path / "oracle-sessions"))
+    monkeypatch.setenv("CODEX_THREAD_ID", source_thread_id)
+    monkeypatch.setattr(state, "_process_may_be_alive", lambda _pid: False)
+
+    state.settle_user_confirmed_no_submission(
+        state_path,
+        confirmation=state.USER_CONFIRMED_NO_SUBMISSION,
+        reason="exact Oracle metadata replacement exhausted before browser launch",
+    )
+    artifact_path = state_path.parent / "user-confirmed-no-submission.json"
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    del artifact["host_failure"]["source_thread_id"]
+    artifact["host_failure"]["ownership_receipt_sha256"] = "0" * 64
+    artifact_bytes = json.dumps(artifact, ensure_ascii=False, indent=2).encode("utf-8")
+    artifact_path.write_bytes(artifact_bytes)
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    payload["user_confirmed_no_submission"]["sha256"] = hashlib.sha256(
+        artifact_bytes
+    ).hexdigest()
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert state.proven_user_confirmed_no_submission(state_path) is None
+
+
 @pytest.mark.parametrize(
     "mutation",
     [


### PR DESCRIPTION
## Summary
- preserve exact v1.20.12 metadata-rename settlements when only the later task-id evidence field is absent
- continue requiring current task/ownership/receipt binding and reject every other field drift
- add positive and adversarial regression tests

## Verification
- focused metadata rename tests: 10 passed
- state + lifecycle suites: 130 passed (one Windows long-path temp rerun with short --basetemp)
- fast gate: PASS
- v3 contracts: PASS
- golden path smoke: PASS, submitted_question=false
- upstream runtime policy: Oracle 0.18.0 and DevSpace 1.0.8 in sync

Exact commit: 2e1ee7282fe4961629f8940762ee695c2185b52f