### PR TITLE
fix: select current Pro tier fail closed

### DIFF
--- a/bin/chatgpt_oracle_comprehensive.py
+++ b/bin/chatgpt_oracle_comprehensive.py
@@ -1246,7 +1246,7 @@ def _oracle_manifest(
         "model_strategy": "select",
         # Pro is the explicit highest effort in the current GPT-5.6 Sol UI;
         # regular comprehensive stages use the separately verified Extra High.
-        "thinking_time": "heavy" if stage == "pro" else "extra-high",
+        "thinking_time": "pro" if stage == "pro" else "extra-high",
         "research": "off",
         "archive": "auto",
         "parallel_parent_id": config["_parallel_parent_id"],

--- a/bin/chatgpt_oracle_profiles.py
+++ b/bin/chatgpt_oracle_profiles.py
@@ -36,6 +36,7 @@ DEVSPACE_APP_NAME = WORKSPACE_CONFIG.DEFAULT_APP_NAME
 # separate model row.  The validated Oracle current/LKG contracts verify that
 # Pro effort independently.
 PRO_MODEL = "gpt-5.6-sol"
+PRO_THINKING_TIME = "pro"
 PRO_COMPOSER_PROMPT = (
     "Read the attached prompt/instructions and all attached files, then provide read-only analysis only. "
     "Do not create, edit, delete, or rename files; do not run commands or change settings, accounts, or external state."
@@ -213,10 +214,10 @@ def build_launch_contract(
             "attachments": [str(path) for path in attachments],
             "model": PRO_MODEL,
             "reasoning_level": "Pro",
-            # `heavy` is Oracle's compatibility token for the current
-            # account-visible Pro power tier.  Keep it explicit so parent
-            # runners cannot fall back to the regular Extra High default.
-            "thinking_time": "heavy",
+            # The current ChatGPT effort menu exposes the fifth tier as Pro.
+            # Keep it explicit so parent runners cannot fall back to regular
+            # Extra High or the retired Heavy compatibility spelling.
+            "thinking_time": PRO_THINKING_TIME,
             "mission_path": str(mission),
             "composer_prompt": PRO_COMPOSER_PROMPT,
         })
@@ -235,7 +236,7 @@ def build_launch_contract(
             "model": PRO_MODEL,
             "model_strategy": "select",
             "reasoning_level": "Pro",
-            "thinking_time": "heavy",
+            "thinking_time": PRO_THINKING_TIME,
             "action_authority": "read-only",
             "write_handoff": "regular-gpt-5.6-extra-high-devspace",
             "mission_path": str(mission),

--- a/bin/chatgpt_oracle_run.py
+++ b/bin/chatgpt_oracle_run.py
@@ -1666,6 +1666,19 @@ def execute_run(
                 "write_thinking_time": "extra-high",
             },
         )
+    if (
+        STATE.is_pro_transport(str(config.transport or ""))
+        and str(config.thinking_time or "").strip().casefold() != STATE.PRO_THINKING_TIME
+    ):
+        raise OracleRunError(
+            "PRO_THINKING_TIME_LEGACY_FORBIDDEN",
+            "new Pro launches require the exact visible Pro tier; legacy Heavy is recovery-only",
+            {
+                "transport": config.transport,
+                "thinking_time": config.thinking_time,
+                "required_thinking_time": STATE.PRO_THINKING_TIME,
+            },
+        )
     validate_oracle_attachment_sizes(config)
     layout = STATE.create_layout(config, run_id=config.requested_run_id)
     transport_mission_path = layout.run_dir / "mission.md"
@@ -3621,7 +3634,7 @@ def _require_followup_parent(parent_run_dir: Path) -> tuple[dict[str, Any], dict
         str(state.get("transport") or "") != "pro-devspace-readonly"
         or str(profile.get("model") or "").casefold() != "gpt-5.6-sol"
         or str(profile.get("model_strategy") or "") != "select"
-        or str(profile.get("thinking_time") or "") != "heavy"
+        or not STATE.is_compatible_pro_thinking_time(profile.get("thinking_time"))
     ):
         raise OracleRunError(
             "FOLLOWUP_PARENT_PROFILE_FORBIDDEN",
@@ -3690,7 +3703,9 @@ def _followup_manifest_payload(
         "episode_policy": policy,
         "model": "gpt-5.6-sol",
         "model_strategy": "select",
-        "thinking_time": "heavy",
+        # A child is a new Pro submission even when its sealed parent used
+        # Oracle's historical Heavy spelling.
+        "thinking_time": STATE.PRO_THINKING_TIME,
         "research": str(profile.get("research") or "off"),
         "archive": "always" if archive_contract.get("was_archived") is True else "never",
         "task_outcome_contract": "v1",

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -359,8 +359,13 @@ ORACLE_MODEL_OPTION_MISSING_PRE_SUBMIT_RE = re.compile(
     r'in the model switcher\. Available: (?P<available>[^\r\n]{1,1000})\.$'
 )
 ORACLE_THINKING_TIME_PRE_SUBMIT_RE = re.compile(
-    r"Thinking time: (?:selection unverified \(requested |unknown outcome selecting )"
-    r"(?P<requested>[^);]+)\)?; refusing to submit without confirmed (?P<required>[^.]+)\.",
+    r"Thinking time: (?:"
+    r"(?:chip not found|menu not found|option not found|selection unverified|"
+    r"model kind not found(?: for [^();\r\n]+)?) \(requested (?P<requested_status>[^);]+)\)"
+    r"|unknown outcome selecting (?P<requested_unknown>[^;\r\n]+)"
+    r"|(?P<requested_unavailable>[^;\r\n]{1,160}?) is unavailable on this account "
+    r"\([^\r\n]*\)"
+    r"); refusing to submit without confirmed (?P<required>[^.]+)\.",
     re.IGNORECASE,
 )
 # Upstream Oracle copies a signed-in browser profile with rsync.  On POSIX
@@ -374,10 +379,24 @@ PROFILE_COPY_DEPENDENCY = "rsync"
 PROFILE_COPY_NATIVE_PLATFORMS = ("nt",)
 PRO_TRANSPORTS = frozenset(("pro-attachment-only", "pro-devspace", "pro-devspace-readonly"))
 DEVSPACE_TRANSPORTS = frozenset(("devspace", "pro-devspace", "pro-devspace-readonly"))
+# New GPT-5.6 Sol Pro launches use the provider's visible fifth effort tier.
+# Historical receipts used Oracle's retired compatibility token; read-only
+# recovery and follow-up validation must continue to recognize those sealed
+# records without ever rewriting them.
+PRO_THINKING_TIME = "pro"
+COMPATIBLE_PRO_THINKING_TIMES = frozenset((PRO_THINKING_TIME, "heavy"))
+VISIBLE_GPT56_SOL_THINKING_TIME_LABELS = (
+    "Instant", "Medium", "High", "Extra High", "Pro",
+)
 
 
 def is_pro_transport(transport: str) -> bool:
     return str(transport or "").strip().casefold() in PRO_TRANSPORTS
+
+
+def is_compatible_pro_thinking_time(value: object) -> bool:
+    """Accept only the current Pro tier plus persisted Heavy receipts."""
+    return str(value or "").strip().casefold() in COMPATIBLE_PRO_THINKING_TIMES
 
 
 def is_devspace_transport(transport: str) -> bool:
@@ -714,11 +733,16 @@ def load_manifest(
     model_strategy = str(payload.get("model_strategy") or "select").strip().casefold()
     if model_strategy not in {"select", "current", "ignore"}:
         raise OracleStateError("MODEL_STRATEGY_INVALID", "model_strategy must be select, current, or ignore")
-    thinking_time = str(payload.get("thinking_time") or "heavy").strip().casefold()
-    if thinking_time not in {"light", "standard", "extended", "extra-high", "heavy"}:
+    # A missing effort on a new Pro manifest is normalized to the visible Pro
+    # tier.  Keep the historical regular default intact for legacy regular
+    # manifests that omitted this optional field.
+    thinking_time = str(
+        payload.get("thinking_time") or (PRO_THINKING_TIME if is_pro_transport(transport) else "heavy")
+    ).strip().casefold()
+    if thinking_time not in {"light", "standard", "extended", "extra-high", *COMPATIBLE_PRO_THINKING_TIMES}:
         raise OracleStateError(
             "THINKING_TIME_INVALID",
-            "thinking_time must be light, standard, extended, extra-high, or heavy",
+            "thinking_time must be light, standard, extended, extra-high, pro, or legacy heavy",
         )
     if is_pro_transport(transport):
         if model.casefold() != "gpt-5.6-sol":
@@ -729,8 +753,14 @@ def load_manifest(
             )
         if model_strategy != "select":
             raise OracleStateError("PRO_MODEL_STRATEGY_INVALID", "Pro requires explicit model selection")
-        if thinking_time != "heavy":
-            raise OracleStateError("PRO_THINKING_TIME_INVALID", "Pro requires heavy reasoning")
+        # Parsing remains lossless for already-persisted Heavy-era manifests.
+        # The runner's pre-layout launch gate rejects this legacy spelling for
+        # every new current Pro execution before it can create a run or submit.
+        if not is_compatible_pro_thinking_time(thinking_time):
+            raise OracleStateError(
+                "PRO_THINKING_TIME_INVALID",
+                "Pro requires the explicit Pro reasoning tier",
+            )
     copy_profile_raw = str(payload.get("copy_profile") or "").strip()
     if copy_profile_raw:
         copy_profile = absolute_path(copy_profile_raw, label="copy_profile", must_exist=True)
@@ -1284,7 +1314,7 @@ def _validate_followup_reservation_for_child(
         or parent_state.get("transport") != "pro-devspace-readonly"
         or parent_profile.get("model") != "gpt-5.6-sol"
         or parent_profile.get("model_strategy") != "select"
-        or parent_profile.get("thinking_time") != "heavy"
+        or not is_compatible_pro_thinking_time(parent_profile.get("thinking_time"))
         or parent_owner is None
         or parent_browser is None
         or parent.get("ownership_receipt_sha256") != parent_owner.get("sha256")
@@ -2992,7 +3022,7 @@ def _standalone_pro_attachment_no_submission_evidence(
         or run_dir.name != run_id
         or str(profile.get("model") or "") != "gpt-5.6-sol"
         or str(profile.get("model_strategy") or "") != "select"
-        or str(profile.get("thinking_time") or "") != "heavy"
+        or not is_compatible_pro_thinking_time(profile.get("thinking_time"))
     ):
         return None
 
@@ -3230,7 +3260,7 @@ def _standalone_pro_no_submission_evidence(
         or run_dir.name != run_id
         or str(profile.get("model") or "") != "gpt-5.6-sol"
         or str(profile.get("model_strategy") or "") != "select"
-        or str(profile.get("thinking_time") or "") != "heavy"
+        or not is_compatible_pro_thinking_time(profile.get("thinking_time"))
     ):
         return None
     oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
@@ -3967,7 +3997,7 @@ def _followup_no_submission_evidence(
         or state.get("transport_status") not in {"failed", "not_submitted_user_confirmed"}
         or profile.get("model") != "gpt-5.6-sol"
         or profile.get("model_strategy") != "select"
-        or profile.get("thinking_time") != "heavy"
+        or not is_compatible_pro_thinking_time(profile.get("thinking_time"))
         or state.get("task_outcome") != "pending"
         or state.get("terminal_harvested") is True
         or state.get("parallel_parent_id") is not None
@@ -5370,7 +5400,7 @@ def proven_pre_submit_cdp_disconnect(state_path: Path) -> dict[str, Any] | None:
     if (
         str(profile.get("model") or "") != "gpt-5.6-sol"
         or str(profile.get("model_strategy") or "") != "select"
-        or str(profile.get("thinking_time") or "") != "heavy"
+        or not is_compatible_pro_thinking_time(profile.get("thinking_time"))
         or copy_profile != expected_profile
         or str(oracle.get("resolved_version") or "").removeprefix("oracle ").strip() != "0.17.1"
         or not locator
@@ -6252,7 +6282,31 @@ def proven_pre_submit_thinking_time_failure(state_path: Path) -> dict[str, Any] 
     if CHATGPT_CONVERSATION_URL_RE.search(combined):
         return None
     match = ORACLE_THINKING_TIME_PRE_SUBMIT_RE.search(combined)
-    if match is None or match.group("requested").casefold() != match.group("required").casefold():
+    if match is None:
+        return None
+    profile = state.get("profile") if isinstance(state.get("profile"), dict) else {}
+    requested_level = next(
+        value.strip()
+        for value in (
+            match.group("requested_status"),
+            match.group("requested_unknown"),
+            match.group("requested_unavailable"),
+        )
+        if value is not None
+    )
+    is_current_pro = (
+        is_pro_transport(str(state.get("transport") or ""))
+        and str(profile.get("model") or "").casefold() == "gpt-5.6-sol"
+        and str(profile.get("model_strategy") or "").casefold() == "select"
+        and str(profile.get("thinking_time") or "").casefold() == PRO_THINKING_TIME
+    )
+    # A current Pro launch may only settle this exact pre-submit refusal when
+    # Oracle itself says it requested Pro.  A different confirmed tier is the
+    # failure we must preserve fail-closed.  Heavy-era receipts retain the
+    # older same-level rule.
+    if is_current_pro and requested_level.casefold() != PRO_THINKING_TIME:
+        return None
+    if not is_current_pro and requested_level.casefold() != match.group("required").strip().casefold():
         return None
     oracle = state.get("oracle") if isinstance(state.get("oracle"), dict) else {}
     locator = str(oracle.get("session_locator") or oracle.get("slug") or "").strip()
@@ -6260,14 +6314,21 @@ def proven_pre_submit_thinking_time_failure(state_path: Path) -> dict[str, Any] 
         return None
     return {
         "schema": "codex.chatgpt.oracle-pre-submit-ui-failure/v1",
-        "code": "ORACLE_THINKING_TIME_PRE_SUBMIT_FAILED",
+        "code": (
+            "ORACLE_PRO_TIER_NOT_SELECTED"
+            if is_current_pro else "ORACLE_THINKING_TIME_PRE_SUBMIT_FAILED"
+        ),
         "oracle_locator": locator,
-        "requested_level": match.group("requested"),
+        "requested_level": requested_level,
+        "required_level": match.group("required").strip(),
         "stdout_sha256": hashlib.sha256(stdout_bytes).hexdigest(),
         "stderr_sha256": hashlib.sha256(stderr_bytes).hexdigest(),
         "output_absent": True,
         "conversation_url_absent": True,
-        "failure_reason": "oracle-thinking-time-selection-unverified",
+        "failure_reason": (
+            "oracle-pro-tier-not-selected"
+            if is_current_pro else "oracle-thinking-time-selection-unverified"
+        ),
     }
 
 
@@ -6385,6 +6446,7 @@ def settle_proven_pre_submit_failure(state_path: Path) -> dict[str, Any] | None:
                 "ORACLE_PROFILE_COPY_EBUSY_PRELAUNCH_FAILED",
                 "ORACLE_PROFILE_COPY_RSYNC_PRELAUNCH_FAILED",
                 "ORACLE_THINKING_TIME_PRE_SUBMIT_FAILED",
+                "ORACLE_PRO_TIER_NOT_SELECTED",
                 "ORACLE_LAUNCH_FLAGS_MUTUALLY_EXCLUSIVE_PRELAUNCH_FAILED",
                 "ORACLE_MANUAL_LOGIN_PROFILE_UNINITIALIZED_PRELAUNCH_FAILED",
                 "ORACLE_CDP_DISCONNECT_PRE_SUBMIT_FAILED",
@@ -6399,6 +6461,8 @@ def settle_proven_pre_submit_failure(state_path: Path) -> dict[str, Any] | None:
             if evidence["code"] == "ORACLE_PROFILE_COPY_RSYNC_PRELAUNCH_FAILED"
             else "oracle-thinking-time-pre-submit"
             if evidence["code"] == "ORACLE_THINKING_TIME_PRE_SUBMIT_FAILED"
+            else "oracle-pro-tier-not-selected-pre-submit"
+            if evidence["code"] == "ORACLE_PRO_TIER_NOT_SELECTED"
             else "oracle-launch-flags-mutually-exclusive-pre-submit"
             if evidence["code"] == "ORACLE_LAUNCH_FLAGS_MUTUALLY_EXCLUSIVE_PRELAUNCH_FAILED"
             else "oracle-manual-login-profile-uninitialized-pre-submit"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,22 @@
 # 기술 변경 기록
 
+## 1.20.14 - Select the current visible Pro effort fail-closed
+
+- New GPT-5.6 Sol Pro and read-only Pro follow-up submissions now pass Oracle
+  0.18.0's explicit `pro` thinking-time token instead of the retired `heavy`
+  compatibility spelling. A missing effort on a new Pro manifest normalizes to
+  `pro`, while regular non-Pro defaults remain unchanged.
+- Historical `heavy` runs, immutable receipts, no-submission evidence, and
+  follow-up parents remain readable and recoverable without rewriting their
+  authority. Only new child submissions are normalized to `pro`; a newly
+  supplied raw Pro manifest that still requests `heavy` is rejected before a
+  run directory or subprocess can be created.
+- If the current ChatGPT effort selector cannot prove that the visible `Pro`
+  radio is selected, the run fails before submission as
+  `ORACLE_PRO_TIER_NOT_SELECTED`; it may not silently continue on Extra High.
+  Regression coverage binds the current five-label effort menu and preserves
+  the bounded legacy Oracle 0.17.1 compatibility paths.
+
 ## 1.20.13 - Preserve exact task-bound metadata settlements
 
 - A `v1.20.12` Oracle metadata-rename settlement created immediately before

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.13",
+  "version": "1.20.14",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.13",
+  "version": "1.20.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.13",
+      "version": "1.20.14",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.13",
+  "version": "1.20.14",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/tests/fixtures/oracle-0180-gpt56-sol-effort-menu.json
+++ b/tests/fixtures/oracle-0180-gpt56-sol-effort-menu.json
@@ -1,0 +1,14 @@
+{
+  "schema": "codex.chatgpt.oracle-effort-menu-fixture/v1",
+  "source": "live-gpt-5.6-sol-model-picker-diagnostic",
+  "requested_model": "gpt-5.6-sol",
+  "requested_effort": "pro",
+  "items": [
+    {"role": "menuitemradio", "label": "Instant", "ariaChecked": false},
+    {"role": "menuitemradio", "label": "Medium", "ariaChecked": false},
+    {"role": "menuitemradio", "label": "High", "ariaChecked": false},
+    {"role": "menuitemradio", "label": "Extra High", "ariaChecked": true},
+    {"role": "menuitemradio", "label": "Pro", "ariaChecked": false}
+  ],
+  "advanced_view_text": "ModelGPT-5.6 SolEffortExtra High"
+}

--- a/tests/test_chatgpt_oracle_compat.py
+++ b/tests/test_chatgpt_oracle_compat.py
@@ -478,6 +478,86 @@ try {
     assert retry_probe.returncode == 0, retry_probe.stderr
 
 
+def test_published_0180_pro_effort_is_strict_for_current_five_row_menu(tmp_path: Path) -> None:
+    compat = load_compat()
+    configured = os.environ.get("ORACLE_018_PACKAGE_ROOT", "").strip()
+    source = Path(configured) if configured else Path("__oracle_018_cache_unset__")
+    if not source.is_dir():
+        if os.environ.get("CI"):
+            pytest.fail("CI must prepare the exact published Oracle 0.18.0 package")
+        pytest.skip("published Oracle 0.18.0 package root is unavailable")
+    package = tmp_path / "oracle-pro-effort"
+    shutil.copytree(source, package)
+    compat.ensure_oracle_compatibility(
+        "oracle 0.18.0", package_root=package, backup_root=tmp_path / "backup-pro-effort"
+    )
+    target = package / "dist/src/browser/actions/thinkingTime.js"
+    fixture = json.loads(
+        (Path(__file__).parent / "fixtures" / "oracle-0180-gpt56-sol-effort-menu.json")
+        .read_text(encoding="utf-8")
+    )
+    labels = [item["label"] for item in fixture["items"]]
+    assert labels == ["Instant", "Medium", "High", "Extra High", "Pro"]
+    assert "Heavy" not in labels
+    node = shutil.which("node")
+    assert node is not None
+    source_text = target.read_text(encoding="utf-8")
+    source_text = source_text.replace(
+        'import { MENU_CONTAINER_SELECTOR, MENU_ITEM_SELECTOR, MODEL_BUTTON_SELECTOR, } from "../constants.js";',
+        'const MENU_CONTAINER_SELECTOR=""; const MENU_ITEM_SELECTOR=""; const MODEL_BUTTON_SELECTOR="";',
+    ).replace(
+        'import { logDomFailure } from "../domDebug.js";',
+        'const logDomFailure=async()=>{};',
+    ).replace(
+        'import { buildClickDispatcher } from "./domEvents.js";',
+        'const buildClickDispatcher=()=>"";',
+    ).replace(
+        'import { BrowserAutomationError } from "../../oracle/errors.js";',
+        'class BrowserAutomationError extends Error { constructor(message, details) { super(message); this.details=details; } }',
+    )
+    test_module = tmp_path / "thinkingTime-current-contract.mjs"
+    test_module.write_text(source_text, encoding="utf-8")
+    assert not source_text.startswith("import ")
+    script = f"""
+import {{ ensureThinkingTime }} from {json.dumps(test_module.as_uri())};
+const diagnostic = {json.dumps(fixture)};
+const runCase = async (firstResult) => {{
+  let calls = 0;
+  const Runtime = {{ evaluate: async () => ({{ result: {{ value: calls++ === 0 ? firstResult : null }} }}) }};
+  const logs = [];
+  try {{
+    await ensureThinkingTime(Runtime, 'pro', (message) => logs.push(message), 'gpt-5.6-sol');
+    return {{ ok: true, logs }};
+  }} catch (error) {{
+    return {{ ok: false, message: error.message, logs }};
+  }}
+}};
+const selected = await runCase({{ status: 'already-selected', label: 'Pro', modelKind: 'gpt56', diagnostic }});
+const missing = await runCase({{ status: 'option-not-found', modelKind: 'gpt56', diagnostic }});
+const unverified = await runCase({{ status: 'selection-unverified', modelKind: 'gpt56', diagnostic }});
+const unavailable = await runCase({{
+  status: 'option-disabled', label: 'Pro', notice: 'temporarily unavailable', modelKind: 'gpt56', diagnostic
+}});
+console.log(JSON.stringify({{ selected, missing, unverified, unavailable }}));
+"""
+    completed = subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout)
+    assert result["selected"] == {
+        "ok": True,
+        "logs": ["[browser] Thinking time: Pro (already selected)"],
+    }
+    for case in ("missing", "unverified", "unavailable"):
+        assert result[case]["ok"] is False
+        assert "refusing to submit without confirmed Pro" in result[case]["message"]
+
+
 def test_oracle_session_metadata_retry_patch_is_bounded_to_windows_transient_errors() -> None:
     patch_text = (
         Path(__file__).resolve().parents[1]

--- a/tests/test_chatgpt_oracle_comprehensive.py
+++ b/tests/test_chatgpt_oracle_comprehensive.py
@@ -99,7 +99,7 @@ def test_ultra_economy_dry_run_starts_with_explicit_pro_design(tmp_path: Path, m
     assert result["stage"] == "pro"
     assert result["workflow_profile"] == "ultra-economy"
     assert seen["model"] == "gpt-5.6-sol"
-    assert seen["thinking_time"] == "heavy"
+    assert seen["thinking_time"] == "pro"
     assert seen["transport"] == "pro-devspace-readonly"
 
 

--- a/tests/test_chatgpt_oracle_dispatch.py
+++ b/tests/test_chatgpt_oracle_dispatch.py
@@ -120,11 +120,11 @@ def test_pro_attachment_compiles_attachment_only_oracle_and_manual_never_launche
     value = json.loads(pro_target.read_text(encoding="utf-8"))
     assert pro["contract"]["route"] == "oracle-pro-attachment-only"
     assert pro["contract"]["task_kind"] == "pro"
-    assert pro["contract"]["thinking_time"] == "heavy"
+    assert pro["contract"]["thinking_time"] == "pro"
     assert value["transport"] == "pro-attachment-only"
     assert value["task_kind"] == "pro"
     assert value["model"] == "gpt-5.6-sol"
-    assert value["thinking_time"] == "heavy"
+    assert value["thinking_time"] == "pro"
     assert value["attachments"] == [str(prompt.resolve()), str(packet.resolve())]
     assert "app_name" not in value
 
@@ -152,7 +152,7 @@ def test_pro_defaults_to_devspace_without_attachments(tmp_path: Path) -> None:
     assert value["app_name"] == "DevSpace"
     assert value["model"] == "gpt-5.6-sol"
     assert value["model_strategy"] == "select"
-    assert value["thinking_time"] == "heavy"
+    assert value["thinking_time"] == "pro"
     assert value["research"] == "off"
     assert value["task_outcome_contract"] == "v1"
     assert "attachments" not in value
@@ -186,4 +186,4 @@ def test_pro_cli_dry_run_validates_compiled_manifest_without_submission(
     assert emitted["run"]["transport"] == "pro-attachment-only"
     assert manifest["task_kind"] == "pro"
     assert manifest["model"] == "gpt-5.6-sol"
-    assert manifest["thinking_time"] == "heavy"
+    assert manifest["thinking_time"] == "pro"

--- a/tests/test_chatgpt_oracle_followup.py
+++ b/tests/test_chatgpt_oracle_followup.py
@@ -46,7 +46,7 @@ def make_parent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         "project_root": str(project), "mission_path": str(mission), "app_name": "codex",
         "mode": "browser", "transport": "pro-devspace-readonly", "run_root": str(run_root),
         "oracle_command": ["oracle"], "model": "gpt-5.6-sol", "model_strategy": "select",
-        "thinking_time": "heavy", "research": "off", "task_outcome_contract": "v1",
+        "thinking_time": "pro", "research": "off", "task_outcome_contract": "v1",
         "source_thread_id": OWNER,
     }), encoding="utf-8")
     config = runner.STATE.load_manifest(manifest, bind_runtime_task=True)
@@ -943,6 +943,33 @@ def test_followup_dry_run_is_same_task_and_same_conversation_without_writes(tmp_
         archive_contract=result["round_receipt_plan"]["parent"]["archive_contract"],
     )
     assert payload["archive"] == "always"
+    assert payload["thinking_time"] == "pro"
+
+
+def test_followup_accepts_sealed_heavy_parent_but_emits_pro_child(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner, parent, mission = make_parent(tmp_path, monkeypatch)
+    parent_state = runner.STATE.load_state(parent.state_path)
+    parent_state["profile"]["thinking_time"] = "heavy"
+    runner.STATE.write_json_atomic(parent.state_path, parent_state)
+
+    result = runner.followup_run(
+        parent.run_dir,
+        mission_path=mission,
+        round_key="legacy-heavy-parent",
+        run_id="followup-legacy-heavy-parent-0001",
+        dry_run=True,
+    )
+
+    assert result["ok"] is True
+    child_payload = runner._followup_manifest_payload(
+        runner.STATE.load_state(parent.state_path),
+        mission_path=mission,
+        run_id="followup-legacy-heavy-child-0001",
+        archive_contract=result["round_receipt_plan"]["parent"]["archive_contract"],
+    )
+    assert child_payload["thinking_time"] == "pro"
 
 
 def test_followup_actual_preflight_failure_has_child_state_logs_and_result_receipt(

--- a/tests/test_chatgpt_oracle_profiles.py
+++ b/tests/test_chatgpt_oracle_profiles.py
@@ -79,7 +79,7 @@ def test_pro_attachment_is_oracle_attachment_only_and_manual_launches_nothing(tm
     assert pro["devspace_required"] is False
     assert pro["model"] == "gpt-5.6-sol"
     assert pro["task_kind"] == "pro"
-    assert pro["thinking_time"] == "heavy"
+    assert pro["thinking_time"] == "pro"
     assert pro["attachment_policy"] == "always"
     assert pro["attachments"] == [str(mission), str(packet)]
     assert pro["composer_prompt"].startswith(
@@ -138,7 +138,8 @@ def test_pro_is_explicit_readonly_devspace_without_attachments(tmp_path: Path) -
     assert contract["app_name"] == "DevSpace"
     assert contract["model"] == "gpt-5.6-sol"
     assert contract["model_strategy"] == "select"
-    assert contract["thinking_time"] == "heavy"
+    assert contract["thinking_time"] == "pro"
+    assert profiles.PRO_THINKING_TIME == "pro"
     assert contract["research"] is False
     assert contract["attachments"] == []
     assert contract["action_authority"] == "read-only"

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -60,7 +60,7 @@ def pro_manifest(tmp_path: Path, **extra) -> Path:
         app_name=None,
         model="gpt-5.6-sol",
         model_strategy="select",
-        thinking_time="heavy",
+        thinking_time="pro",
         attachments=[str(prompt.resolve()), str(packet.resolve())],
         mission_path=str(prompt.resolve()),
         **extra,
@@ -68,13 +68,14 @@ def pro_manifest(tmp_path: Path, **extra) -> Path:
 
 
 def pro_readonly_manifest(tmp_path: Path, **extra) -> Path:
+    thinking_time = extra.pop("thinking_time", "pro")
     return manifest(
         tmp_path,
         transport="pro-devspace-readonly",
         app_name="DevSpace",
         model="gpt-5.6-sol",
         model_strategy="select",
-        thinking_time="heavy",
+        thinking_time=thinking_time,
         research="off",
         task_outcome_contract="v1",
         **extra,
@@ -950,10 +951,10 @@ def thinking_time_selection_unverified_popen(command, **kwargs):
         b"oracle 0.17.1\n"
         b"Session: oracle-test-thinking-time\n"
         b"Launching browser mode (target=GPT-5.6 Sol; requested=gpt-5.6-sol) with 2 files.\n"
-        b"ERROR: Thinking time: selection unverified (requested Heavy); "
-        b"refusing to submit without confirmed Heavy.\n"
+        b"ERROR: Thinking time: selection unverified (requested Pro); "
+        b"refusing to submit without confirmed Pro.\n"
         b"User error (browser-automation): Thinking time: selection unverified "
-        b"(requested Heavy); refusing to submit without confirmed Heavy.\n"
+        b"(requested Pro); refusing to submit without confirmed Pro.\n"
     )
     kwargs["stdout"].flush()
     return Process(1, [])
@@ -964,10 +965,38 @@ def thinking_time_unknown_outcome_popen(command, **kwargs):
         b"oracle 0.17.1\n"
         b"Session: oracle-test-thinking-time-unknown\n"
         b"Launching browser mode (target=GPT-5.6 Sol; requested=gpt-5.6-sol) with 2 files.\n"
-        b"ERROR: Thinking time: unknown outcome selecting Heavy; "
-        b"refusing to submit without confirmed Heavy.\n"
-        b"User error (browser-automation): Thinking time: unknown outcome selecting Heavy; "
-        b"refusing to submit without confirmed Heavy.\n"
+        b"ERROR: Thinking time: unknown outcome selecting Pro; "
+        b"refusing to submit without confirmed Extra High.\n"
+        b"User error (browser-automation): Thinking time: unknown outcome selecting Pro; "
+        b"refusing to submit without confirmed Extra High.\n"
+    )
+    kwargs["stdout"].flush()
+    return Process(1, [])
+
+
+def thinking_time_option_not_found_popen(command, **kwargs):
+    kwargs["stdout"].write(
+        b"oracle 0.18.0\n"
+        b"Session: oracle-test-thinking-time-option-not-found\n"
+        b"Launching browser mode (target=GPT-5.6 Sol; requested=gpt-5.6-sol) with 2 files.\n"
+        b"ERROR: Thinking time: option not found (requested Pro); "
+        b"refusing to submit without confirmed Pro.\n"
+        b"User error (browser-automation): Thinking time: option not found "
+        b"(requested Pro); refusing to submit without confirmed Pro.\n"
+    )
+    kwargs["stdout"].flush()
+    return Process(1, [])
+
+
+def thinking_time_pro_unavailable_popen(command, **kwargs):
+    kwargs["stdout"].write(
+        b"oracle 0.18.0\n"
+        b"Session: oracle-test-thinking-time-unavailable\n"
+        b"Launching browser mode (target=GPT-5.6 Sol; requested=gpt-5.6-sol) with 2 files.\n"
+        b"ERROR: Thinking time: Pro is unavailable on this account (rate limited); "
+        b"refusing to submit without confirmed Pro.\n"
+        b"User error (browser-automation): Thinking time: Pro is unavailable on this account "
+        b"(rate limited); refusing to submit without confirmed Pro.\n"
     )
     kwargs["stdout"].flush()
     return Process(1, [])
@@ -1222,13 +1251,32 @@ def test_pro_devspace_dry_run_uses_readonly_handoff_without_file_transport(tmp_p
     assert "--browser-attachments" not in argv
     assert "--file" not in argv
     assert argv[argv.index("--model") + 1] == "gpt-5.6-sol"
-    assert argv[argv.index("--browser-thinking-time") + 1] == "heavy"
+    assert argv[argv.index("--browser-thinking-time") + 1] == "pro"
     assert prompt.startswith(f"@DevSpace First open exactly this project root in checkout mode: {tmp_path}.")
     assert f"Then read the read-only mission file: {tmp_path / 'mission.md'}." in prompt
     assert "Do not open the mission directory, a parent, a child" in prompt
     assert prompt.index(str(tmp_path)) < prompt.index(str(tmp_path / "mission.md"))
     assert "Perform read-only work only; do not modify files" in prompt
     assert preflight_calls == [True]
+
+
+def test_new_pro_readonly_heavy_manifest_is_rejected_before_layout_or_subprocess(
+    tmp_path: Path,
+) -> None:
+    runner = load_runner()
+    calls: list[str] = []
+
+    with pytest.raises(runner.OracleRunError) as failure:
+        runner.execute_run(
+            pro_readonly_manifest(tmp_path, thinking_time="heavy"),
+            dry_run=True,
+            run_factory=lambda *_args, **_kwargs: calls.append("run"),
+            popen_factory=lambda *_args, **_kwargs: calls.append("popen"),
+        )
+
+    assert failure.value.code == "PRO_THINKING_TIME_LEGACY_FORBIDDEN"
+    assert calls == []
+    assert not (tmp_path / "runs").exists()
 
 
 def test_pro_readonly_dry_run_fails_before_layout_without_fresh_app_read_gate(
@@ -1283,7 +1331,7 @@ def test_new_writable_pro_manifest_is_rejected_before_layout_or_browser(tmp_path
         app_name="DevSpace",
         model="gpt-5.6-sol",
         model_strategy="select",
-        thinking_time="heavy",
+        thinking_time="pro",
         research="off",
         task_outcome_contract="v1",
     )
@@ -2418,9 +2466,9 @@ def test_thinking_time_selection_unverified_is_proven_pre_submit_and_releases_pr
     assert state["session_authority"] == "pre_submit"
     assert state["transport_status"] == "failed_pre_submit"
     assert state["task_outcome"] == "not_executed"
-    assert state["task_outcome_reason"] == "oracle-thinking-time-pre-submit"
-    assert state["pre_submit_failure"]["code"] == "ORACLE_THINKING_TIME_PRE_SUBMIT_FAILED"
-    assert state["pre_submit_failure"]["requested_level"] == "Heavy"
+    assert state["task_outcome_reason"] == "oracle-pro-tier-not-selected-pre-submit"
+    assert state["pre_submit_failure"]["code"] == "ORACLE_PRO_TIER_NOT_SELECTED"
+    assert state["pre_submit_failure"]["requested_level"] == "Pro"
     assert runner.STATE.unresolved_project_sessions(
         runner.STATE.load_manifest(pro_manifest(tmp_path)).run_root,
         tmp_path,
@@ -2445,9 +2493,44 @@ def test_thinking_time_unknown_outcome_is_proven_pre_submit_and_releases_project
     assert state["session_authority"] == "pre_submit"
     assert state["transport_status"] == "failed_pre_submit"
     assert state["task_outcome"] == "not_executed"
-    assert state["task_outcome_reason"] == "oracle-thinking-time-pre-submit"
-    assert state["pre_submit_failure"]["code"] == "ORACLE_THINKING_TIME_PRE_SUBMIT_FAILED"
-    assert state["pre_submit_failure"]["requested_level"] == "Heavy"
+    assert state["task_outcome_reason"] == "oracle-pro-tier-not-selected-pre-submit"
+    assert state["pre_submit_failure"]["code"] == "ORACLE_PRO_TIER_NOT_SELECTED"
+    assert state["pre_submit_failure"]["requested_level"] == "Pro"
+    assert state["pre_submit_failure"]["required_level"] == "Extra High"
+    assert runner.STATE.unresolved_project_sessions(
+        runner.STATE.load_manifest(pro_manifest(tmp_path)).run_root,
+        tmp_path,
+    ) == []
+
+
+@pytest.mark.parametrize(
+    "popen_factory",
+    (thinking_time_option_not_found_popen, thinking_time_pro_unavailable_popen),
+)
+def test_current_pro_selector_failures_are_proven_pre_submit_and_release_project(
+    tmp_path: Path,
+    popen_factory,
+) -> None:
+    runner = load_runner()
+    seed = tmp_path.parent / f"{tmp_path.name}-profile"
+    seed.mkdir(parents=True)
+    result = execute_run(
+        runner,
+        pro_manifest(tmp_path, run_id="e" * 32, copy_profile=str(seed)),
+        run_factory=version_0171_runner,
+        popen_factory=popen_factory,
+    )
+    state = runner.STATE.load_state(Path(result["run_dir"]) / "state.json")
+
+    assert result["status"] == "pre_submit_failed"
+    assert result["safe_for_fresh_run"] is True
+    assert state["session_authority"] == "pre_submit"
+    assert state["transport_status"] == "failed_pre_submit"
+    assert state["task_outcome"] == "not_executed"
+    assert state["task_outcome_reason"] == "oracle-pro-tier-not-selected-pre-submit"
+    assert state["pre_submit_failure"]["code"] == "ORACLE_PRO_TIER_NOT_SELECTED"
+    assert state["pre_submit_failure"]["requested_level"] == "Pro"
+    assert state["pre_submit_failure"]["required_level"] == "Pro"
     assert runner.STATE.unresolved_project_sessions(
         runner.STATE.load_manifest(pro_manifest(tmp_path)).run_root,
         tmp_path,
@@ -2734,7 +2817,7 @@ def test_cdp_disconnect_with_exact_unsent_oracle_ledger_is_pre_submit(
 
     result = execute_run(
         runner,
-        pro_readonly_manifest(tmp_path, run_id="c" * 32),
+        pro_readonly_manifest(tmp_path, run_id="c" * 32, thinking_time="pro"),
         run_factory=version_0171_runner,
         popen_factory=cdp_disconnect_pre_submit_popen(session_root),
     )
@@ -2767,7 +2850,7 @@ def test_cdp_disconnect_keeps_lock_when_unsent_proof_is_incomplete(
 
     result = execute_run(
         runner,
-        pro_readonly_manifest(tmp_path, run_id=(variation[0] * 32)),
+        pro_readonly_manifest(tmp_path, run_id=(variation[0] * 32), thinking_time="pro"),
         run_factory=version_0171_runner,
         popen_factory=cdp_disconnect_pre_submit_popen(session_root, variation=variation),
     )
@@ -2790,7 +2873,7 @@ def test_recovery_repairs_legacy_unsent_cdp_disconnect_without_oracle_call(
     monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
     initial = execute_run(
         runner,
-        pro_readonly_manifest(tmp_path, run_id="e" * 32),
+        pro_readonly_manifest(tmp_path, run_id="e" * 32, thinking_time="pro"),
         run_factory=version_0171_runner,
         popen_factory=cdp_disconnect_pre_submit_popen(session_root),
     )

--- a/tests/test_chatgpt_oracle_state.py
+++ b/tests/test_chatgpt_oracle_state.py
@@ -722,7 +722,7 @@ def test_readonly_pro_auto_archive_normalizes_to_never_for_followup(tmp_path: Pa
         transport="pro-devspace-readonly",
         model="gpt-5.6-sol",
         model_strategy="select",
-        thinking_time="heavy",
+        thinking_time="pro",
         archive="auto",
         task_outcome_contract="v1",
     ))
@@ -733,7 +733,7 @@ def test_readonly_pro_auto_archive_normalizes_to_never_for_followup(tmp_path: Pa
         transport="pro-devspace-readonly",
         model="gpt-5.6-sol",
         model_strategy="select",
-        thinking_time="heavy",
+        thinking_time="pro",
         archive="always",
         task_outcome_contract="v1",
     ))
@@ -766,7 +766,7 @@ def test_pro_manifest_is_attachment_only_and_hashes_exact_files(tmp_path: Path) 
             transport="pro-attachment-only",
             app_name=None,
             model="gpt-5.6-sol",
-            thinking_time="heavy",
+            thinking_time="pro",
             attachments=[str(prompt.resolve()), str(packet.resolve())],
         )
     )
@@ -851,7 +851,7 @@ def test_historical_writable_pro_stays_loadable_and_current_pro_is_readonly(tmp_
         app_name="DevSpace",
         model="gpt-5.6-sol",
         model_strategy="select",
-        thinking_time="heavy",
+        thinking_time="pro",
         research="off",
         task_outcome_contract="v1",
     ))
@@ -862,6 +862,56 @@ def test_historical_writable_pro_stays_loadable_and_current_pro_is_readonly(tmp_
     assert f"Then read the read-only mission file: {mission.resolve()}." in current_prompt
     assert "Perform read-only work only; do not modify files, settings, accounts, or external state." in current_prompt
     assert "create, edit, and remove mission-owned files and run commands" not in current_prompt
+
+
+def test_pro_tier_uses_visible_pro_and_parses_legacy_heavy_losslessly(tmp_path: Path) -> None:
+    state = load_state()
+    mission = tmp_path / "mission.md"
+    mission.write_text("read only", encoding="utf-8")
+
+    common = {
+        "transport": "pro-devspace-readonly",
+        "app_name": "DevSpace",
+        "model": "gpt-5.6-sol",
+        "model_strategy": "select",
+        "research": "off",
+        "task_outcome_contract": "v1",
+    }
+    current = state.load_manifest(manifest(tmp_path, mission.resolve(), thinking_time="pro", **common))
+    legacy = state.load_manifest(manifest(tmp_path, mission.resolve(), thinking_time="heavy", **common))
+
+    assert current.thinking_time == "pro"
+    assert legacy.thinking_time == "heavy"
+    assert state.is_compatible_pro_thinking_time("pro") is True
+    # Historical state/receipt validators still recognize the sealed spelling.
+    assert state.is_compatible_pro_thinking_time("heavy") is True
+    assert state.is_compatible_pro_thinking_time("extra-high") is False
+    fixture = json.loads(
+        (Path(__file__).parent / "fixtures" / "oracle-0180-gpt56-sol-effort-menu.json")
+        .read_text(encoding="utf-8")
+    )
+    observed_labels = tuple(item["label"] for item in fixture["items"])
+    assert observed_labels == state.VISIBLE_GPT56_SOL_THINKING_TIME_LABELS
+    assert "Heavy" not in observed_labels
+    assert next(item for item in fixture["items"] if item["ariaChecked"])["label"] == "Extra High"
+    assert next(item for item in fixture["items"] if item["label"] == "Pro")["ariaChecked"] is False
+
+
+def test_missing_new_pro_effort_normalizes_to_visible_pro(tmp_path: Path) -> None:
+    state = load_state()
+    mission = tmp_path / "mission.md"
+    mission.write_text("read only", encoding="utf-8")
+    config = state.load_manifest(manifest(
+        tmp_path,
+        mission.resolve(),
+        transport="pro-devspace-readonly",
+        app_name="DevSpace",
+        model="gpt-5.6-sol",
+        model_strategy="select",
+        research="off",
+        task_outcome_contract="v1",
+    ))
+    assert config.thinking_time == "pro"
 
 
 def test_pro_composer_identity_changes_with_project_or_attachment_bytes(tmp_path: Path) -> None:
@@ -879,7 +929,7 @@ def test_pro_composer_identity_changes_with_project_or_attachment_bytes(tmp_path
             transport="pro-attachment-only",
             app_name=None,
             model="gpt-5.6-sol",
-            thinking_time="heavy",
+            thinking_time="pro",
             attachments=[str(prompt.resolve()), str(packet.resolve())],
         ))
 
@@ -914,7 +964,7 @@ def test_pro_manifest_fails_closed_without_exact_contract(tmp_path: Path, extra:
         "transport": "pro-attachment-only",
         "app_name": None,
         "model": "gpt-5.6-sol",
-        "thinking_time": "heavy",
+        "thinking_time": "pro",
         "attachments": [str(prompt.resolve())],
     }
     value.update(extra)
@@ -1498,7 +1548,7 @@ def test_connector_identity_guard_interpolates_arbitrary_app_names(app_name: str
             {
                 "model": "gpt-5.6-sol",
                 "model_strategy": "select",
-                "thinking_time": "heavy",
+                "thinking_time": "pro",
                 "research": "off",
                 "task_outcome_contract": "v1",
             },
@@ -1508,7 +1558,7 @@ def test_connector_identity_guard_interpolates_arbitrary_app_names(app_name: str
             {
                 "model": "gpt-5.6-sol",
                 "model_strategy": "select",
-                "thinking_time": "heavy",
+                "thinking_time": "pro",
                 "research": "off",
                 "task_outcome_contract": "v1",
             },
@@ -1551,7 +1601,7 @@ def test_attachment_prompt_omits_connector_identity_guard(tmp_path: Path) -> Non
             transport="pro-attachment-only",
             app_name=None,
             model="gpt-5.6-sol",
-            thinking_time="heavy",
+            thinking_time="pro",
             attachments=[str(mission.resolve())],
         )
     )
@@ -1584,7 +1634,7 @@ def test_pro_devspace_connector_guard_prompt_stays_single_line(tmp_path: Path) -
             transport="pro-devspace",
             model="gpt-5.6-sol",
             model_strategy="select",
-            thinking_time="heavy",
+            thinking_time="pro",
             research="off",
             task_outcome_contract="v1",
         )

--- a/tests/test_ultra_economy_mode.py
+++ b/tests/test_ultra_economy_mode.py
@@ -105,7 +105,7 @@ def test_ultra_economy_runtime_dry_run_is_pro_first_and_readonly(tmp_path: Path,
     result = module.run_workflow(workflow_manifest(tmp_path), dry_run=True, oracle_execute=preview)
     assert result["stage"] == "pro"
     assert seen["transport"] == "pro-devspace-readonly"
-    assert seen["thinking_time"] == "heavy"
+    assert seen["thinking_time"] == "pro"
 
 
 def test_ultra_economy_requires_separate_explicit_pro_authority(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- emit Oracle 0.18.0's explicit `pro` effort token for every new GPT-5.6 Sol Pro route
- reject newly supplied legacy `heavy` Pro manifests before run layout or subprocess creation
- preserve sealed historical `heavy` state and follow-up parents without rewriting them; child rounds emit `pro`
- classify current Pro selector failures as `ORACLE_PRO_TIER_NOT_SELECTED` before submission
- bind the live five-row effort menu fixture (Instant/Medium/High/Extra High/Pro) and exercise the published 0.18.0 strict Pro contract

## Verification
- 498 passed, 10 skipped: Oracle state/profiles/run/comprehensive/followup/dispatch/Ultra Economy + current Pro contract
- 46 passed, 2 skipped: Oracle compatibility suite with exact published 0.18.0 package
- 32 passed: portable/install lifecycle with bounded short Windows temp path
- 26 passed: upstream runtime and global browser policy
- 6 passed: exact new-heavy rejection, legacy-heavy recovery/follow-up, five-row Pro fail-closed regression
- `git diff --check`
- `py_compile` for all changed runner modules

## Independent review
A read-only verifier found that an earlier draft still accepted `heavy` for new raw Pro launches. This commit closes that gap at the pre-layout execution gate while keeping historical parsing and recovery lossless.

## Known unrelated full-suite environment failures
The broad repository run reached 1478 passed / 24 skipped and 73 failures, all in retired agbrowse skill tests because this workstation lacks the external `agbrowse-0.1.18` contract/executable. The focused Oracle, compatibility, lifecycle, and policy gates above are green.