### PR TITLE
Recover malformed final gate receipts safely

### DIFF
--- a/bin/chatgpt_oracle_comprehensive.py
+++ b/bin/chatgpt_oracle_comprehensive.py
@@ -1175,6 +1175,17 @@ def _stage_mission(
                 "its mission authority, writes the bound final verification mission, and returns next_stage="
                 "final-web-gate.\n"
             )
+    if stage == "final-web-gate":
+        protocol += (
+            "\n[FINAL_GATE_RECEIPT_CONTRACT]\n"
+            "A passing final gate must use status=PASS, next_stage=complete, ready_for_next=true, "
+            "and blocker=\"\". Complete is a transition to the mandatory host local gate, not a claim "
+            "that the workflow has already completed. For this terminal transition only, set "
+            "next_mission_path=null and next_mission_sha256=null; do not create an empty terminal mission. "
+            "For the materialization fallback use next_mission_text=\"\". Never use an empty next_stage "
+            "or ready_for_next=false for PASS. If verification cannot pass, report the concrete mismatch "
+            "without asserting PASS; never convert missing evidence into completion.\n"
+        )
     target.write_text(body.rstrip() + protocol, encoding="utf-8")
     return target, receipt, input_sha
 
@@ -2612,6 +2623,7 @@ def _run_workflow_locked(
         elif stored.get("status") in {"running", "attention_required"}:
             return {"ok": False, **stored}
         else:
+            _verify_prepared_final_receipt_retry(config, stored)
             stage = str(stored["next_stage"])
             source = Path(str(stored["next_mission_path"])).resolve(strict=True)
             if str(stored.get("next_mission_sha256") or "") != sha(source):
@@ -2913,11 +2925,183 @@ def run_workflow(
         )
 
 
+def _verify_prepared_final_receipt_retry(config: dict[str, Any], stored: dict[str, Any]) -> None:
+    records = stored.get("records") or []
+    if not records or not records[-1].get("final_receipt_retry_authority"):
+        return
+    record = records[-1]
+    authority_path = Path(record["final_receipt_retry_authority"])
+    authority, _ = _load_expected_json(authority_path, record["authority_sha256"], label="retry authority")
+    state_path = _state_path(config, config["workflow_id"])
+    expected_path = state_path.parent / "final-receipt-retries" / config["workflow_id"] / f"{authority['run_id']}.json"
+    if (
+        authority_path != expected_path
+        or authority.get("workflow_id") != config["workflow_id"]
+        or authority.get("target_source_thread_id") != config.get("source_thread_id")
+        or stored.get("next_stage") != "final-web-gate"
+        or stored.get("next_index") != authority.get("next_index")
+        or stored.get("next_mission_sha256") != authority.get("input_mission_sha256")
+    ):
+        raise WorkflowError("retry authority binding mismatch")
+    run_dir = RUNNER.STATE.oracle_state_root() / "projects" / state_path.parent.name / "runs" / authority["run_id"]
+    for path, digest in (
+        (Path(authority["receipt_path"]), authority["receipt_sha256"]),
+        (run_dir / "state.json", authority["run_state_sha256"]),
+        (run_dir / "output.md", authority["output_sha256"]),
+        (run_dir / "mission.md", authority["augmented_mission_sha256"]),
+        (Path(authority["stage_output_path"]), authority["stage_output_sha256"]),
+        (Path(authority["empty_terminal_path"]), authority["empty_terminal_sha256"]),
+    ):
+        if path.is_symlink() or sha(path) != digest:
+            raise WorkflowError("retry evidence changed before submission")
+
+
+def prepare_final_receipt_retry(
+    manifest_path: Path, *, expected_workflow_sha256: str,
+    expected_scope_sha256: str, expected_run_state_sha256: str,
+    expected_receipt_sha256: str, confirmation: str, dry_run: bool = False,
+) -> dict[str, Any]:
+    """Authorize one fresh final attestation; never repair a web verdict in place."""
+    if confirmation != "user-authorized-final-receipt-retry":
+        raise WorkflowError("explicit user-authorized-final-receipt-retry confirmation required")
+    expected_workflow_sha256 = _required_sha256(expected_workflow_sha256, label="workflow state")
+    expected_scope_sha256 = _required_sha256(expected_scope_sha256, label="scope state")
+    expected_run_state_sha256 = _required_sha256(expected_run_state_sha256, label="Oracle run state")
+    expected_receipt_sha256 = _required_sha256(expected_receipt_sha256, label="stage receipt")
+    config = load_manifest(manifest_path)
+    if config["workflow_profile"] != "standard" or _closed_audit_enabled(config):
+        raise WorkflowError("final receipt retry supports standard workflows only")
+    owner = RUNNER.STATE.current_source_thread_id()
+    if not owner or owner != config.get("source_thread_id"):
+        raise WorkflowError("FOREIGN_TASK_SESSION: final receipt retry requires the owning task")
+    workflow_id = config["workflow_id"]
+    state_path = _state_path(config, workflow_id)
+    scope_path = _scope_path(config)
+    with RUNNER.STATE.project_submit_mutex(
+        config["project_root"], timeout_seconds=30, source_thread_id=owner,
+    ):
+        stored, _ = _load_expected_json(state_path, expected_workflow_sha256, label="workflow state")
+        scope, _ = _load_expected_json(scope_path, expected_scope_sha256, label="scope state")
+        if (
+            stored.get("status") != "awaiting_receipt"
+            or stored.get("current_stage") != "final-web-gate"
+            or stored.get("workflow_id") != workflow_id
+            or stored.get("manifest_sha256") != config["manifest_sha256"]
+            or stored.get("source_thread_id") != owner
+            or scope.get("source_thread_id") != owner
+            or scope.get("active_workflow_id") != workflow_id
+            or scope.get("status") != "active"
+            or stored.get("final_receipt_retry")
+            or any(record.get("final_receipt_retry_authority") for record in stored.get("records", []))
+        ):
+            raise WorkflowError("workflow is not an owned, unretried final receipt candidate")
+        index = int(stored["next_index"]) + 1
+        if index >= config["max_stages"]:
+            raise WorkflowError("final receipt retry cannot reset the stage budget")
+        attempt = str(stored["current_attempt_id"])
+        if not re.fullmatch(r"[0-9a-f]{32}", attempt):
+            raise WorkflowError("invalid exact attempt ID")
+        project_key = state_path.parent.name
+        run_dir = RUNNER.STATE.oracle_state_root() / "projects" / project_key / "runs" / attempt
+        if Path(stored["oracle_run_dir"]).resolve() != run_dir.resolve():
+            raise WorkflowError("Oracle run directory identity mismatch")
+        run_path = run_dir / "state.json"
+        run, _ = _load_expected_json(run_path, expected_run_state_sha256, label="Oracle run state")
+        if (
+            RUNNER.STATE.source_thread_id_from_state(run) != owner
+            or run.get("run_id") != attempt
+            or run.get("project_root") != str(config["project_root"])
+            or run.get("status") != "complete"
+            or run.get("session_authority") != "terminal"
+            or run.get("terminal_harvested") is not True
+            or run.get("task_outcome") != "executed"
+            or not RUNNER.STATE.proven_ownership_receipt(run_path)
+            or not RUNNER.STATE.proven_browser_identity_receipt(run_path)
+        ):
+            raise WorkflowError("exact Oracle run is not owned, completed and harvested")
+        provider = run.get("provider_session") or {}
+        meta_path = Path(str(provider.get("oracle_meta_path") or "")).expanduser()
+        if (
+            provider.get("terminal_confirmed") is not True
+            or provider.get("status") != "completed"
+            or not meta_path.is_absolute() or not meta_path.is_file() or meta_path.is_symlink()
+            or sha(meta_path) != provider.get("oracle_meta_sha256")
+        ):
+            raise WorkflowError("terminal provider evidence changed")
+        observer = run.get("browser_observer") or {}
+        pid = observer.get("oracle_process_pid")
+        if observer.get("status") != "process-exited" or not isinstance(pid, int) or RUNNER.STATE._process_may_be_alive(pid):
+            raise WorkflowError("Oracle observer is live or uncertain")
+        output = run_dir / "output.md"
+        output_lines = output.read_text(encoding="utf-8").rstrip().splitlines()
+        if sha(output) != run.get("artifact_sha256") or not output_lines or output_lines[-1] != "TASK_OUTCOME: EXECUTED":
+            raise WorkflowError("terminal Oracle output changed")
+        source = _inside(config["project_root"], stored["current_binding_source_path"])
+        augmented = _inside(config["project_root"], stored["current_augmented_mission_path"])
+        if (
+            sha(source) != stored["current_input_sha256"]
+            or sha(source) != stored["current_binding_source_sha256"]
+            or sha(augmented) != stored["current_augmented_mission_sha256"]
+            or sha(augmented) != (run.get("mission") or {}).get("sha256")
+            or sha(run_dir / "mission.md") != sha(augmented)
+        ):
+            raise WorkflowError("immutable mission binding changed")
+        receipt_path = _inside(config["project_root"], stored["receipt_path"])
+        receipt, _ = _load_expected_json(receipt_path, expected_receipt_sha256, label="stage receipt")
+        expected = {
+            "schema": RECEIPT_SCHEMA, "workflow_id": workflow_id, "stage": "final-web-gate",
+            "attempt_id": attempt, "input_mission_sha256": sha(source),
+            "status": "PASS", "next_stage": "", "ready_for_next": False, "blocker": "",
+        }
+        if any(receipt.get(key) != value for key, value in expected.items()):
+            raise WorkflowError("receipt is not the bounded empty-transition PASS error")
+        result_path = _inside(config["project_root"], receipt["output_path"])
+        terminal = _inside(config["project_root"], receipt["next_mission_path"])
+        if (
+            not result_path.read_bytes().strip() or sha(result_path) != receipt["output_sha256"]
+            or terminal.read_bytes() != b"" or sha(terminal) != receipt["next_mission_sha256"]
+        ):
+            raise WorkflowError("stage output or empty terminal mission changed")
+        authority_path = state_path.parent / "final-receipt-retries" / workflow_id / f"{attempt}.json"
+        authority = {
+            "schema": "codex.chatgpt.final-receipt-retry/v1", "workflow_id": workflow_id,
+            "evaluated_from_thread": owner, "target_source_thread_id": owner,
+            "run_id": attempt, "slug": (run.get("oracle") or {}).get("slug"),
+            "confirmation": confirmation, "workflow_state_sha256": expected_workflow_sha256,
+            "scope_state_sha256": expected_scope_sha256, "run_state_sha256": expected_run_state_sha256,
+            "receipt_path": str(receipt_path), "receipt_sha256": expected_receipt_sha256,
+            "output_sha256": sha(output), "stage_output_sha256": sha(result_path),
+            "stage_output_path": str(result_path), "empty_terminal_path": str(terminal),
+            "empty_terminal_sha256": sha(terminal),
+            "input_mission_sha256": sha(source), "augmented_mission_sha256": sha(augmented),
+            "next_index": index, "action": "prepare-same-workflow-final-attestation",
+        }
+        if not dry_run:
+            config["_review_policy"] = dict(stored["review_policy"])
+            _materialize_bound_text(authority_path, json.dumps(authority, sort_keys=True, indent=2) + "\n")
+            _write_workflow_state(state_path, config, {
+                **stored, "status": "prepared", "next_stage": "final-web-gate",
+                "next_mission_path": str(source), "next_mission_sha256": sha(source),
+                "next_index": index,
+                "final_receipt_retry": {"path": str(authority_path), "sha256": sha(authority_path)},
+                "records": list(stored.get("records") or []) + [{
+                    "stage": "final-web-gate", "run_dir": str(run_dir),
+                    "final_receipt_retry_authority": str(authority_path),
+                    "authority_sha256": sha(authority_path),
+                }],
+            })
+        return {"ok": True, "dry_run": dry_run, "workflow_id": workflow_id,
+                "authority_path": str(authority_path), "submission_action": "none",
+                "next_action": "resume-the-same-manifest"}
+
+
 def main(argv: Iterable[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Run a bounded Oracle comprehensive workflow.")
     parser.add_argument("--manifest", type=Path)
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--cancel-user-stopped", action="store_true")
+    parser.add_argument("--retry-final-receipt", action="store_true")
+    parser.add_argument("--expected-receipt-sha256")
     parser.add_argument("--workflow-state", type=Path)
     parser.add_argument("--scope-state", type=Path)
     parser.add_argument("--run-dir", type=Path)
@@ -2929,7 +3113,17 @@ def main(argv: Iterable[str] | None = None) -> int:
     parser.add_argument("--confirmation")
     args = parser.parse_args(argv)
     try:
-        if args.cancel_user_stopped:
+        if args.retry_final_receipt:
+            if args.cancel_user_stopped or args.manifest is None:
+                raise WorkflowError("--retry-final-receipt requires --manifest and excludes cancellation")
+            value = prepare_final_receipt_retry(
+                args.manifest, expected_workflow_sha256=args.expected_workflow_sha256,
+                expected_scope_sha256=args.expected_scope_sha256,
+                expected_run_state_sha256=args.expected_run_state_sha256,
+                expected_receipt_sha256=args.expected_receipt_sha256,
+                confirmation=args.confirmation, dry_run=args.dry_run,
+            )
+        elif args.cancel_user_stopped:
             if args.manifest is not None:
                 raise WorkflowError("--manifest cannot be combined with --cancel-user-stopped")
             required = {

--- a/bin/chatgpt_oracle_state.py
+++ b/bin/chatgpt_oracle_state.py
@@ -1430,6 +1430,25 @@ def proven_ownership_receipt(state_path: Path) -> dict[str, Any] | None:
     return {"path": str(path), "sha256": hashlib.sha256(raw).hexdigest(), "payload": receipt}
 
 
+def _receipt_runtime_profile_path(state_path: Path, value: Any) -> str:
+    """Recover this run's profile path after its deterministic POSIX temp alias was cleaned."""
+    profile = Path(str(value or "")).expanduser()
+    if os.name != "nt":
+        browser_temp = state_path.parent.resolve() / "browser-temp"
+        digest = hashlib.sha256(str(browser_temp).encode("utf-8")).hexdigest()[:16]
+        alias = Path("/tmp/Codex") / f"oracle-{os.getuid()}-{digest}" / "t"
+        if not alias.parent.exists() and not alias.parent.is_symlink():
+            try:
+                relative = profile.relative_to(alias)
+            except ValueError:
+                pass
+            else:
+                if relative.parts and ".." not in relative.parts:
+                    return str((browser_temp / relative).resolve())
+    # A surviving or retargeted alias must pass ordinary filesystem resolution.
+    return str(profile.resolve())
+
+
 def proven_browser_identity_receipt(state_path: Path) -> dict[str, Any] | None:
     state = load_state(state_path)
     path = browser_identity_receipt_path(state_path.parent.resolve())
@@ -1576,7 +1595,7 @@ def proven_browser_identity_receipt(state_path: Path) -> dict[str, Any] | None:
     observed = {
         "chrome_pid": runtime.get("chromePid"),
         "browser_parent_pid": runtime.get("controllerPid"),
-        "profile_path": str(Path(str(runtime.get("userDataDir") or "")).expanduser().resolve()),
+        "profile_path": _receipt_runtime_profile_path(state_path, runtime.get("userDataDir")),
         "cdp_port": runtime.get("chromePort"),
         "target_id": runtime.get("chromeTargetId"),
         "conversation_url": runtime.get("tabUrl"),

--- a/skills/chatgpt-pro-plan-handoff/SKILL.md
+++ b/skills/chatgpt-pro-plan-handoff/SKILL.md
@@ -134,6 +134,31 @@ If an observer returns while the exact session remains live, comprehensive mode
 continues exact-slug live recovery automatically. Time alone never kills,
 fails, releases, replaces, restarts, or resubmits the session.
 
+If a completed, terminal-harvested regular final gate wrote the exact malformed
+transition `status=PASS`, empty `next_stage`, `ready_for_next=false`, empty
+`blocker`, and an empty terminal mission, leave that receipt and Oracle run
+unchanged. After explicit user authorization, the owning maintenance task may
+prepare one fresh final attestation in the same workflow with
+`--retry-final-receipt`. Bind the current workflow state, scope state, Oracle
+run state, and malformed receipt by exact SHA-256, use confirmation token
+`user-authorized-final-receipt-retry`, and run `--dry-run` first. The command
+accepts only the standard profile, the exact task owner, a stopped observer,
+valid ownership/browser/provider evidence, unchanged mission and output bytes,
+and remaining stage budget. It writes an immutable authority receipt and
+prepares only `final-web-gate`; it never repairs the old verdict, replays
+implementation, or launches a prompt itself. Resume the same manifest normally
+after preparation. The fresh final receipt must use `next_stage=complete` and
+`ready_for_next=true`, after which the existing deterministic local gate still
+decides completion.
+
+```text
+python ~/.codex/bin/chatgpt_oracle_comprehensive.py \
+  --manifest <same-workflow.json> --retry-final-receipt --dry-run \
+  --expected-workflow-sha256 <sha256> --expected-scope-sha256 <sha256> \
+  --expected-run-state-sha256 <sha256> --expected-receipt-sha256 <sha256> \
+  --confirmation user-authorized-final-receipt-retry
+```
+
 `Prompt did not appear in conversation before timeout (send may have failed)`
 remains submission-uncertain by default. Exact recovery reporting no live tab
 and no saved conversation URL is still not enough to release ownership. Only

--- a/tests/test_chatgpt_oracle_comprehensive.py
+++ b/tests/test_chatgpt_oracle_comprehensive.py
@@ -1951,6 +1951,185 @@ def test_plan_mission_teaches_declared_packet_contract(tmp_path: Path) -> None:
     assert "Do not both write the receipt/files and return this fallback envelope." in text
 
 
+def test_final_gate_mission_requires_complete_transition_before_local_gate(tmp_path: Path) -> None:
+    module = load()
+    config = module.load_manifest(manifest(tmp_path))
+    mission, _, _ = module._stage_mission(
+        config, "a" * 32, 3, "final-web-gate", config["initial_mission_path"], "b" * 32
+    )
+    text = mission.read_text(encoding="utf-8")
+    assert "[FINAL_GATE_RECEIPT_CONTRACT]" in text
+    assert "status=PASS, next_stage=complete, ready_for_next=true" in text
+    assert "Complete is a transition to the mandatory host local gate" in text
+    assert "Never use an empty next_stage" in text
+
+
+@pytest.mark.parametrize("failure", [None, "foreign", "live", "source", "receipt_hash",
+                                   "terminal", "run_status", "ownership", "provider", "budget"])
+def test_explicit_final_receipt_retry_preserves_old_run_and_prepares_same_stage(
+    tmp_path: Path, monkeypatch, failure: str | None,
+) -> None:
+    module = load()
+    owner = "11111111-1111-4111-8111-111111111111"
+    monkeypatch.setattr(module.RUNNER.STATE, "current_source_thread_id", lambda: owner)
+    workflow_manifest = manifest(tmp_path)
+    manifest_value = json.loads(workflow_manifest.read_text(encoding="utf-8"))
+    manifest_value["source_thread_id"] = owner
+    workflow_manifest.write_text(json.dumps(manifest_value), encoding="utf-8")
+    config = module.load_manifest(workflow_manifest)
+    config["_review_policy"] = module._default_review_policy()
+    workflow_id = config["workflow_id"]
+    attempt = "b" * 32
+    source = tmp_path / "final-source.md"
+    source.write_text("final verification", encoding="utf-8")
+    stage = tmp_path / "workflow" / "stages" / f"03-final-web-gate-{attempt[:12]}"
+    stage.mkdir(parents=True)
+    augmented = stage / "mission.md"
+    augmented.write_text("augmented final verification", encoding="utf-8")
+    result = stage / "final-result.md"
+    result.write_text("PASS\n", encoding="utf-8")
+    terminal = stage / "terminal.md"
+    terminal.write_bytes(b"")
+    receipt = stage / "stage-result.json"
+    receipt.write_text(json.dumps({
+        "schema": module.RECEIPT_SCHEMA, "workflow_id": workflow_id,
+        "stage": "final-web-gate", "attempt_id": attempt,
+        "input_mission_sha256": module.sha(source), "status": "PASS",
+        "output_path": str(result), "output_sha256": module.sha(result),
+        "next_stage": "", "next_mission_path": str(terminal),
+        "next_mission_sha256": module.sha(terminal), "ready_for_next": False, "blocker": "",
+    }), encoding="utf-8")
+    state_path = module._state_path(config, workflow_id)
+    project_key = state_path.parent.name
+    run_dir = module.RUNNER.STATE.oracle_state_root() / "projects" / project_key / "runs" / attempt
+    run_dir.mkdir(parents=True)
+    (run_dir / "mission.md").write_bytes(augmented.read_bytes())
+    oracle_output = run_dir / "output.md"
+    oracle_output.write_text("web final output\nTASK_OUTCOME: EXECUTED\n", encoding="utf-8")
+    meta = run_dir / "meta.json"
+    meta.write_text("{}\n", encoding="utf-8")
+    run_state_path = run_dir / "state.json"
+    run_state = {
+        "run_id": attempt, "project_root": str(config["project_root"]),
+        "originating_task": {"source_thread_id": owner, "binding": "bound"},
+        "status": "complete", "session_authority": "terminal", "terminal_harvested": True,
+        "task_outcome": "executed", "mission": {"sha256": module.sha(augmented)},
+        "oracle": {"slug": "oracle-project-retry"}, "artifact_sha256": module.sha(oracle_output),
+        "provider_session": {"terminal_confirmed": True, "status": "completed",
+                             "oracle_meta_path": str(meta), "oracle_meta_sha256": module.sha(meta)},
+        "browser_observer": {"status": "process-exited", "oracle_process_pid": 43210},
+    }
+    run_state_path.write_text(json.dumps(run_state), encoding="utf-8")
+    monkeypatch.setattr(module.RUNNER.STATE, "source_thread_id_from_state", lambda value: owner)
+    monkeypatch.setattr(module.RUNNER.STATE, "proven_ownership_receipt", lambda value: {"ok": True})
+    monkeypatch.setattr(module.RUNNER.STATE, "proven_browser_identity_receipt", lambda value: {"ok": True})
+    monkeypatch.setattr(module.RUNNER.STATE, "_process_may_be_alive", lambda value: False)
+    stored = {
+        "schema": module.STATE_SCHEMA, "status": "awaiting_receipt", "workflow_id": workflow_id,
+        "manifest_sha256": config["manifest_sha256"], "source_thread_id": owner,
+        "current_stage": "final-web-gate", "current_attempt_id": attempt,
+        "current_input_sha256": module.sha(source), "current_binding_source_path": str(source),
+        "current_binding_source_sha256": module.sha(source),
+        "current_augmented_mission_path": str(augmented),
+        "current_augmented_mission_sha256": module.sha(augmented),
+        "oracle_run_dir": str(run_dir), "receipt_path": str(receipt), "next_index": 3,
+        "records": [{"stage": "final-web-gate", "run_dir": str(run_dir), "ok": True}],
+    }
+    module._write_workflow_state(state_path, config, stored)
+    scope_path = module._scope_path(config)
+    hashes = {"expected_workflow_sha256": module.sha(state_path),
+              "expected_scope_sha256": module.sha(scope_path),
+              "expected_run_state_sha256": module.sha(run_state_path),
+              "expected_receipt_sha256": module.sha(receipt)}
+    if failure == "foreign":
+        monkeypatch.setattr(module.RUNNER.STATE, "current_source_thread_id",
+                            lambda: "22222222-2222-4222-8222-222222222222")
+    elif failure == "live":
+        monkeypatch.setattr(module.RUNNER.STATE, "_process_may_be_alive", lambda value: True)
+    elif failure == "source":
+        source.write_text("changed", encoding="utf-8")
+    elif failure == "receipt_hash":
+        hashes["expected_receipt_sha256"] = "0" * 64
+    elif failure == "terminal":
+        terminal.write_text("do more work", encoding="utf-8")
+    elif failure == "run_status":
+        run_state["status"] = "running"
+        run_state_path.write_text(json.dumps(run_state), encoding="utf-8")
+        hashes["expected_run_state_sha256"] = module.sha(run_state_path)
+    elif failure == "ownership":
+        monkeypatch.setattr(module.RUNNER.STATE, "proven_ownership_receipt", lambda value: None)
+    elif failure == "provider":
+        meta.write_text("changed", encoding="utf-8")
+    elif failure == "budget":
+        current = module._json(state_path)
+        current["next_index"] = 7
+        module._write_workflow_state(state_path, config, current)
+        hashes["expected_workflow_sha256"] = module.sha(state_path)
+    if failure:
+        before = state_path.read_bytes()
+        with pytest.raises(module.WorkflowError):
+            module.prepare_final_receipt_retry(
+                workflow_manifest, **hashes, confirmation="user-authorized-final-receipt-retry"
+            )
+        assert state_path.read_bytes() == before
+        return
+    preview = module.prepare_final_receipt_retry(
+        workflow_manifest, **hashes, confirmation="user-authorized-final-receipt-retry", dry_run=True
+    )
+    assert preview["submission_action"] == "none"
+    assert module._json(state_path)["status"] == "awaiting_receipt"
+    with pytest.raises(module.WorkflowError, match="stage receipt did not pass"):
+        module._validate_receipt(
+            config, receipt, workflow_id, "final-web-gate", attempt, module.sha(source)
+        )
+    result_value = module.prepare_final_receipt_retry(
+        workflow_manifest, **hashes, confirmation="user-authorized-final-receipt-retry"
+    )
+    prepared = module._json(state_path)
+    assert result_value["next_action"] == "resume-the-same-manifest"
+    assert prepared["status"] == "prepared"
+    assert prepared["next_stage"] == "final-web-gate"
+    assert prepared["next_mission_path"] == str(source)
+    assert prepared["next_index"] == 4
+    assert prepared["final_receipt_retry"]["sha256"] == module.sha(
+        Path(prepared["final_receipt_retry"]["path"])
+    )
+    assert module.sha(receipt) == hashes["expected_receipt_sha256"]
+    assert module.sha(run_state_path) == hashes["expected_run_state_sha256"]
+    hashes["expected_workflow_sha256"] = module.sha(state_path)
+    hashes["expected_scope_sha256"] = module.sha(scope_path)
+    with pytest.raises(module.WorkflowError, match="unretried final receipt candidate"):
+        module.prepare_final_receipt_retry(
+            workflow_manifest, **hashes, confirmation="user-authorized-final-receipt-retry"
+        )
+
+    result.write_text("changed after authorization\n", encoding="utf-8")
+    with pytest.raises(module.WorkflowError, match="retry evidence changed before submission"):
+        module.run_workflow(workflow_manifest, oracle_execute=lambda *args, **kwargs: pytest.fail("submitted"))
+    result.write_text("PASS\n", encoding="utf-8")
+
+    seen = []
+    def final_only(path: Path, *, dry_run: bool):
+        oracle = json.loads(path.read_text(encoding="utf-8"))
+        mission = Path(oracle["mission_path"])
+        text = mission.read_text(encoding="utf-8")
+        assert "stage=final-web-gate\n" in text
+        assert "stage_index=4\n" in text
+        assert text.startswith(source.read_text(encoding="utf-8"))
+        seen.append(oracle["run_id"])
+        new_receipt = json.loads(receipt.read_text(encoding="utf-8"))
+        new_receipt.update(attempt_id=oracle["run_id"], next_stage="complete", ready_for_next=True,
+                           next_mission_path=None, next_mission_sha256=None)
+        (mission.parent / "stage-result.json").write_text(json.dumps(new_receipt), encoding="utf-8")
+        return {"ok": True, "run_dir": str(mission.parent / "run")}
+    completed = module.run_workflow(
+        workflow_manifest, oracle_execute=final_only,
+        local_gate_runner=lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, "ok", ""),
+    )
+    assert completed["status"] == "complete"
+    assert len(seen) == 1 and seen[0] != attempt
+
+
 def test_receipt_compatibly_resolves_project_relative_paths_with_hash_binding(tmp_path: Path) -> None:
     module = load()
     config = module.load_manifest(manifest(tmp_path))

--- a/tests/test_chatgpt_oracle_state.py
+++ b/tests/test_chatgpt_oracle_state.py
@@ -1120,6 +1120,69 @@ def test_browser_identity_receipt_binds_exact_task_run_profile_port_target_and_u
     assert state.proven_browser_identity_receipt(layout.state_path) is None
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX temp alias")
+def test_browser_identity_receipt_survives_owned_temp_alias_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = load_state()
+    monkeypatch.delenv("CODEX_THREAD_ID", raising=False)
+    mission = tmp_path / "mission.md"
+    mission.write_text("work", encoding="utf-8")
+    task_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    config = state.load_manifest(manifest(tmp_path, mission.resolve(), source_thread_id=task_id))
+    layout = state.create_layout(config, run_id="identity-alias-run-123456")
+    layout.run_dir.mkdir(parents=True)
+    layout.browser_temp_path.mkdir()
+    state.write_json_atomic(
+        layout.state_path,
+        state.state_payload(config, layout, status="running", resolved_version="0.18.0", cdp_port=43101),
+    )
+    state.persist_ownership_receipt(layout.state_path, oracle_process_pid=101)
+    session_root = tmp_path / "oracle-sessions"
+    monkeypatch.setenv("ORACLE_SESSION_ROOT", str(session_root))
+    digest = hashlib.sha256(str(layout.browser_temp_path.resolve()).encode("utf-8")).hexdigest()[:16]
+    alias = Path("/tmp/Codex") / f"oracle-{os.getuid()}-{digest}" / "t"
+    alias.parent.mkdir(mode=0o700, parents=True)
+    alias.symlink_to(layout.browser_temp_path.resolve(), target_is_directory=True)
+    profile = alias / "oracle-browser-isolated"
+    meta = {"browser": {"runtime": {
+        "chromePid": 102,
+        "controllerPid": 101,
+        "chromePort": 43101,
+        "userDataDir": str(profile),
+        "chromeTargetId": "target-exact",
+        "tabUrl": "https://chatgpt.com/c/exact-conversation",
+    }}}
+    meta_path = session_root / layout.slug / "meta.json"
+    meta_path.parent.mkdir(parents=True)
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+
+    captured = state.capture_browser_identity_receipt(layout.state_path)
+    assert captured is not None
+    alias.unlink()
+    alias.parent.rmdir()
+    assert state.proven_browser_identity_receipt(layout.state_path) is not None
+
+    changed = json.loads(meta_path.read_text(encoding="utf-8"))
+    foreign = tmp_path / "foreign" / "browser-temp"
+    foreign_digest = hashlib.sha256(str(foreign).encode("utf-8")).hexdigest()[:16]
+    changed["browser"]["runtime"]["userDataDir"] = str(
+        Path("/tmp/Codex") / f"oracle-{os.getuid()}-{foreign_digest}" / "t" / profile.name
+    )
+    meta_path.write_text(json.dumps(changed), encoding="utf-8")
+    assert state.proven_browser_identity_receipt(layout.state_path) is None
+
+    meta_path.write_text(json.dumps(meta), encoding="utf-8")
+    alias.parent.mkdir(mode=0o700)
+    alias.symlink_to(foreign, target_is_directory=True)
+    try:
+        assert state.proven_browser_identity_receipt(layout.state_path) is None
+    finally:
+        alias.unlink()
+        alias.parent.rmdir()
+
+
 def test_provider_session_terminal_requires_exact_browser_identity_receipt(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
A terminal Web GPT final gate can report `PASS` while emitting an empty transition, leaving a valid comprehensive workflow permanently stuck at `awaiting_receipt` even though its run is complete and harvested.

This adds a user-authorized, hash-bound `--retry-final-receipt` recovery that preserves the malformed receipt and exact Oracle run, prepares one fresh final attestation in the same workflow, and still requires the ordinary local gate. It also teaches final-gate prompts the exact completion receipt contract and preserves browser identity verification after a deterministic POSIX temp alias has been cleaned.

Validation:
- `uv run --with 'pytest>=8,<10' python scripts/run_fast_gate.py --enforce-budget` (447 passed, 7 skipped, 1 deselected)
- `python scripts/check_portability.py --root .`
- `python scripts/check_docs.py --root .`
- Live `--retry-final-receipt --dry-run` against the exact affected workflow and evidence hashes
