### PR TITLE
fix: harden GPT-5.6 Pro browser recovery

### DIFF
--- a/bin/chatgpt_oracle_compat.py
+++ b/bin/chatgpt_oracle_compat.py
@@ -248,7 +248,11 @@ PATCHES = {
     "dist/src/browser/actions/thinkingTime.js": {
         "patch": "thinkingTime.gpt56-pro-power-slider.patch",
         "pristine": "3d9d06b08417bca3b2d646eb4d46887d26c5de7c068d1e995c73b6b6e2f61199",
-        "patched": "978f754ba4011957790530474d27d629a8d353dd449f8e2636e02a9abd27b81a",
+        "patched": "a19ce77fe57b4fa1a290e130da323377ed69b6e51b1ad133b1ab5355ead59345",
+        "legacy_patched": [
+            "978f754ba4011957790530474d27d629a8d353dd449f8e2636e02a9abd27b81a",
+        ],
+        "legacy_patch": "thinkingTime.gpt56-pro-power-slider.v1.20.15.patch",
     },
     "dist/src/browser/actions/assistantResponse.js": {
         "patch": "../0.17.1/assistantResponse.terminal-marker-fallback.patch",

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -2991,6 +2991,7 @@ def _standalone_pro_attachment_no_submission_evidence(
     state_path: Path,
     *,
     allow_settled_attachment_source_drift: bool = False,
+    require_recovery_evidence: bool = True,
 ) -> dict[str, Any] | None:
     """Return bounded user-adjudication evidence for attachment upload timeout.
 
@@ -3063,19 +3064,37 @@ def _standalone_pro_attachment_no_submission_evidence(
         stdout_text = stdout_bytes.decode("utf-8", errors="strict")
     except UnicodeDecodeError:
         return None
-    expected_marker_lines = {
+    expected_attachment_marker_lines = {
         f"ERROR: {ORACLE_ATTACHMENTS_UPLOAD_TIMEOUT_MARKER}",
         f"User error (browser-automation): {ORACLE_ATTACHMENTS_UPLOAD_TIMEOUT_MARKER}",
     }
-    observed_marker_lines = {
+    observed_attachment_marker_lines = {
         line.strip()
         for line in stdout_text.splitlines()
         if ORACLE_ATTACHMENTS_UPLOAD_TIMEOUT_MARKER in line
     }
+    expected_prompt_marker_lines = {
+        f"ERROR: {ORACLE_PROMPT_NOT_OBSERVED_MARKER}",
+        f"User error (browser-automation): {ORACLE_PROMPT_NOT_OBSERVED_MARKER}",
+    }
+    observed_prompt_marker_lines = {
+        line.strip()
+        for line in stdout_text.splitlines()
+        if ORACLE_PROMPT_NOT_OBSERVED_MARKER in line
+    }
+    attachment_timeout = (
+        observed_attachment_marker_lines == expected_attachment_marker_lines
+        and stdout_text.count(ORACLE_ATTACHMENTS_UPLOAD_TIMEOUT_MARKER) == 2
+        and not observed_prompt_marker_lines
+    )
+    prompt_timeout = (
+        observed_prompt_marker_lines == expected_prompt_marker_lines
+        and stdout_text.count(ORACLE_PROMPT_NOT_OBSERVED_MARKER)
+        == len(observed_prompt_marker_lines)
+        and not observed_attachment_marker_lines
+    )
     if (
-        observed_marker_lines != expected_marker_lines
-        or stdout_text.count(ORACLE_ATTACHMENTS_UPLOAD_TIMEOUT_MARKER) != 2
-        or ORACLE_PROMPT_NOT_OBSERVED_MARKER in stdout_text
+        attachment_timeout == prompt_timeout
         or f"Session: {locator}" not in stdout_text
         or CHATGPT_CONVERSATION_URL_RE.search(stdout_text)
     ):
@@ -3198,7 +3217,7 @@ def _standalone_pro_attachment_no_submission_evidence(
             "stderr_name": recovery_stderr.name,
             "stderr_sha256": hashlib.sha256(recovery_stderr_bytes).hexdigest(),
         })
-    if not recovery_records:
+    if require_recovery_evidence and not recovery_records:
         return None
     return {
         "settlement_eligibility": "oracle-standalone-pro-attachment/v1",
@@ -3215,12 +3234,19 @@ def _standalone_pro_attachment_no_submission_evidence(
         "oracle_locator": locator,
         "oracle_version": version,
         "oracle_command": list(oracle.get("command") or []),
-        "pre_submit_marker": ORACLE_ATTACHMENTS_UPLOAD_TIMEOUT_MARKER,
+        "pre_submit_marker": (
+            ORACLE_ATTACHMENTS_UPLOAD_TIMEOUT_MARKER
+            if attachment_timeout
+            else ORACLE_PROMPT_NOT_OBSERVED_MARKER
+        ),
         "stdout_sha256": hashlib.sha256(stdout_bytes).hexdigest(),
         "stderr_sha256": hashlib.sha256(stderr_bytes).hexdigest(),
         "recovery_evidence": recovery_records,
         "output_absent": True,
         "conversation_url_absent": True,
+        "_pre_submit_failure_kind": (
+            "attachment-upload-timeout" if attachment_timeout else "prompt-not-observed"
+        ),
         "_source_mission_path": str(source_path),
         "_transport_mission_path": str(transport_path),
     }
@@ -3589,12 +3615,22 @@ def _bounded_task_owned_prompt_timeout_evidence(
     direct_recovery_evidence = (
         direct_evidence.get("recovery_evidence") if direct_evidence is not None else None
     )
+    attachment_evidence = _standalone_pro_attachment_no_submission_evidence(
+        state_path,
+        require_recovery_evidence=False,
+    )
     if (
         direct_evidence is not None
         and isinstance(direct_recovery_evidence, list)
         and (allow_recovery_evidence or direct_recovery_evidence == [])
     ):
         evidence = direct_evidence
+    elif (
+        attachment_evidence is not None
+        and attachment_evidence.get("_pre_submit_failure_kind") == "prompt-not-observed"
+        and attachment_evidence.get("recovery_evidence") == []
+    ):
+        evidence = attachment_evidence
     else:
         evidence = _standalone_pro_no_submission_evidence(
             state_path,
@@ -3612,7 +3648,10 @@ def _bounded_task_owned_prompt_timeout_evidence(
         )
     ):
         return None
-    if evidence.get("settlement_eligibility") == "oracle-standalone-qualified-pro/v1":
+    if evidence.get("settlement_eligibility") in {
+        "oracle-standalone-qualified-pro/v1",
+        "oracle-standalone-pro-attachment/v1",
+    }:
         if evidence.get("_pre_submit_failure_kind") != "prompt-not-observed":
             return None
     elif evidence.get("settlement_eligibility") != "oracle-direct-devspace/v1":

--- a/bin/oracle-compat/0.18.0/thinkingTime.gpt56-pro-power-slider.v1.20.15.patch
+++ b/bin/oracle-compat/0.18.0/thinkingTime.gpt56-pro-power-slider.v1.20.15.patch
@@ -1,7 +1,7 @@
 diff --git a/dist/src/browser/actions/thinkingTime.js b/dist/src/browser/actions/thinkingTime.js
 --- a/dist/src/browser/actions/thinkingTime.js
 +++ b/dist/src/browser/actions/thinkingTime.js
-@@ -849,6 +849,107 @@ function buildThinkingTimeExpression(level, desiredModel) {
+@@ -849,6 +849,90 @@ function buildThinkingTimeExpression(level, desiredModel) {
        'effort', 'aufwand', '强度', '努力', '推論レベル',
        'esfuerzo', 'esforco', 'sforzo', 'inspanning', 'wysilek',
      ];
@@ -24,20 +24,6 @@ diff --git a/dist/src/browser/actions/thinkingTime.js b/dist/src/browser/actions
 +        if (!isVisible(item) || !optionIsSelected(item)) return false;
 +        return nodeLabel(item).replace(/\\s+/g, '') === 'gpt56sol';
 +      });
-+    const findGpt56PowerSliderMenu = (preferred) => {
-+      const candidates = [];
-+      const addCandidate = (candidate) => {
-+        if (candidate && !candidates.includes(candidate)) candidates.push(candidate);
-+      };
-+      addCandidate(preferred);
-+      for (const candidate of document.querySelectorAll(MENU_CONTAINER_SELECTOR)) addCandidate(candidate);
-+      const matches = candidates.filter((candidate) => {
-+        if (!isVisible(candidate)) return false;
-+        const view = candidate.querySelector?.(POWER_SIMPLE_VIEW_SELECTOR);
-+        return isVisible(view) && selectedModelIsExactGpt56Sol(candidate);
-+      });
-+      return matches.length === 1 ? matches[0] : null;
-+    };
 +    const exactGpt56ProPowerProof = (menu) => {
 +      if (!TARGET_IS_GPT56_MODEL || TARGET_LEVEL !== 'pro' || !menu) return false;
 +      const view = menu.querySelector?.(POWER_SIMPLE_VIEW_SELECTOR);
@@ -50,10 +36,7 @@ diff --git a/dist/src/browser/actions/thinkingTime.js b/dist/src/browser/actions
 +    };
 +    const selectGpt56ProPowerSlider = async (trigger, initialMenu) => {
 +      if (!TARGET_IS_GPT56_MODEL || TARGET_LEVEL !== 'pro') return null;
-+      const currentMenu = () => {
-+        const preferred = findVisibleEffortMenu(trigger) || initialMenu;
-+        return findGpt56PowerSliderMenu(preferred) || preferred;
-+      };
++      const currentMenu = () => findVisibleEffortMenu(trigger) || initialMenu;
 +      let menu = currentMenu();
 +      let view = menu?.querySelector?.(POWER_SIMPLE_VIEW_SELECTOR) ?? null;
 +      if (!isVisible(view)) return null;
@@ -109,7 +92,7 @@ diff --git a/dist/src/browser/actions/thinkingTime.js b/dist/src/browser/actions
      const containsAny = (label, words) => words.some((word) => label.includes(word));
      const findAdvancedToggle = (menu) => {
        for (const item of (menu || document).querySelectorAll('[role="menuitem"]')) {
-@@ -1069,6 +1170,13 @@ function buildThinkingTimeExpression(level, desiredModel) {
+@@ -1069,6 +1153,13 @@ function buildThinkingTimeExpression(level, desiredModel) {
        while (performance.now() < deadline) {
          const menu = findVisibleEffortMenu(composerEffortPill);
          if (menu) {

--- a/docs/templates/codex-agents/global-agents-policy.md
+++ b/docs/templates/codex-agents/global-agents-policy.md
@@ -17,18 +17,32 @@
 - Put reusable third-party source checkouts under `%LOCALAPPDATA%\Codex\Sources`. Keep explicit user project roots separate and never repurpose them as scratch space.
 - Before cleanup, verify ownership and active references. Preserve user projects, system folders, credentials, and ambiguous items; move confirmed automation artifacts to a recoverable archive instead of deleting them.
 
-## CGW web model routing
+## Oracle long-run observation
 
-- OpenCodex is the single Codex routing entrypoint. Codex Web GPT (CGW) is an external provider behind OpenCodex; keep the CGW direct bridge inactive and never let CGW overwrite the OpenCodex base URL or unrelated provider routes.
-- Ordinary requested web-model work uses `cgw/chatgpt-web-extra-high`. The phrases "ask GPT Pro", "ask Pro", and equivalent explicit requests mean a `cgw/chatgpt-web-pro` subagent with `max` reasoning. Never reinterpret them as an Oracle or DevSpace run.
-- CGW is semantic assistance, not execution authority. Local Codex owns files, commands, tests, device actions, accounts, and deterministic verification. A CGW answer never proves a local mutation or user-visible outcome by itself.
-- If the requested CGW model is unavailable, fails before returning a durable answer, or cannot be selected exactly, fail closed or continue with authorized local work. Do not silently downgrade, resend an uncertain prompt, or fall back to Oracle, DevSpace, attachments, or another web harness.
-- Preserve Local Multi GPT and native Codex subagents as independent local advisory/execution paths. This migration does not disable, replace, or route Local Multi GPT through CGW.
+- Treat 80 minutes as a caution/status-audit threshold, never as a forced stop, failure, handoff, ownership release, or replacement-submission deadline.
+- At the threshold inspect the exact run's process liveness, response/log/output progress, known conversation binding, and provider terminal evidence. If it is live, streaming, progressing, or uncertain, continue the same process or exact-slug live recovery.
+- If a host observer must return, preserve the Oracle process/session and automatically continue observation through the same exact slug. Never create a fresh prompt or release the task-scoped project lock because elapsed time alone.
+- Only a real provider hard limit, explicit terminal evidence, an explicit user stop, or verified inability may end observation. Keep prompt-not-observed fail-closed and no-duplicate rules unchanged.
 
-## Legacy Oracle and DevSpace freeze
+## Oracle task ownership
 
-- Oracle, DevSpace-backed GPT runs, Web Multi, comprehensive/Ultra web orchestration, CodexPro, and agbrowse are frozen for new user work. Do not open their Chrome windows, create runs, register roots, submit prompts, or select them as fallbacks.
-- Keep their source, installed bytes, historical state, receipts, and recovery tooling intact for maintenance and audit. Exact recovery of a persisted historical run requires an explicit user request naming that legacy run; project work must not trigger it automatically.
-- Maintenance of the legacy automation repository may continue separately, but it must not change the active user-work route back from CGW or manipulate ChatGPT apps, DevSpace, Chrome profiles, or project files as part of ordinary work.
-- The installed `ultra-gpt-mode`, `ultra-economy-mode`, Oracle-browser, question-designer, workspace-setup, and Web Multi skills are legacy-frozen. Their presence is compatibility evidence, not permission to use them for new work.
+- Ownership is bound to the originating Codex task plus the exact run, not to the project root alone. Different tasks may run concurrently at the same root with separate task-scoped mutexes, slugs, dynamic CDP ports, browser profiles, conversations, and receipts. Only the same task's unresolved run blocks its next submission.
+- A foreign task may be listed for diagnosis but must never be adopted, recovered, harvested, followed up, canceled, or stopped. Never infer a legacy-unbound owner from the project root, newest run, Chrome window, or timestamp.
+- A same-conversation read-only Pro round may use only the runner's internal `followup` command against a task-bound terminal `pro-devspace-readonly` parent. Raw `--followup`, `--browser-follow-up`, and `session` injection stay forbidden. New read-only Pro parents normalize default `archive=auto` to `never`; explicit `always` is a single-turn choice. A historical or explicitly archived exact parent may be restored only through the bounded compatibility path for that round and must be re-archived afterward. If restoration fails before the composer, do not harvest; preserve the run and require explicit user no-submission confirmation before exact settlement. Each round must prove the unchanged conversation, archive transition, and append hash-bound reservation/result receipts; an unproven or changed conversation fails closed without a replacement prompt.
+- Follow-up dry-run is side-effect free. A live attempt creates child state/logs before local preflight and appends parent launch/result evidence. Historical reservation-only round keys stay immutable and are never deleted or replayed; after proving the detached controller ended, the owner uses a new unique key.
+
+## Web GPT model and Pro authority
+
+- Default ordinary web work to `gpt-5.6` with `extra-high`, the highest supported non-Pro reasoning tier. Never select or upgrade to Pro automatically.
+- Treat Pro as quota-limited and explicit-only. Use `GPT-5.6 Sol` at the Pro effort only after the user explicitly requests Pro; a standard comprehensive workflow additionally requires `allow_pro: true`.
+- Every new explicit Pro run uses the `pro-devspace-readonly` route as read-only DevSpace for design, advice, or review. It must not create, edit, or remove files or run commands; a regular `GPT-5.6` `extra-high` DevSpace stage owns those actions under the applicable `AGENTS.md` and repository safety rules.
+- Pro must not alter accounts, ChatGPT app settings, or external state. Explicit `pro-attachment` remains a separate read-only immutable/external-evidence route and is never an automatic fallback.
+- Preserve persisted legacy `pro-devspace` write and `pro-devspace-readonly` runs with their original authority and transport during exact recovery; never reinterpret historical authority.
+
+## Ultra GPT mode
+
+- When the user explicitly requests `울트라 GPT 모드` or `Ultra GPT Mode`, use the installed `ultra-gpt-mode` skill and the `ultra-gpt` comprehensive profile.
+- Closed workflow provenance is an explicit `closed_audit` option of `ultra-gpt`, not a separate mode. Never enable it silently. Accept `workflow_profile: strict-ultra` only for exact legacy compatibility and recovery.
+- In that profile, do not spawn native Codex subagents for semantic work. Use separate web GPT sessions for planning, review and partitioning, parallel implementation lanes in distinct pre-created Git worktrees with host-audited disjoint project-relative ownership, an all-lanes barrier, merging, and final verification. Local Codex remains a deterministic controller and runs only the final local gate.
+- Pro is not an internal Ultra GPT stage. A user-requested Pro design advisory is a separate, single pre-workflow consultation; ordinary Ultra GPT stages remain on the highest supported non-Pro tier.
 <!-- END CODEX WEB GPT SUBAGENT POLICY -->

--- a/skills/mcp-update-guard/SKILL.md
+++ b/skills/mcp-update-guard/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-update-guard
-description: Safely update MCP servers, CGW and OpenCodex integration, frozen legacy Oracle automation, global skills, plugins, and related shared automation while preserving local customizations.
+description: Part of the current Oracle automation path, safely update MCP servers, shared harness helpers, Oracle GPT runners, global skills, plugins, and related automation while preserving local customizations.
 ---
 
 # MCP update guard
@@ -16,17 +16,21 @@ preserve unrelated local customizations.
 2. Inspect source Git status and the installed file identity before editing.
    Never overwrite credentials, browser profiles, runtime state, or unrelated
    user changes.
-3. For non-trivial GPT design or review, use web delegation only when the user
-   asked for it. OpenCodex remains the single Codex entrypoint and CGW remains
-   an external provider:
-   - ordinary requested web work uses `cgw/chatgpt-web-extra-high`;
-   - an explicit request to ask GPT Pro or Pro uses a
-     `cgw/chatgpt-web-pro` subagent with `max` reasoning;
-   - local Codex owns files, commands, tests, and deterministic verification;
-   - never fall back to Oracle, DevSpace, Web Multi, attachments, CodexPro, or
-     agbrowse when CGW is unavailable or uncertain. Those paths are frozen for
-     new work and retained only for maintenance or explicitly requested exact
-     historical recovery.
+3. For non-trivial GPT automation design or implementation, use the selected
+   current GPT workflow only when the user asked for web delegation. Every new
+   ChatGPT run uses Oracle:
+   - regular modes, Deep Research, comprehensive stages, and Web Multi use
+     Oracle plus the manually registered DevSpace app;
+    - regular web work defaults to the highest supported non-Pro reasoning tier;
+      only explicit user opt-in selects new qualified Pro with `GPT-5.6 Sol` at
+      the Pro effort and read-only DevSpace for design, advice, or review. A
+      regular `GPT-5.6` `extra-high` DevSpace stage performs file mutations and
+      commands. Explicit `pro-attachment` remains a separate read-only
+      immutable/external-evidence route and is never an automatic fallback;
+      persisted legacy `pro-devspace` write runs retain their exact authority
+      only during recovery;
+   - CodexPro/agbrowse may be used only for exact recovery of an already
+     persisted legacy run and never as a fallback.
 4. Prefer small compatibility changes over wholesale replacement. Preserve
    local ports, names, roots, tokens, routing, and hooks unless the task
    explicitly changes them.
@@ -134,8 +138,8 @@ instead of the layer that failed.
 - Do not delete or recreate credential-bearing state during a normal update.
 - Do not use resource pressure as authority to block, terminate, downgrade, or
   duplicate user-visible work.
-- Do not silently switch a CGW model, reasoning level, provider route, or a
-  persisted legacy Oracle model, transport, or browser backend.
+- Do not silently switch Oracle model, reasoning level, transport, or browser
+  backend.
 - Do not create a new legacy agbrowse/CodexPro run while repairing recovery
   code.
 - Stop and report exact dirty files when authoritative persistence, push, or CI

--- a/tests/test_chatgpt_oracle_compat.py
+++ b/tests/test_chatgpt_oracle_compat.py
@@ -743,6 +743,49 @@ console.log(JSON.stringify({{
     assert "refusing to submit without confirmed Pro" in result["wrongModel"]["message"]
 
 
+def test_published_0180_pro_power_slider_migrates_v12015_exact_bytes(
+    tmp_path: Path,
+) -> None:
+    compat = load_compat()
+    configured = os.environ.get("ORACLE_018_PACKAGE_ROOT", "").strip()
+    source = Path(configured) if configured else Path("__oracle_018_cache_unset__")
+    if not source.is_dir():
+        if os.environ.get("CI"):
+            pytest.fail("CI must prepare the exact published Oracle 0.18.0 package")
+        pytest.skip("published Oracle 0.18.0 package root is unavailable")
+    package = tmp_path / "oracle-pro-power-slider-legacy"
+    shutil.copytree(source, package)
+    relative = "dist/src/browser/actions/thinkingTime.js"
+    contract = compat.PATCHES[relative]
+    legacy_patch = str(contract["legacy_patch"])
+    legacy_hashes = list(contract["legacy_patched"])
+    assert legacy_hashes == [
+        "978f754ba4011957790530474d27d629a8d353dd449f8e2636e02a9abd27b81a"
+    ]
+    compat._apply_patch(package, compat.patch_root("0.18.0") / legacy_patch)
+    target = package / relative
+    assert compat.sha256_file(target) == legacy_hashes[0]
+
+    backup = tmp_path / "backup-pro-power-slider-legacy"
+    first = compat.ensure_oracle_compatibility(
+        "oracle 0.18.0", package_root=package, backup_root=backup
+    )
+    second = compat.ensure_oracle_compatibility(
+        "oracle 0.18.0", package_root=package, backup_root=backup
+    )
+
+    assert relative in first["changed"]
+    assert relative in second["already_patched"]
+    assert compat.sha256_file(target) == contract["patched"]
+    assert compat.sha256_file(backup / relative) == contract["pristine"]
+    node = shutil.which("node")
+    assert node is not None
+    syntax = subprocess.run(
+        [node, "--check", str(target)], capture_output=True, text=True, check=False
+    )
+    assert syntax.returncode == 0, syntax.stderr
+
+
 def test_oracle_session_metadata_retry_patch_is_bounded_to_windows_transient_errors() -> None:
     patch_text = (
         Path(__file__).resolve().parents[1]

--- a/tests/test_chatgpt_oracle_compat.py
+++ b/tests/test_chatgpt_oracle_compat.py
@@ -635,12 +635,13 @@ globalThis.window = globalThis;
       constructor(type, init) {{ super(type, init); this.key=init.key; this.code=init.code; }}
     }};
 
-const runCase = async (initialStep, validModel) => {{
+const runCase = async (initialStep, validModel, controlledFragment = false) => {{
   let step = initialStep;
   let keydowns = 0;
   const pill = new FakeElement(fixture.model_button.text, {{
     'aria-haspopup': fixture.model_button.ariaHaspopup,
     'aria-expanded': fixture.model_button.ariaExpanded,
+    'aria-controls': controlledFragment ? 'controlled-effort-fragment' : null,
   }});
   const view = new FakeElement(() =>
     (step === 5 ? 'Pro' : 'Extra High') + ', ' + step + ' of 5.Use Left and Right arrow keys to adjust power.',
@@ -661,6 +662,12 @@ const runCase = async (initialStep, validModel) => {{
   const menu = new FakeElement('ProPro, 5 of 5.GPT-5.6 SolGPT-5.5', {{
     role: 'menu', 'data-testid': 'composer-intelligence-picker-content',
   }});
+  const fragment = new FakeElement('Pro, 5 of 5.', {{
+    role: 'menu', 'data-testid': 'composer-intelligence-picker-content',
+  }});
+  fragment.queryOne = (selector) =>
+    selector.includes('composer-model-picker-slider-simple-view') ? view : null;
+  fragment.queryMany = () => [];
   menu.queryOne = (selector) =>
     selector.includes('composer-model-picker-slider-simple-view') ? view :
     selector.includes('composer-intelligence-picker-content') ? menu : null;
@@ -679,7 +686,7 @@ const runCase = async (initialStep, validModel) => {{
       selector.includes('button.__composer-pill') ? [pill] :
       selector === '[role=menu]' ? [menu] :
       selector.includes('form button[aria-haspopup="menu"]') ? [pill] : [],
-    getElementById: () => null,
+    getElementById: (id) => id === 'controlled-effort-fragment' ? fragment : null,
     dispatchEvent: () => true,
   }};
   const logs = [];
@@ -693,6 +700,7 @@ const runCase = async (initialStep, validModel) => {{
 }};
 console.log(JSON.stringify({{
   selected: await runCase(5, true),
+  controlledPortal: await runCase(5, true, true),
   switched: await runCase(4, true),
   switchedFromMedium: await runCase(2, true),
   wrongModel: await runCase(5, false),
@@ -708,6 +716,12 @@ console.log(JSON.stringify({{
     assert completed.returncode == 0, completed.stderr
     result = json.loads(completed.stdout)
     assert result["selected"] == {
+        "ok": True,
+        "logs": ["[browser] Thinking time: Pro, 5 of 5 (already selected)"],
+        "step": 5,
+        "keydowns": 0,
+    }
+    assert result["controlledPortal"] == {
         "ok": True,
         "logs": ["[browser] Thinking time: Pro, 5 of 5 (already selected)"],
         "step": 5,

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -90,6 +90,10 @@ def version_0171_runner(command, **kwargs):
     return subprocess.CompletedProcess(command, 0, stdout="oracle 0.17.1\n", stderr="")
 
 
+def version_0180_runner(command, **kwargs):
+    return subprocess.CompletedProcess(command, 0, stdout="oracle 0.18.0\n", stderr="")
+
+
 def version_timeout_runner(command, **kwargs):
     raise subprocess.TimeoutExpired(command, kwargs.get("timeout", 30))
 
@@ -3425,6 +3429,63 @@ def test_task_bound_readonly_prompt_timeout_can_harvest_without_browser_receipt(
         source_thread_id=owner,
     )
     assert [item["run_id"] for item in owners] == ["c" * 32]
+
+
+def test_task_bound_attachment_pro_prompt_timeout_can_harvest_and_user_settle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    owner = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("CODEX_THREAD_ID", owner)
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    initial = execute_run(
+        runner,
+        pro_manifest(tmp_path),
+        run_factory=version_0180_runner,
+        popen_factory=prompt_not_observed_popen,
+    )
+    run_dir = Path(initial["run_dir"])
+    state_path = run_dir / "state.json"
+    write_prompt_timeout_oracle_meta(runner, run_dir, session_root)
+
+    evidence = runner.STATE.bounded_task_owned_prompt_timeout_harvest_evidence(state_path)
+    assert evidence is not None
+    assert evidence["settlement_eligibility"] == "oracle-standalone-pro-attachment/v1"
+    assert evidence["transport"] == "pro-attachment-only"
+    assert evidence["commit_probe_turns"] == 0
+    assert evidence["conversation_url_absent"] is True
+    assert len(evidence["attachment_evidence"]) == 2
+
+    dry_run = runner.recover_run(
+        run_dir,
+        action="harvest",
+        dry_run=True,
+        oracle_command=["oracle"],
+    )
+    assert dry_run["browser_identity_mode"] == "bounded-prompt-timeout-harvest"
+    assert "--harvest" in dry_run["argv"]
+    assert "--prompt" not in dry_run["argv"]
+
+    recovered = runner.recover_run(
+        run_dir,
+        action="harvest",
+        oracle_command=["oracle"],
+        popen_factory=recovery_binding_unavailable_popen,
+    )
+    assert recovered["status"] == "recovery_binding_unavailable"
+    settled = runner.settle_user_confirmed_no_submission(
+        run_dir,
+        confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
+        reason="user confirmed the exact zero-turn attachment-only run did not submit",
+    )
+    proof = runner.STATE.proven_user_confirmed_no_submission(state_path)
+
+    assert settled["result"]["session_authority"] == "pre_submit"
+    assert proof is not None
+    assert proof["settlement_eligibility"] == "oracle-standalone-pro-attachment/v1"
+    assert proof["pre_submit_marker"] == runner.STATE.ORACLE_PROMPT_NOT_OBSERVED_MARKER
 
 
 def test_task_bound_direct_devspace_prompt_timeout_can_harvest_without_browser_receipt(

--- a/tests/test_chatgpt_oracle_run.py
+++ b/tests/test_chatgpt_oracle_run.py
@@ -3488,6 +3488,121 @@ def test_task_bound_attachment_pro_prompt_timeout_can_harvest_and_user_settle(
     assert proof["pre_submit_marker"] == runner.STATE.ORACLE_PROMPT_NOT_OBSERVED_MARKER
 
 
+@pytest.mark.parametrize(
+    "contradiction",
+    (
+        "conversation-url",
+        "prompt-not-submitted",
+        "turn-observed",
+        "assistant-visible",
+        "output-present",
+        "stdout-marker-tampered",
+    ),
+)
+def test_task_bound_attachment_pro_prompt_timeout_rejects_pre_harvest_contradictions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    contradiction: str,
+) -> None:
+    runner = load_runner()
+    owner = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("CODEX_THREAD_ID", owner)
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    initial = execute_run(
+        runner,
+        pro_manifest(tmp_path),
+        run_factory=version_0180_runner,
+        popen_factory=prompt_not_observed_popen,
+    )
+    run_dir = Path(initial["run_dir"])
+    state_path = run_dir / "state.json"
+    meta_mutation = contradiction if contradiction in {
+        "conversation-url",
+        "prompt-not-submitted",
+        "turn-observed",
+        "assistant-visible",
+    } else None
+    write_prompt_timeout_oracle_meta(
+        runner,
+        run_dir,
+        session_root,
+        mutation=meta_mutation,
+    )
+    if contradiction == "output-present":
+        Path(runner.STATE.load_state(state_path)["artifacts"]["output"]).write_text(
+            "unexpected assistant output\n", encoding="utf-8"
+        )
+    elif contradiction == "stdout-marker-tampered":
+        stdout_path = run_dir / "stdout.log"
+        stdout_path.write_text(
+            stdout_path.read_text(encoding="utf-8").replace(
+                runner.STATE.ORACLE_PROMPT_NOT_OBSERVED_MARKER,
+                "Prompt marker was altered",
+                1,
+            ),
+            encoding="utf-8",
+        )
+
+    assert runner.STATE.bounded_task_owned_prompt_timeout_harvest_evidence(state_path) is None
+    with pytest.raises(runner.OracleRunError) as recovery_exc:
+        runner.recover_run(
+            run_dir,
+            action="harvest",
+            dry_run=True,
+            oracle_command=["oracle"],
+        )
+    assert recovery_exc.value.code == "BROWSER_IDENTITY_RECEIPT_REQUIRED"
+
+
+def test_task_bound_attachment_pro_prompt_timeout_settlement_requires_intact_recovery_logs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    owner = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("CODEX_THREAD_ID", owner)
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    initial = execute_run(
+        runner,
+        pro_manifest(tmp_path),
+        run_factory=version_0180_runner,
+        popen_factory=prompt_not_observed_popen,
+    )
+    run_dir = Path(initial["run_dir"])
+    write_prompt_timeout_oracle_meta(runner, run_dir, session_root)
+
+    with pytest.raises(runner.STATE.OracleStateError) as missing_recovery:
+        runner.settle_user_confirmed_no_submission(
+            run_dir,
+            confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
+            reason="recovery evidence does not exist yet",
+        )
+    assert missing_recovery.value.code == "NO_SUBMISSION_EVIDENCE_INCOMPLETE"
+
+    recovered = runner.recover_run(
+        run_dir,
+        action="harvest",
+        oracle_command=["oracle"],
+        popen_factory=recovery_binding_unavailable_popen,
+    )
+    assert recovered["status"] == "recovery_binding_unavailable"
+    recovery_stdout = run_dir / "recovery-harvest-stdout.log"
+    recovery_stdout.write_text(
+        recovery_stdout.read_text(encoding="utf-8")
+        + "https://chatgpt.com/c/unexpected-recovery-binding\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(runner.STATE.OracleStateError) as tampered_recovery:
+        runner.settle_user_confirmed_no_submission(
+            run_dir,
+            confirmation=runner.STATE.USER_CONFIRMED_NO_SUBMISSION,
+            reason="tampered recovery evidence must fail closed",
+        )
+    assert tampered_recovery.value.code == "NO_SUBMISSION_EVIDENCE_INCOMPLETE"
+
+
 def test_task_bound_direct_devspace_prompt_timeout_can_harvest_without_browser_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Supersedes and preserves the focused fix from #39 while rebasing it onto the current repository policy and adding the missing migration/recovery gates.\n\nChanges:\n- recognize the current GPT-5.6 Pro power-slider state fail closed\n- preserve exact same-task, zero-turn recovery semantics\n- migrate the pinned Oracle 0.18.0 legacy patch hash to the new exact patch\n- reject contradictory no-submission evidence and tampered recovery logs\n- revert the unrelated CGW policy from this Oracle/DevSpace compatibility repository; CGW remains outside this project\n\nLocal verification on Windows:\n- focused contract: 61 passed\n- full contract: 1410 passed, 22 skipped\n- exact Oracle 0.18.0 npm artifact integrity and migration test passed\n- fast gate, portability, docs contract, golden no-submission, and v3 contract gates passed\n\nNo Pro prompt was submitted. No user project/account state, CGW runtime, or global routing was changed.