### PR TITLE
fix: verify current Pro power slider

### DIFF
--- a/bin/chatgpt_oracle_compat.py
+++ b/bin/chatgpt_oracle_compat.py
@@ -245,6 +245,11 @@ PATCHES = {
         "pristine": "312b45c44d4cd69a3a057e7bd1584b58182b4b37bc88f6ce6c7d11e216267c81",
         "patched": "f3b405464515e858c9f773d67fa0e94bca07dadff8ea49caa7859ad37e730ff7",
     },
+    "dist/src/browser/actions/thinkingTime.js": {
+        "patch": "thinkingTime.gpt56-pro-power-slider.patch",
+        "pristine": "3d9d06b08417bca3b2d646eb4d46887d26c5de7c068d1e995c73b6b6e2f61199",
+        "patched": "978f754ba4011957790530474d27d629a8d353dd449f8e2636e02a9abd27b81a",
+    },
     "dist/src/browser/actions/assistantResponse.js": {
         "patch": "../0.17.1/assistantResponse.terminal-marker-fallback.patch",
         "pristine": "93d2465ed7dce43d8093a91bada7656bc9ba7ba3729d2fcc43229fa8aa6e36de",

--- a/bin/oracle-compat/0.18.0/thinkingTime.gpt56-pro-power-slider.patch
+++ b/bin/oracle-compat/0.18.0/thinkingTime.gpt56-pro-power-slider.patch
@@ -1,0 +1,108 @@
+diff --git a/dist/src/browser/actions/thinkingTime.js b/dist/src/browser/actions/thinkingTime.js
+--- a/dist/src/browser/actions/thinkingTime.js
++++ b/dist/src/browser/actions/thinkingTime.js
+@@ -849,6 +849,90 @@ function buildThinkingTimeExpression(level, desiredModel) {
+       'effort', 'aufwand', '强度', '努力', '推論レベル',
+       'esfuerzo', 'esforco', 'sforzo', 'inspanning', 'wysilek',
+     ];
++    const POWER_SIMPLE_VIEW_SELECTOR =
++      '[data-testid="composer-model-picker-slider-simple-view"]';
++    const readPowerStep = (view) => {
++      const control = view?.querySelector?.('[role="slider"], input[type="range"]');
++      const ariaValue = Number(control?.getAttribute?.('aria-valuenow') ?? '');
++      if (Number.isInteger(ariaValue) && ariaValue >= 1 && ariaValue <= 5) {
++        return ariaValue;
++      }
++      const compact = nodeLabel(view).replace(/\\s+/g, '');
++      for (let candidate = 1; candidate <= 5; candidate += 1) {
++        if (compact.includes(String(candidate) + 'of5')) return candidate;
++      }
++      return null;
++    };
++    const selectedModelIsExactGpt56Sol = (menu) =>
++      Array.from(menu?.querySelectorAll?.('[role="menuitemradio"]') ?? []).some((item) => {
++        if (!isVisible(item) || !optionIsSelected(item)) return false;
++        return nodeLabel(item).replace(/\\s+/g, '') === 'gpt56sol';
++      });
++    const exactGpt56ProPowerProof = (menu) => {
++      if (!TARGET_IS_GPT56_MODEL || TARGET_LEVEL !== 'pro' || !menu) return false;
++      const view = menu.querySelector?.(POWER_SIMPLE_VIEW_SELECTOR);
++      return Boolean(
++        isVisible(view) &&
++        readPowerStep(view) === 5 &&
++        hasToken(nodeLabel(view), 'pro') &&
++        selectedModelIsExactGpt56Sol(menu)
++      );
++    };
++    const selectGpt56ProPowerSlider = async (trigger, initialMenu) => {
++      if (!TARGET_IS_GPT56_MODEL || TARGET_LEVEL !== 'pro') return null;
++      const currentMenu = () => findVisibleEffortMenu(trigger) || initialMenu;
++      let menu = currentMenu();
++      let view = menu?.querySelector?.(POWER_SIMPLE_VIEW_SELECTOR) ?? null;
++      if (!isVisible(view)) return null;
++      if (exactGpt56ProPowerProof(menu)) {
++        closeOpenMenus();
++        return { status: 'already-selected', label: 'Pro, 5 of 5' };
++      }
++      if (!selectedModelIsExactGpt56Sol(menu)) {
++        return failure('selection-unverified', { modelKind: 'gpt56' });
++      }
++      for (let attempt = 0; attempt < 5; attempt += 1) {
++        menu = currentMenu();
++        view = menu?.querySelector?.(POWER_SIMPLE_VIEW_SELECTOR) ?? null;
++        const current = readPowerStep(view);
++        if (current === 5) break;
++        if (current === null) {
++          return failure('selection-unverified', { modelKind: 'gpt56' });
++        }
++        const control =
++          view.querySelector?.('[role="slider"], input[type="range"]') ||
++          Array.from(menu.querySelectorAll?.('[role="menuitem"], button') ?? []).find(
++            (item) => isVisible(item) && normalize(item.getAttribute?.('aria-label') ?? '') === 'power',
++          ) ||
++          view;
++        try { control.focus?.(); } catch {}
++        control.dispatchEvent(
++          new KeyboardEvent('keydown', {
++            key: 'ArrowRight', code: 'ArrowRight', bubbles: true, cancelable: true,
++          }),
++        );
++        control.dispatchEvent(
++          new KeyboardEvent('keyup', {
++            key: 'ArrowRight', code: 'ArrowRight', bubbles: true, cancelable: true,
++          }),
++        );
++        await sleep(STEP_WAIT_MS);
++      }
++      let consecutive = 0;
++      const deadline = performance.now() + INTELLIGENCE_WAIT_MS;
++      while (performance.now() < deadline) {
++        menu = currentMenu();
++        consecutive = exactGpt56ProPowerProof(menu) ? consecutive + 1 : 0;
++        if (consecutive >= 2) {
++          closeOpenMenus();
++          return { status: 'switched', label: 'Pro, 5 of 5' };
++        }
++        await sleep(100);
++      }
++      const result = failure('selection-unverified', { modelKind: 'gpt56' });
++      closeOpenMenus();
++      return result;
++    };
+     const containsAny = (label, words) => words.some((word) => label.includes(word));
+     const findAdvancedToggle = (menu) => {
+       for (const item of (menu || document).querySelectorAll('[role="menuitem"]')) {
+@@ -1069,6 +1153,13 @@ function buildThinkingTimeExpression(level, desiredModel) {
+       while (performance.now() < deadline) {
+         const menu = findVisibleEffortMenu(composerEffortPill);
+         if (menu) {
++          const powerSliderResult = await selectGpt56ProPowerSlider(
++            composerEffortPill,
++            menu,
++          );
++          if (powerSliderResult) {
++            return powerSliderResult;
++          }
+           const proEffortResult = await selectProEffortFromSubmenu();
+           if (proEffortResult) {
+             return proEffortResult;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,21 @@
 # 기술 변경 기록
 
+## 1.20.15 - Verify the current GPT-5.6 Sol Pro power slider
+
+- Oracle 0.18.0 now recognizes ChatGPT's current unified `Thinking effort`
+  picker, where Pro is represented by the simple Power slider as `Pro, 5 of
+  5` instead of a separate Heavy/Pro effort row. An already-selected Pro tier
+  is accepted only when the same visible menu also proves that the checked
+  model is exactly `GPT-5.6 Sol`.
+- When the slider is below Pro, the adapter uses bounded ArrowRight input and
+  requires two consecutive post-change proofs of both Power 5/5 and the exact
+  checked model. A missing slider, changed model, unavailable control, or
+  unverified result remains a pre-submit failure; no lower effort is submitted
+  as Pro.
+- The compatibility patch is hash-gated against the exact published Oracle
+  0.18.0 package, and the regression fixture preserves the live 2026-08-28 UI
+  shape whose trigger is named `Thinking effort` rather than `Pro`.
+
 ## 1.20.14 - Select the current visible Pro effort fail-closed
 
 - New GPT-5.6 Sol Pro and read-only Pro follow-up submissions now pass Oracle

--- a/install-manifest.json
+++ b/install-manifest.json
@@ -1,6 +1,6 @@
 {
   "schema": "codexpro.install-manifest/v1",
-  "version": "1.20.14",
+  "version": "1.20.15",
   "include": [
     "bin/chatgpt_agbrowse_bridge.py",
     "bin/chatgpt_agbrowse_composer.py",
@@ -69,6 +69,7 @@
     "bin/oracle-compat/0.18.0/browserConfig.followup-port-binding.patch",
     "bin/oracle-compat/0.18.0/browserConfig.copy-profile-windows.patch",
     "bin/oracle-compat/0.18.0/chromeLifecycle.disable-session-crash-bubble.patch",
+    "bin/oracle-compat/0.18.0/thinkingTime.gpt56-pro-power-slider.patch",
     "bin/oracle-compat/0.18.0/sessionManager.windows-atomic-rename-retry.patch",
     "bin/chatgpt_oracle_state.py",
     "bin/chatgpt_oracle_profiles.py",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.14",
+  "version": "1.20.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-web-gpt-automation",
-      "version": "1.20.14",
+      "version": "1.20.15",
       "license": "MIT",
       "engines": {
         "node": ">=24 <27"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-web-gpt-automation",
-  "version": "1.20.14",
+  "version": "1.20.15",
   "private": false,
   "description": "Guarded, recoverable web ChatGPT automation for local Codex projects on Windows and macOS",
   "license": "MIT",

--- a/tests/fixtures/oracle-0180-gpt56-sol-power-slider.json
+++ b/tests/fixtures/oracle-0180-gpt56-sol-power-slider.json
@@ -1,0 +1,23 @@
+{
+  "schema": "codex.chatgpt.oracle-power-slider-fixture/v1",
+  "source": "live-gpt-5.6-sol-thinking-effort-diagnostic-2026-08-28",
+  "requested_model": "gpt-5.6-sol",
+  "requested_effort": "pro",
+  "model_button": {
+    "text": "Thinking effort",
+    "ariaHaspopup": "menu",
+    "ariaExpanded": "true"
+  },
+  "simple_view": {
+    "testid": "composer-model-picker-slider-simple-view",
+    "text": "Pro, 5 of 5.Use Left and Right arrow keys to adjust power."
+  },
+  "power_control": {
+    "role": "menuitem",
+    "ariaLabel": "Power"
+  },
+  "model_rows": [
+    {"role": "menuitemradio", "label": "GPT-5.6 Sol", "ariaChecked": true},
+    {"role": "menuitemradio", "label": "GPT-5.5", "ariaChecked": false}
+  ]
+}

--- a/tests/test_chatgpt_oracle_compat.py
+++ b/tests/test_chatgpt_oracle_compat.py
@@ -558,6 +558,177 @@ console.log(JSON.stringify({{ selected, missing, unverified, unavailable }}));
         assert "refusing to submit without confirmed Pro" in result[case]["message"]
 
 
+def test_published_0180_pro_power_slider_current_ui_is_verified_and_fail_closed(
+    tmp_path: Path,
+) -> None:
+    compat = load_compat()
+    configured = os.environ.get("ORACLE_018_PACKAGE_ROOT", "").strip()
+    source = Path(configured) if configured else Path("__oracle_018_cache_unset__")
+    if not source.is_dir():
+        if os.environ.get("CI"):
+            pytest.fail("CI must prepare the exact published Oracle 0.18.0 package")
+        pytest.skip("published Oracle 0.18.0 package root is unavailable")
+    package = tmp_path / "oracle-pro-power-slider"
+    shutil.copytree(source, package)
+    compat.ensure_oracle_compatibility(
+        "oracle 0.18.0", package_root=package, backup_root=tmp_path / "backup-pro-power-slider"
+    )
+    target = package / "dist/src/browser/actions/thinkingTime.js"
+    fixture = json.loads(
+        (Path(__file__).parent / "fixtures" / "oracle-0180-gpt56-sol-power-slider.json")
+        .read_text(encoding="utf-8")
+    )
+    assert fixture["model_button"]["text"] == "Thinking effort"
+    assert fixture["simple_view"]["text"].startswith("Pro, 5 of 5")
+    assert fixture["model_rows"][0] == {
+        "role": "menuitemradio",
+        "label": "GPT-5.6 Sol",
+        "ariaChecked": True,
+    }
+    node = shutil.which("node")
+    assert node is not None
+    source_text = target.read_text(encoding="utf-8")
+    assert "selectGpt56ProPowerSlider" in source_text
+    assert "selectedModelIsExactGpt56Sol" in source_text
+    assert "TARGET_LEVEL !== 'pro'" in source_text
+    source_text = source_text.replace(
+        'import { MENU_CONTAINER_SELECTOR, MENU_ITEM_SELECTOR, MODEL_BUTTON_SELECTOR, } from "../constants.js";',
+        'const MENU_CONTAINER_SELECTOR="[role=menu]"; '
+        'const MENU_ITEM_SELECTOR="[role=menuitem],[role=menuitemradio]"; '
+        'const MODEL_BUTTON_SELECTOR=".model-button";',
+    ).replace(
+        'import { logDomFailure } from "../domDebug.js";',
+        'const logDomFailure=async()=>{};',
+    ).replace(
+        'import { buildClickDispatcher } from "./domEvents.js";',
+        'const buildClickDispatcher=()=>"";',
+    ).replace(
+        'import { BrowserAutomationError } from "../../oracle/errors.js";',
+        'class BrowserAutomationError extends Error { constructor(message, details) { super(message); this.details=details; } }',
+    )
+    test_module = tmp_path / "thinkingTime-power-slider-contract.mjs"
+    test_module.write_text(source_text, encoding="utf-8")
+    fixture_literal = json.dumps(fixture)
+    script = f"""
+import {{ ensureThinkingTime }} from {json.dumps(test_module.as_uri())};
+const fixture = {fixture_literal};
+class FakeElement extends EventTarget {{
+  constructor(text, attrs = {{}}, visible = true) {{
+    super(); this._text = text; this.attrs = attrs; this.visible = visible;
+    this.queryOne = () => null; this.queryMany = () => [];
+  }}
+  get textContent() {{ return typeof this._text === 'function' ? this._text() : this._text; }}
+  getAttribute(name) {{ return Object.prototype.hasOwnProperty.call(this.attrs, name) ? this.attrs[name] : null; }}
+  getBoundingClientRect() {{ return this.visible ? {{width: 240, height: 40}} : {{width: 0, height: 0}}; }}
+  querySelector(selector) {{ return this.queryOne(selector); }}
+  querySelectorAll(selector) {{ return this.queryMany(selector); }}
+  matches(selector) {{ return selector === 'button.__composer-pill' || selector === '.model-button'; }}
+  closest() {{ return null; }}
+  focus() {{}}
+  get isConnected() {{ return true; }}
+}}
+globalThis.HTMLElement = FakeElement;
+globalThis.window = globalThis;
+    globalThis.MouseEvent = class extends Event {{ constructor(type, init) {{ super(type, init); }} }};
+    globalThis.PointerEvent = globalThis.MouseEvent;
+    globalThis.KeyboardEvent = class extends Event {{
+      constructor(type, init) {{ super(type, init); this.key=init.key; this.code=init.code; }}
+    }};
+
+const runCase = async (initialStep, validModel) => {{
+  let step = initialStep;
+  let keydowns = 0;
+  const pill = new FakeElement(fixture.model_button.text, {{
+    'aria-haspopup': fixture.model_button.ariaHaspopup,
+    'aria-expanded': fixture.model_button.ariaExpanded,
+  }});
+  const view = new FakeElement(() =>
+    (step === 5 ? 'Pro' : 'Extra High') + ', ' + step + ' of 5.Use Left and Right arrow keys to adjust power.',
+    {{'data-testid': fixture.simple_view.testid}},
+  );
+  const power = new FakeElement('', {{role: 'menuitem', 'aria-label': fixture.power_control.ariaLabel}});
+  power.addEventListener('keydown', (event) => {{
+    if (event.key === 'ArrowRight') {{ step = Math.min(5, step + 1); keydowns += 1; }}
+  }});
+  const model56 = new FakeElement(fixture.model_rows[0].label, {{
+    role: 'menuitemradio', 'aria-checked': validModel ? 'true' : 'false',
+    'data-state': validModel ? 'checked' : null,
+  }});
+  const model55 = new FakeElement(fixture.model_rows[1].label, {{
+    role: 'menuitemradio', 'aria-checked': validModel ? 'false' : 'true',
+    'data-state': validModel ? null : 'checked',
+  }});
+  const menu = new FakeElement('ProPro, 5 of 5.GPT-5.6 SolGPT-5.5', {{
+    role: 'menu', 'data-testid': 'composer-intelligence-picker-content',
+  }});
+  menu.queryOne = (selector) =>
+    selector.includes('composer-model-picker-slider-simple-view') ? view :
+    selector.includes('composer-intelligence-picker-content') ? menu : null;
+  menu.queryMany = (selector) =>
+    selector === '[role="menuitemradio"]' ? [model56, model55] :
+    selector.includes('[role="menuitem"], button') ? [power] :
+    selector.includes('[role="menuitem"]') ? [power] :
+    selector.includes('[role="menuitemradio"]') ? [model56, model55] :
+    selector.includes('[data-testid]') ? [view] : [];
+  globalThis.document = {{
+    body: new FakeElement('body'),
+    querySelector: (selector) =>
+      selector === '.model-button' ? pill :
+      selector.includes('composer-intelligence-picker-content') ? menu : null,
+    querySelectorAll: (selector) =>
+      selector.includes('button.__composer-pill') ? [pill] :
+      selector === '[role=menu]' ? [menu] :
+      selector.includes('form button[aria-haspopup="menu"]') ? [pill] : [],
+    getElementById: () => null,
+    dispatchEvent: () => true,
+  }};
+  const logs = [];
+  const Runtime = {{evaluate: async ({{expression}}) => ({{result: {{value: await eval(expression)}}}})}};
+  try {{
+    await ensureThinkingTime(Runtime, 'pro', (message) => logs.push(message), 'gpt-5.6-sol');
+    return {{ok: true, logs, step, keydowns}};
+  }} catch (error) {{
+    return {{ok: false, message: error.message, logs, step, keydowns}};
+  }}
+}};
+console.log(JSON.stringify({{
+  selected: await runCase(5, true),
+  switched: await runCase(4, true),
+  switchedFromMedium: await runCase(2, true),
+  wrongModel: await runCase(5, false),
+}}));
+"""
+    completed = subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+    assert completed.returncode == 0, completed.stderr
+    result = json.loads(completed.stdout)
+    assert result["selected"] == {
+        "ok": True,
+        "logs": ["[browser] Thinking time: Pro, 5 of 5 (already selected)"],
+        "step": 5,
+        "keydowns": 0,
+    }
+    assert result["switched"] == {
+        "ok": True,
+        "logs": ["[browser] Thinking time: Pro, 5 of 5"],
+        "step": 5,
+        "keydowns": 1,
+    }
+    assert result["switchedFromMedium"] == {
+        "ok": True,
+        "logs": ["[browser] Thinking time: Pro, 5 of 5"],
+        "step": 5,
+        "keydowns": 3,
+    }
+    assert result["wrongModel"]["ok"] is False
+    assert "refusing to submit without confirmed Pro" in result["wrongModel"]["message"]
+
+
 def test_oracle_session_metadata_retry_patch_is_bounded_to_windows_transient_errors() -> None:
     patch_text = (
         Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- hash-gate a current Oracle 0.18.0 compatibility patch for the ChatGPT Thinking effort Power slider
- require Power 5/5 and the checked GPT-5.6 Sol row before accepting Pro
- add the live 2026-08-28 DOM fixture, bounded slider transition coverage, and fail-closed wrong-model coverage
- bump the release contract to v1.20.15

## Local verification
- published Oracle 0.18.0 archive integrity matches policy
- python -m pytest tests/test_chatgpt_oracle_compat.py -q: 47 passed, 2 skipped
- python scripts/check_portability.py --root .: pass
- python scripts/check_docs.py --root .: pass
- python scripts/check_upstream_runtime_policy.py: in sync
- python scripts/verify_upstream_runtime_maintainer.py: pass
- python scripts/run_fast_gate.py --enforce-budget: pass
- python scripts/run_golden_path_smoke.py: pass; submitted_question=false
- python scripts/run_v4_contract_tests.py --focused: 61 passed
- python scripts/run_v3_contract_tests.py: pass
- python scripts/run_v4_contract_tests.py --full: 1397 passed, 26 skipped

No Pro prompt was submitted and no project files or active Oracle runs were touched.